### PR TITLE
feat: add MiniMax cloud LLM provider for prompt assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Advanced ComfyUI users can also optionally download the `Workflow Starter Pack` 
 - Generate images, videos, and audio through curated local or cloud workflows.
 - Use Director Mode to turn structured script input into keyframes and video shots.
 - Search Pexels stock footage and stills directly from the app.
-- Refine prompts locally with LM Studio.
+- Refine prompts with LM Studio (local) or MiniMax (cloud).
 
 ## Core Product Decisions
 
 - ComfyUI is local-only in this build. Remote and LAN ComfyUI targets are intentionally disabled.
 - The default ComfyUI endpoint is `http://127.0.0.1:8188`, but users can override the port in Settings.
-- LM Studio integration is local-only.
+- LM Studio integration is local-only. MiniMax cloud LLM is also available as an alternative.
 - Generate includes dependency preflight checks before queueing workflows.
 
 ## Desktop App Requirements
@@ -57,6 +57,7 @@ Optional integrations:
 - Pexels API key for the `Stock` tab
 - Comfy account API key for paid partner-node workflows
 - LM Studio for local prompt assistance in the `LLM` tab
+- MiniMax API key for cloud-based prompt assistance (alternative to LM Studio)
 
 ## First Run
 
@@ -162,14 +163,23 @@ The `Stock` tab uses Pexels.
 
 ### LLM
 
-The `LLM` tab connects to LM Studio.
+The `LLM` tab supports two providers:
+
+**LM Studio (Local)**
 
 - Start LM Studio locally.
 - Enable the local API server.
 - Load a model.
 - Use the model to refine prompts before generating.
+- If your GPU memory is tight, unload the LM Studio model before heavy ComfyUI generation.
 
-If your GPU memory is tight, unload the LM Studio model before heavy ComfyUI generation.
+**MiniMax (Cloud)**
+
+- Open `Settings > LLM Provider` and select `MiniMax (Cloud)`.
+- Enter your MiniMax API key (get one at [platform.minimaxi.com](https://platform.minimaxi.com)).
+- Choose between MiniMax M2.5 or M2.5 Highspeed models.
+- No local GPU or VRAM needed — prompts are processed in the cloud.
+- Supports 204K token context window for long creative sessions.
 
 ## Workflow Starter Pack
 

--- a/src/components/LLMAssistantWorkspace.jsx
+++ b/src/components/LLMAssistantWorkspace.jsx
@@ -1,9 +1,19 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import {
   Bot, Loader2, Send, Copy, Check, Power, PowerOff, RefreshCw,
-  AlertCircle, Sparkles, MessageSquare, X
+  AlertCircle, Sparkles, MessageSquare, X, Cloud, Monitor
 } from 'lucide-react'
 import lmstudio from '../services/lmstudio'
+import minimax from '../services/minimax'
+import {
+  PROVIDERS,
+  getProviderTypeSync,
+  getActiveService,
+  supportsModelManagement,
+  getMiniMaxApiKey,
+  getMiniMaxModelSync,
+  saveMiniMaxModel,
+} from '../services/llmProvider'
 
 const SYSTEM_PROMPT = `You are an expert AI assistant specialized in helping users create high-quality prompts for AI video and image generation. 
 
@@ -24,12 +34,16 @@ When helping with prompts:
 Be creative, helpful, and focused on achieving the best possible generation results.`
 
 function LLMAssistantWorkspace() {
+  const [providerType, setProviderType] = useState(getProviderTypeSync)
   const [isConnected, setIsConnected] = useState(false)
   const [isCheckingConnection, setIsCheckingConnection] = useState(false)
   const [models, setModels] = useState([])
   const [selectedModelId, setSelectedModelId] = useState(() => {
     // Load last selected model from localStorage
     try {
+      if (getProviderTypeSync() === PROVIDERS.MINIMAX) {
+        return getMiniMaxModelSync()
+      }
       return localStorage.getItem('llm-assistant-selected-model') || null
     } catch (error) {
       return null
@@ -37,16 +51,38 @@ function LLMAssistantWorkspace() {
   })
   const [loadedModelId, setLoadedModelId] = useState(null)
 
+  // Listen for provider changes from settings
+  useEffect(() => {
+    const handler = (e) => {
+      const newType = e.detail
+      setProviderType(newType)
+      setIsConnected(false)
+      setModels([])
+      setLoadedModelId(null)
+      if (newType === PROVIDERS.MINIMAX) {
+        setSelectedModelId(getMiniMaxModelSync())
+      } else {
+        setSelectedModelId(localStorage.getItem('llm-assistant-selected-model') || null)
+      }
+    }
+    window.addEventListener('comfystudio-llm-provider-changed', handler)
+    return () => window.removeEventListener('comfystudio-llm-provider-changed', handler)
+  }, [])
+
   // Persist selected model to localStorage
   useEffect(() => {
     if (selectedModelId) {
       try {
-        localStorage.setItem('llm-assistant-selected-model', selectedModelId)
+        if (providerType === PROVIDERS.MINIMAX) {
+          saveMiniMaxModel(selectedModelId)
+        } else {
+          localStorage.setItem('llm-assistant-selected-model', selectedModelId)
+        }
       } catch (error) {
         console.error('Failed to save selected model:', error)
       }
     }
-  }, [selectedModelId])
+  }, [selectedModelId, providerType])
   const [isLoadingModel, setIsLoadingModel] = useState(false)
   const [isUnloadingModel, setIsUnloadingModel] = useState(false)
   const [isLoadingModels, setIsLoadingModels] = useState(false)
@@ -96,7 +132,8 @@ function LLMAssistantWorkspace() {
   const checkConnection = async () => {
     setIsCheckingConnection(true)
     try {
-      const connected = await lmstudio.checkConnection()
+      const service = await getActiveService(providerType)
+      const connected = await service.checkConnection()
       setIsConnected(connected)
       if (connected) {
         await loadModels()
@@ -111,27 +148,39 @@ function LLMAssistantWorkspace() {
   const loadModels = async () => {
     setIsLoadingModels(true)
     try {
-      const modelList = await lmstudio.listModels()
+      const service = await getActiveService(providerType)
+      const modelList = await service.listModels()
       setModels(modelList)
-      
-      // Get current selectedModelId from state (may be from localStorage)
-      setSelectedModelId(currentSelected => {
-        // Find currently loaded model
-        const loaded = modelList.find(m => m.state === 'loaded')
-        if (loaded) {
-          setLoadedModelId(loaded.id)
-          // Prefer loaded model if one exists
-          return loaded.id
-        }
-        
-        // If we have a saved selection, verify it still exists
-        if (currentSelected && modelList.find(m => m.id === currentSelected)) {
-          return currentSelected
-        }
-        
-        // Otherwise use first available model
-        return modelList.length > 0 ? modelList[0].id : null
-      })
+
+      if (providerType === PROVIDERS.MINIMAX) {
+        // Cloud models are always "loaded"
+        setSelectedModelId(currentSelected => {
+          if (currentSelected && modelList.find(m => m.id === currentSelected)) {
+            return currentSelected
+          }
+          return modelList.length > 0 ? modelList[0].id : null
+        })
+        setLoadedModelId(modelList.length > 0 ? (getMiniMaxModelSync() || modelList[0].id) : null)
+      } else {
+        // Get current selectedModelId from state (may be from localStorage)
+        setSelectedModelId(currentSelected => {
+          // Find currently loaded model
+          const loaded = modelList.find(m => m.state === 'loaded')
+          if (loaded) {
+            setLoadedModelId(loaded.id)
+            // Prefer loaded model if one exists
+            return loaded.id
+          }
+
+          // If we have a saved selection, verify it still exists
+          if (currentSelected && modelList.find(m => m.id === currentSelected)) {
+            return currentSelected
+          }
+
+          // Otherwise use first available model
+          return modelList.length > 0 ? modelList[0].id : null
+        })
+      }
     } catch (error) {
       console.error('Failed to load models:', error)
     } finally {
@@ -192,9 +241,10 @@ function LLMAssistantWorkspace() {
       ]
 
       let fullResponse = ''
-      
+      const service = await getActiveService(providerType)
+
       // Use streaming for better UX
-      await lmstudio.streamChatCompletion(
+      await service.streamChatCompletion(
         loadedModelId,
         chatMessages,
         (chunk) => {
@@ -203,7 +253,7 @@ function LLMAssistantWorkspace() {
         },
         {
           temperature: 0.7,
-          max_tokens: -1,
+          max_tokens: providerType === PROVIDERS.MINIMAX ? 4096 : -1,
         }
       )
 
@@ -212,9 +262,12 @@ function LLMAssistantWorkspace() {
       setCurrentResponse('')
     } catch (error) {
       console.error('Chat error:', error)
+      const hint = providerType === PROVIDERS.MINIMAX
+        ? 'Check your MiniMax API key in Settings > LLM Provider.'
+        : 'Make sure LM Studio is running and the model is loaded.'
       setMessages([...newMessages, {
         role: 'assistant',
-        content: `Error: ${error.message}. Make sure LM Studio is running and the model is loaded.`,
+        content: `Error: ${error.message}. ${hint}`,
       }])
       setCurrentResponse('')
     } finally {
@@ -262,9 +315,16 @@ function LLMAssistantWorkspace() {
             Refresh
           </button>
           <div className="flex items-center gap-2">
+            {providerType === PROVIDERS.MINIMAX ? (
+              <Cloud className="w-3 h-3 text-sf-text-muted" />
+            ) : (
+              <Monitor className="w-3 h-3 text-sf-text-muted" />
+            )}
             <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`} />
             <span className="text-[10px] text-sf-text-muted">
-              {isConnected ? 'LM Studio Connected' : 'LM Studio Offline'}
+              {providerType === PROVIDERS.MINIMAX
+                ? (isConnected ? 'MiniMax Connected' : 'MiniMax Offline')
+                : (isConnected ? 'LM Studio Connected' : 'LM Studio Offline')}
             </span>
           </div>
         </div>
@@ -282,21 +342,41 @@ function LLMAssistantWorkspace() {
                 <div className="flex items-start gap-2 text-xs text-sf-text-muted">
                   <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
                   <div>
-                    <div className="font-medium text-sf-text-secondary mb-2">LM Studio API not connected</div>
-                    <div className="text-[10px] space-y-1.5">
-                      <div className="font-medium text-sf-text-primary">To enable the API:</div>
-                      <ol className="list-decimal list-inside space-y-1 ml-1">
-                        <li>Open LM Studio</li>
-                        <li>Go to <strong>Settings</strong> → <strong>Developer</strong> tab</li>
-                        <li>Find the <strong>"Local LLM Service (headless)"</strong> section</li>
-                        <li>Check <strong>"Enable Local LLM Service"</strong></li>
-                        <li>Alternatively, look for a <strong>"Start server"</strong> toggle/button</li>
-                        <li>Click <strong>Refresh</strong> above to reconnect</li>
-                      </ol>
-                      <div className="mt-2 pt-2 border-t border-sf-dark-700 text-[9px] opacity-80">
-                        The API server runs on <code className="bg-sf-dark-700 px-1 rounded">localhost:1234</code> by default
-                      </div>
-                    </div>
+                    {providerType === PROVIDERS.MINIMAX ? (
+                      <>
+                        <div className="font-medium text-sf-text-secondary mb-2">MiniMax API not connected</div>
+                        <div className="text-[10px] space-y-1.5">
+                          <div className="font-medium text-sf-text-primary">To connect:</div>
+                          <ol className="list-decimal list-inside space-y-1 ml-1">
+                            <li>Open <strong>Settings</strong> → <strong>LLM Provider</strong></li>
+                            <li>Select <strong>MiniMax (Cloud)</strong></li>
+                            <li>Enter your <strong>MiniMax API key</strong></li>
+                            <li>Click <strong>Refresh</strong> above to reconnect</li>
+                          </ol>
+                          <div className="mt-2 pt-2 border-t border-sf-dark-700 text-[9px] opacity-80">
+                            Get an API key at <a href="https://platform.minimaxi.com" target="_blank" rel="noopener noreferrer" className="text-sf-accent hover:underline">platform.minimaxi.com</a>
+                          </div>
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <div className="font-medium text-sf-text-secondary mb-2">LM Studio API not connected</div>
+                        <div className="text-[10px] space-y-1.5">
+                          <div className="font-medium text-sf-text-primary">To enable the API:</div>
+                          <ol className="list-decimal list-inside space-y-1 ml-1">
+                            <li>Open LM Studio</li>
+                            <li>Go to <strong>Settings</strong> → <strong>Developer</strong> tab</li>
+                            <li>Find the <strong>"Local LLM Service (headless)"</strong> section</li>
+                            <li>Check <strong>"Enable Local LLM Service"</strong></li>
+                            <li>Alternatively, look for a <strong>"Start server"</strong> toggle/button</li>
+                            <li>Click <strong>Refresh</strong> above to reconnect</li>
+                          </ol>
+                          <div className="mt-2 pt-2 border-t border-sf-dark-700 text-[9px] opacity-80">
+                            The API server runs on <code className="bg-sf-dark-700 px-1 rounded">localhost:1234</code> by default
+                          </div>
+                        </div>
+                      </>
+                    )}
                   </div>
                 </div>
               </div>
@@ -342,48 +422,59 @@ function LLMAssistantWorkspace() {
                   </div>
                 )}
 
-                {/* Load/Unload buttons */}
-                <div className="flex gap-2">
-                  {loadedModelId ? (
-                    <>
-                      <button
-                        onClick={handleUnloadModel}
-                        disabled={isUnloadingModel}
-                        className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-red-600/20 hover:bg-red-600/30 border border-red-600/50 rounded text-xs text-red-400 transition-colors disabled:opacity-50"
-                      >
-                        {isUnloadingModel ? (
-                          <Loader2 className="w-3 h-3 animate-spin" />
-                        ) : (
-                          <PowerOff className="w-3 h-3" />
-                        )}
-                        Unload Model
-                      </button>
-                      <div className="flex items-center gap-1 px-2 text-[10px] text-green-400">
-                        <div className="w-1.5 h-1.5 rounded-full bg-green-400" />
-                        Loaded
-                      </div>
-                    </>
-                  ) : (
-                    <button
-                      onClick={handleLoadModel}
-                      disabled={!selectedModelId || isLoadingModel}
-                      className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-sf-accent hover:bg-sf-accent-hover rounded text-xs text-white transition-colors disabled:opacity-50"
-                    >
-                      {isLoadingModel ? (
-                        <Loader2 className="w-3 h-3 animate-spin" />
+                {/* Load/Unload buttons — only for local providers */}
+                {supportsModelManagement(providerType) ? (
+                  <>
+                    <div className="flex gap-2">
+                      {loadedModelId ? (
+                        <>
+                          <button
+                            onClick={handleUnloadModel}
+                            disabled={isUnloadingModel}
+                            className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-red-600/20 hover:bg-red-600/30 border border-red-600/50 rounded text-xs text-red-400 transition-colors disabled:opacity-50"
+                          >
+                            {isUnloadingModel ? (
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                            ) : (
+                              <PowerOff className="w-3 h-3" />
+                            )}
+                            Unload Model
+                          </button>
+                          <div className="flex items-center gap-1 px-2 text-[10px] text-green-400">
+                            <div className="w-1.5 h-1.5 rounded-full bg-green-400" />
+                            Loaded
+                          </div>
+                        </>
                       ) : (
-                        <Power className="w-3 h-3" />
+                        <button
+                          onClick={handleLoadModel}
+                          disabled={!selectedModelId || isLoadingModel}
+                          className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-sf-accent hover:bg-sf-accent-hover rounded text-xs text-white transition-colors disabled:opacity-50"
+                        >
+                          {isLoadingModel ? (
+                            <Loader2 className="w-3 h-3 animate-spin" />
+                          ) : (
+                            <Power className="w-3 h-3" />
+                          )}
+                          Load Model
+                        </button>
                       )}
-                      Load Model
-                    </button>
-                  )}
-                </div>
+                    </div>
 
-                {loadedModel && (
-                  <div className="mt-3 p-2 bg-green-500/10 border border-green-500/30 rounded text-[10px] text-green-400">
-                    <div className="font-medium mb-1">Model Loaded</div>
+                    {loadedModel && (
+                      <div className="mt-3 p-2 bg-green-500/10 border border-green-500/30 rounded text-[10px] text-green-400">
+                        <div className="font-medium mb-1">Model Loaded</div>
+                        <div className="text-[9px] opacity-80">
+                          VRAM is being used. Unload when generating videos/images to free memory.
+                        </div>
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className="mt-2 p-2 bg-green-500/10 border border-green-500/30 rounded text-[10px] text-green-400">
+                    <div className="font-medium mb-1">Cloud Model Ready</div>
                     <div className="text-[9px] opacity-80">
-                      VRAM is being used. Unload when generating videos/images to free memory.
+                      Using MiniMax cloud API. No local VRAM required.
                     </div>
                   </div>
                 )}
@@ -395,31 +486,62 @@ function LLMAssistantWorkspace() {
           <div className="flex-1 overflow-auto p-4">
             <div className="text-[10px] text-sf-text-muted uppercase tracking-wider mb-2">How to Use</div>
             <div className="space-y-2 text-[11px] text-sf-text-secondary">
-              <div>
-                <div className="font-medium text-sf-text-primary mb-1">1. Enable API Server</div>
-                <div className="text-[10px]">
-                  In LM Studio: <strong>Settings</strong> → <strong>Developer</strong> tab → 
-                  Check <strong>"Enable Local LLM Service"</strong> or toggle <strong>"Start server"</strong>
-                </div>
-              </div>
-              <div>
-                <div className="font-medium text-sf-text-primary mb-1">2. Load a Model</div>
-                <div className="text-[10px]">Select and load a model to use for prompt assistance</div>
-              </div>
-              <div>
-                <div className="font-medium text-sf-text-primary mb-1">3. Chat & Refine</div>
-                <div className="text-[10px]">Ask for help creating or improving prompts</div>
-              </div>
-              <div>
-                <div className="font-medium text-sf-text-primary mb-1">4. Copy & Use</div>
-                <div className="text-[10px]">Copy generated prompts to the Generate workspace</div>
-              </div>
-              <div className="pt-2 border-t border-sf-dark-700">
-                <div className="font-medium text-yellow-400 mb-1">💡 Tip</div>
-                <div className="text-[10px]">
-                  Unload the model before generating videos/images to free VRAM for ComfyUI.
-                </div>
-              </div>
+              {providerType === PROVIDERS.MINIMAX ? (
+                <>
+                  <div>
+                    <div className="font-medium text-sf-text-primary mb-1">1. Add API Key</div>
+                    <div className="text-[10px]">
+                      Go to <strong>Settings</strong> → <strong>LLM Provider</strong> → enter your MiniMax API key
+                    </div>
+                  </div>
+                  <div>
+                    <div className="font-medium text-sf-text-primary mb-1">2. Select a Model</div>
+                    <div className="text-[10px]">Choose between M2.5 (balanced) or M2.5 Highspeed (faster)</div>
+                  </div>
+                  <div>
+                    <div className="font-medium text-sf-text-primary mb-1">3. Chat & Refine</div>
+                    <div className="text-[10px]">Ask for help creating or improving prompts</div>
+                  </div>
+                  <div>
+                    <div className="font-medium text-sf-text-primary mb-1">4. Copy & Use</div>
+                    <div className="text-[10px]">Copy generated prompts to the Generate workspace</div>
+                  </div>
+                  <div className="pt-2 border-t border-sf-dark-700">
+                    <div className="font-medium text-blue-400 mb-1">Cloud</div>
+                    <div className="text-[10px]">
+                      MiniMax runs in the cloud — no local GPU or VRAM needed.
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div>
+                    <div className="font-medium text-sf-text-primary mb-1">1. Enable API Server</div>
+                    <div className="text-[10px]">
+                      In LM Studio: <strong>Settings</strong> → <strong>Developer</strong> tab →
+                      Check <strong>"Enable Local LLM Service"</strong> or toggle <strong>"Start server"</strong>
+                    </div>
+                  </div>
+                  <div>
+                    <div className="font-medium text-sf-text-primary mb-1">2. Load a Model</div>
+                    <div className="text-[10px]">Select and load a model to use for prompt assistance</div>
+                  </div>
+                  <div>
+                    <div className="font-medium text-sf-text-primary mb-1">3. Chat & Refine</div>
+                    <div className="text-[10px]">Ask for help creating or improving prompts</div>
+                  </div>
+                  <div>
+                    <div className="font-medium text-sf-text-primary mb-1">4. Copy & Use</div>
+                    <div className="text-[10px]">Copy generated prompts to the Generate workspace</div>
+                  </div>
+                  <div className="pt-2 border-t border-sf-dark-700">
+                    <div className="font-medium text-yellow-400 mb-1">Tip</div>
+                    <div className="text-[10px]">
+                      Unload the model before generating videos/images to free VRAM for ComfyUI.
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -540,7 +662,9 @@ function LLMAssistantWorkspace() {
             {!loadedModelId && (
               <div className="mt-2 text-[10px] text-yellow-500 flex items-center gap-1">
                 <AlertCircle className="w-3 h-3" />
-                Load a model in the left panel to start chatting
+                {providerType === PROVIDERS.MINIMAX
+                  ? 'Connect to MiniMax to start chatting'
+                  : 'Load a model in the left panel to start chatting'}
               </div>
             )}
           </div>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import {
   X, Server, FolderOpen, Palette, Monitor, Save,
-  HardDrive, Film, ChevronDown, ChevronRight
+  HardDrive, Film, ChevronDown, ChevronRight, Bot
 } from 'lucide-react'
 import useProjectStore, { RESOLUTION_PRESETS, FPS_PRESETS } from '../stores/projectStore'
 import { getPexelsApiKey, setPexelsApiKey } from '../services/pexelsSettings'
@@ -13,6 +13,13 @@ import {
   parseLocalComfyPortInput,
   saveLocalComfyConnectionPort,
 } from '../services/localComfyConnection'
+import {
+  PROVIDERS,
+  getProviderTypeSync,
+  saveProviderType,
+  getMiniMaxApiKey,
+  saveMiniMaxApiKey,
+} from '../services/llmProvider'
 const COMFY_ORG_API_KEY_SETTING_KEY = 'comfyApiKeyComfyOrg'
 const COMFY_ORG_API_KEY_LOCAL_KEY = 'comfystudio-comfy-api-key'
 
@@ -28,6 +35,8 @@ function GeneralTab({ initialSection = null }) {
   const [theme, setTheme] = useState('dark')
   const [pexelsApiKey, setPexelsApiKeyLocal] = useState('')
   const [comfyOrgApiKey, setComfyOrgApiKey] = useState('')
+  const [llmProvider, setLlmProvider] = useState(getProviderTypeSync)
+  const [minimaxApiKey, setMinimaxApiKey] = useState('')
   const [settingsSaved, setSettingsSaved] = useState(false)
   const [expandedSections, setExpandedSections] = useState(['connection', 'storage', 'stock'])
 
@@ -64,6 +73,7 @@ function GeneralTab({ initialSection = null }) {
 
   useEffect(() => {
     getPexelsApiKey().then(key => setPexelsApiKeyLocal(key || ''))
+    getMiniMaxApiKey().then(key => setMinimaxApiKey(key || ''))
     ;(async () => {
       try {
         let next = ''
@@ -193,9 +203,20 @@ function GeneralTab({ initialSection = null }) {
     })
   }
 
+  const handleSaveLlmProvider = async (type) => {
+    setLlmProvider(type)
+    await saveProviderType(type)
+    window.dispatchEvent(new CustomEvent('comfystudio-llm-provider-changed', { detail: type }))
+  }
+
+  const handleSaveMinimaxApiKey = async () => {
+    await saveMiniMaxApiKey(minimaxApiKey)
+  }
+
   const handleSaveAllSettings = async () => {
     await setPexelsApiKey(pexelsApiKey.trim())
     await handleSaveComfyOrgApiKey()
+    await handleSaveMinimaxApiKey()
     const connectionSaved = await handleSaveComfyConnection()
     if (connectionSaved) {
       setSettingsSaved(true)
@@ -299,6 +320,48 @@ function GeneralTab({ initialSection = null }) {
               . Used by the Stock tab to search photos and videos.
             </p>
           </div>
+        </div>
+      </Section>
+
+      <Section id="llm" icon={Bot} title="LLM Provider">
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs text-sf-text-muted mb-1">Provider</label>
+            <select
+              value={llmProvider}
+              onChange={(e) => handleSaveLlmProvider(e.target.value)}
+              className="w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-3 py-2 text-sm text-sf-text-primary focus:outline-none focus:border-sf-accent"
+            >
+              <option value={PROVIDERS.LMSTUDIO}>Local (LM Studio)</option>
+              <option value={PROVIDERS.MINIMAX}>MiniMax (Cloud)</option>
+            </select>
+            <p className="text-[10px] text-sf-text-muted mt-1">
+              {llmProvider === PROVIDERS.MINIMAX
+                ? 'Uses MiniMax cloud API. No local GPU needed.'
+                : 'Connects to a local LM Studio server on localhost:1234.'}
+            </p>
+          </div>
+          {llmProvider === PROVIDERS.MINIMAX && (
+            <div>
+              <label className="block text-xs text-sf-text-muted mb-1">MiniMax API Key</label>
+              <input
+                type="password"
+                autoComplete="off"
+                value={minimaxApiKey}
+                onChange={(e) => setMinimaxApiKey(e.target.value)}
+                onBlur={handleSaveMinimaxApiKey}
+                placeholder="Your MiniMax API key"
+                className="w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-3 py-2 text-sm text-sf-text-primary placeholder-sf-text-muted focus:outline-none focus:border-sf-accent"
+              />
+              <p className="text-[10px] text-sf-text-muted mt-1">
+                Get a key at{' '}
+                <a href="https://platform.minimaxi.com" target="_blank" rel="noopener noreferrer" className="text-sf-accent hover:underline">
+                  platform.minimaxi.com
+                </a>
+                . Used by the LLM Assistant for cloud-based prompt help.
+              </p>
+            </div>
+          )}
         </div>
       </Section>
 

--- a/src/services/llmProvider.js
+++ b/src/services/llmProvider.js
@@ -1,0 +1,126 @@
+/**
+ * LLM Provider Manager
+ * Manages switching between local (LM Studio) and cloud (MiniMax) LLM providers.
+ *
+ * Settings are stored in Electron settings (if available) with localStorage fallback.
+ */
+
+import lmstudio from './lmstudio'
+import minimax from './minimax'
+
+const LLM_PROVIDER_SETTING_KEY = 'llmProviderType'
+const LLM_PROVIDER_LOCAL_KEY = 'comfystudio-llm-provider'
+const MINIMAX_API_KEY_SETTING_KEY = 'minimaxApiKey'
+const MINIMAX_API_KEY_LOCAL_KEY = 'comfystudio-minimax-api-key'
+const MINIMAX_MODEL_LOCAL_KEY = 'comfystudio-minimax-model'
+
+export const PROVIDERS = {
+  LMSTUDIO: 'lmstudio',
+  MINIMAX: 'minimax',
+}
+
+/**
+ * Get the stored LLM provider type
+ */
+export function getProviderTypeSync() {
+  try {
+    return localStorage.getItem(LLM_PROVIDER_LOCAL_KEY) || PROVIDERS.LMSTUDIO
+  } catch {
+    return PROVIDERS.LMSTUDIO
+  }
+}
+
+/**
+ * Save the LLM provider type
+ */
+export async function saveProviderType(type) {
+  try {
+    if (window?.electronAPI?.setSetting) {
+      await window.electronAPI.setSetting(LLM_PROVIDER_SETTING_KEY, type)
+    }
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(LLM_PROVIDER_LOCAL_KEY, type)
+    }
+  } catch (err) {
+    console.error('Failed to save LLM provider type:', err)
+  }
+}
+
+/**
+ * Get the stored MiniMax API key
+ */
+export async function getMiniMaxApiKey() {
+  try {
+    if (window?.electronAPI?.getSetting) {
+      const key = await window.electronAPI.getSetting(MINIMAX_API_KEY_SETTING_KEY)
+      if (key) return String(key)
+    }
+  } catch { /* fall through */ }
+  try {
+    return localStorage.getItem(MINIMAX_API_KEY_LOCAL_KEY) || ''
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Save the MiniMax API key
+ */
+export async function saveMiniMaxApiKey(key) {
+  const normalized = String(key || '').trim()
+  try {
+    if (window?.electronAPI?.setSetting) {
+      await window.electronAPI.setSetting(MINIMAX_API_KEY_SETTING_KEY, normalized)
+    }
+    if (typeof localStorage !== 'undefined') {
+      if (normalized) {
+        localStorage.setItem(MINIMAX_API_KEY_LOCAL_KEY, normalized)
+      } else {
+        localStorage.removeItem(MINIMAX_API_KEY_LOCAL_KEY)
+      }
+    }
+  } catch (err) {
+    console.error('Failed to save MiniMax API key:', err)
+  }
+}
+
+/**
+ * Get the stored MiniMax model selection
+ */
+export function getMiniMaxModelSync() {
+  try {
+    return localStorage.getItem(MINIMAX_MODEL_LOCAL_KEY) || 'MiniMax-M2.5'
+  } catch {
+    return 'MiniMax-M2.5'
+  }
+}
+
+/**
+ * Save the MiniMax model selection
+ */
+export function saveMiniMaxModel(modelId) {
+  try {
+    localStorage.setItem(MINIMAX_MODEL_LOCAL_KEY, modelId)
+  } catch { /* ignore */ }
+}
+
+/**
+ * Get the active LLM service instance based on the current provider type.
+ * Initializes the service with stored credentials.
+ */
+export async function getActiveService(providerType) {
+  const type = providerType || getProviderTypeSync()
+  if (type === PROVIDERS.MINIMAX) {
+    const apiKey = await getMiniMaxApiKey()
+    minimax.setApiKey(apiKey)
+    return minimax
+  }
+  return lmstudio
+}
+
+/**
+ * Check whether a provider type requires model loading/unloading (local only)
+ */
+export function supportsModelManagement(providerType) {
+  return providerType === PROVIDERS.LMSTUDIO
+}

--- a/src/services/minimax.js
+++ b/src/services/minimax.js
@@ -1,0 +1,177 @@
+/**
+ * MiniMax Cloud LLM Service
+ * Handles communication with MiniMax's OpenAI-compatible API
+ *
+ * API documentation: https://platform.minimaxi.com/document/introduction
+ * Base URL: https://api.minimax.io/v1
+ */
+
+const MINIMAX_BASE = 'https://api.minimax.io/v1'
+
+const MINIMAX_MODELS = [
+  { id: 'MiniMax-M2.5', name: 'MiniMax M2.5', context_length: 204800 },
+  { id: 'MiniMax-M2.5-highspeed', name: 'MiniMax M2.5 Highspeed', context_length: 204800 },
+]
+
+class MiniMaxService {
+  constructor() {
+    this.baseUrl = MINIMAX_BASE
+    this.apiKey = null
+  }
+
+  /**
+   * Set API key for authentication
+   */
+  setApiKey(key) {
+    this.apiKey = key
+  }
+
+  /**
+   * Get headers for API requests
+   */
+  getHeaders() {
+    const headers = {
+      'Content-Type': 'application/json',
+    }
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`
+    }
+    return headers
+  }
+
+  /**
+   * Check if MiniMax API is reachable with the configured API key
+   */
+  async checkConnection() {
+    if (!this.apiKey) return false
+    try {
+      const response = await fetch(`${this.baseUrl}/models`, {
+        method: 'GET',
+        headers: this.getHeaders(),
+      })
+      return response.ok
+    } catch (error) {
+      return false
+    }
+  }
+
+  /**
+   * List available MiniMax models
+   */
+  async listModels() {
+    return MINIMAX_MODELS.map(m => ({
+      id: m.id,
+      type: 'cloud',
+      state: 'loaded',
+      max_context_length: m.context_length,
+    }))
+  }
+
+  /**
+   * Send a chat completion request
+   * @param {string} modelId - Model identifier
+   * @param {Array} messages - Array of {role, content} messages
+   * @param {object} options - Generation options (temperature, max_tokens, etc.)
+   */
+  async chatCompletion(modelId, messages, options = {}) {
+    try {
+      let temperature = options.temperature ?? 0.7
+      // MiniMax requires temperature in (0.0, 1.0] — zero is rejected
+      if (temperature <= 0) temperature = 0.01
+
+      const body = {
+        model: modelId,
+        messages,
+        temperature,
+        stream: false,
+      }
+      if (options.max_tokens && options.max_tokens > 0) {
+        body.max_tokens = options.max_tokens
+      }
+
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`Chat completion failed: ${errorText}`)
+      }
+      const data = await response.json()
+      return data
+    } catch (error) {
+      console.error('Error in MiniMax chat completion:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Stream chat completion (for real-time responses)
+   * @param {string} modelId - Model identifier
+   * @param {Array} messages - Array of {role, content} messages
+   * @param {Function} onChunk - Callback for each chunk
+   * @param {object} options - Generation options
+   */
+  async streamChatCompletion(modelId, messages, onChunk, options = {}) {
+    try {
+      let temperature = options.temperature ?? 0.7
+      if (temperature <= 0) temperature = 0.01
+
+      const body = {
+        model: modelId,
+        messages,
+        temperature,
+        stream: true,
+      }
+      if (options.max_tokens && options.max_tokens > 0) {
+        body.max_tokens = options.max_tokens
+      }
+
+      const response = await fetch(`${this.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: this.getHeaders(),
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`Stream chat completion failed: ${errorText}`)
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        const chunk = decoder.decode(value)
+        const lines = chunk.split('\n').filter(line => line.trim() !== '')
+
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            const data = line.slice(6)
+            if (data === '[DONE]') {
+              return
+            }
+            try {
+              const json = JSON.parse(data)
+              if (json.choices?.[0]?.delta?.content) {
+                onChunk(json.choices[0].delta.content)
+              }
+            } catch (e) {
+              // Skip invalid JSON
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error in MiniMax stream chat completion:', error)
+      throw error
+    }
+  }
+}
+
+// Export singleton instance
+const minimax = new MiniMaxService()
+export default minimax


### PR DESCRIPTION
## Summary

This PR adds [MiniMax](https://platform.minimaxi.com) as an alternative cloud LLM provider for the prompt assistant, giving users a no-GPU option alongside the existing LM Studio integration.

### Changes

- **New `src/services/minimax.js`** — MiniMax service with OpenAI-compatible chat completions (streaming & non-streaming)
- **New `src/services/llmProvider.js`** — Provider manager to switch between LM Studio (local) and MiniMax (cloud)
- **Updated `src/components/SettingsModal.jsx`** — Added "LLM Provider" settings section with provider selector and MiniMax API key input
- **Updated `src/components/LLMAssistantWorkspace.jsx`** — Adapted UI to show provider-specific instructions, connection status, and model management
- **Updated `README.md`** — Documented MiniMax setup instructions alongside LM Studio

### How it works

1. Open **Settings → LLM Provider**
2. Select **MiniMax (Cloud)** from the dropdown
3. Enter a MiniMax API key (get one at [platform.minimaxi.com](https://platform.minimaxi.com))
4. The LLM Assistant automatically switches to cloud mode — no local GPU or VRAM needed

### Supported MiniMax models

| Model | Context Window | Notes |
|-------|---------------|-------|
| MiniMax-M2.5 | 204K tokens | Balanced quality and speed |
| MiniMax-M2.5-highspeed | 204K tokens | Optimized for faster responses |

### Design decisions

- **Non-breaking** — LM Studio remains the default provider; existing users are unaffected
- **Follows existing patterns** — Settings storage uses the same Electron + localStorage fallback as Pexels and Comfy.org API keys
- **Provider event system** — Settings changes dispatch a custom event so the workspace updates in real-time without a page reload
- **Cloud models skip load/unload** — The left sidebar adapts to hide model management controls when using a cloud provider

### Testing

- [x] `npm run build` passes without errors
- [ ] Manual testing with MiniMax API key
- [ ] Manual testing with LM Studio (backward compatibility)
