### PR TITLE
Perf/media loading and scroll

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -2119,6 +2119,67 @@ ipcMain.handle('media:getAudioWaveform', async (event, mediaInput, options = {})
   })
 })
 
+ipcMain.handle('media:extractVideoPoster', async (event, inputPath, outputPath, options = {}) => {
+  if (!ffmpegPath) {
+    return { success: false, error: 'FFmpeg binary not available.' }
+  }
+  if (!inputPath || !outputPath) {
+    return { success: false, error: 'Missing inputPath or outputPath.' }
+  }
+
+  let stat
+  try {
+    stat = await fs.stat(inputPath)
+  } catch (err) {
+    return { success: false, error: `Video file not found: ${err.message}` }
+  }
+
+  const seekSeconds = Math.max(0, Math.min(10, Number(options?.seekSeconds) || 0.1))
+  const posterWidth = Math.max(240, Math.min(1280, Math.round(Number(options?.width) || 640)))
+  const quality = Math.max(2, Math.min(31, Math.round(Number(options?.quality) || 3)))
+
+  try {
+    await fs.mkdir(path.dirname(outputPath), { recursive: true })
+  } catch (err) {
+    return { success: false, error: `Could not create poster directory: ${err.message}` }
+  }
+
+  return await new Promise((resolve) => {
+    const args = [
+      '-y',
+      '-ss', String(seekSeconds),
+      '-i', inputPath,
+      '-frames:v', '1',
+      '-vf', `scale=${posterWidth}:-2:force_original_aspect_ratio=decrease`,
+      '-q:v', String(quality),
+      outputPath,
+    ]
+
+    const proc = spawn(ffmpegPath, args, { windowsHide: true })
+    let stderr = ''
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+    proc.on('error', (err) => {
+      resolve({ success: false, error: err.message })
+    })
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve({
+          success: true,
+          width: posterWidth,
+          height: null,
+          sourceSize: stat.size,
+          sourceModified: stat.mtimeMs,
+        })
+      } else {
+        resolve({ success: false, error: stderr || `FFmpeg exited with code ${code}` })
+      }
+    })
+  })
+})
+
 // Mix the full timeline's program audio (video-embedded audio + audio clips) into
 // a single mono 16 kHz WAV file using FFmpeg in the main process. This exists as
 // a dedicated handler (not part of export:mixAudio) because:

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -287,6 +287,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAudioWaveform: (mediaInput, options = {}) => ipcRenderer.invoke('media:getAudioWaveform', mediaInput, options),
 
   /**
+   * Extract a poster image from the first frames of a video via ffmpeg.
+   * @param {string} inputPath - Absolute source file path
+   * @param {string} outputPath - Absolute poster destination path
+   * @param {object} options - { seekSeconds?: number, width?: number, quality?: number }
+   * @returns {Promise<{success: boolean, width?: number, height?: number, error?: string}>}
+   */
+  extractVideoPoster: (inputPath, outputPath, options = {}) => ipcRenderer.invoke('media:extractVideoPoster', inputPath, outputPath, options),
+
+  /**
    * Mix the full timeline's program audio into a single mono 16 kHz WAV file
    * via FFmpeg in the main process. Required for timeline-scope transcription
    * (decoding long videos in the renderer via Web Audio causes renderer OOMs).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,8 @@ import WelcomeScreen from './components/WelcomeScreen'
 import BottomBar from './components/BottomBar'
 import useProjectStore from './stores/projectStore'
 import useAssetsStore from './stores/assetsStore'
+import useTimelineStore from './stores/timelineStore'
+import videoCache from './services/videoCache'
 import { WORKFLOW_SETUP_SECTION_ID } from './services/workflowSetupManager'
 import {
   COMFY_CONNECTION_CHANGED_EVENT,
@@ -118,7 +120,16 @@ function App() {
   }, [])
 
   useEffect(() => {
+    const previousTab = mainTabRef.current
     mainTabRef.current = mainTab
+    if (previousTab === 'editor' && mainTab !== 'editor') {
+      try {
+        useTimelineStore.getState().shuttlePause?.()
+        videoCache.clear()
+      } catch (_) {
+        // Best-effort release of hidden editor media resources.
+      }
+    }
   }, [mainTab])
 
   // Auto-import outputs from custom workflows run while the embedded
@@ -451,11 +462,17 @@ function App() {
         >
           <ExportPanel />
         </div>
-        {mainTab === 'stock' ? (
+        {mainTab === "stock" && (
           <StockPanel />
-        ) : mainTab === 'llm-assistant' ? (
+        )}
+        {mainTab === "llm-assistant" && (
           <LLMAssistantWorkspace />
-        ) : mainTab === 'comfyui' || mainTab === 'generate' || mainTab === 'flow-ai' || mainTab === 'mog' || mainTab === 'export' ? null : (
+        )}
+        {/* Editor tab: unmount when hidden so video/canvas preview resources are released before Generate opens. */}
+        {mainTab === "editor" && (
+        <div
+          className="flex-1 flex min-h-0 overflow-hidden bg-sf-dark-950"
+        >
           <>
             {/* Left Panel - Full Height Mode (spans entire left side) */}
             {leftPanelFullHeight && (
@@ -613,6 +630,7 @@ function App() {
               </div>
             </div>
           </>
+        </div>
         )}
       </div>
       

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -465,6 +465,7 @@ function App() {
                   className="flex-shrink-0 transition-[width] duration-200 ease-out h-full"
                 >
                   <LeftPanel 
+                    isActive={mainTab === 'editor'}
                     isExpanded={leftPanelExpanded}
                     onToggleExpanded={handleToggleLeftPanelExpanded}
                     activeTab={leftPanelTab}
@@ -496,6 +497,7 @@ function App() {
                       className="flex-shrink-0 transition-[width] duration-200 ease-out"
                     >
                       <LeftPanel 
+                        isActive={mainTab === 'editor'}
                         isExpanded={leftPanelExpanded}
                         onToggleExpanded={handleToggleLeftPanelExpanded}
                         activeTab={leftPanelTab}

--- a/src/components/GenerateWorkspace.jsx
+++ b/src/components/GenerateWorkspace.jsx
@@ -8494,7 +8494,9 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             duration: jobDuration,
             fps: jobFps,
             resolution: jobResolution ? `${jobResolution.width}x${jobResolution.height}` : undefined,
-            seed: jobSeed
+            seed: jobSeed,
+            inputAssetId: job?.inputAssetId || undefined,
+            keyframeAssetId: job?.inputAssetId || shortFilmMeta?.keyframeAssetId || undefined,
           }
         }, generatedVideoFolderPath)
         if (newAsset) importedAssets.push(newAsset)
@@ -8518,7 +8520,13 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           yolo: directorMeta || undefined,
           shortFilm: shortFilmMeta || undefined,
           folderId: generatedVideoFolderId,
-          settings: { duration: jobDuration, fps: jobFps, seed: jobSeed }
+          settings: {
+            duration: jobDuration,
+            fps: jobFps,
+            seed: jobSeed,
+            inputAssetId: job?.inputAssetId || undefined,
+            keyframeAssetId: job?.inputAssetId || shortFilmMeta?.keyframeAssetId || undefined,
+          }
         })
         if (fallbackAsset) importedAssets.push(fallbackAsset)
         didImportAny = true

--- a/src/components/LeftPanel.jsx
+++ b/src/components/LeftPanel.jsx
@@ -7,7 +7,7 @@ import AssetsPanel from './panels/AssetsPanel'
 import TextPanel from './panels/TextPanel'
 import EffectsPanel from './panels/EffectsPanel'
 
-function LeftPanel({ isExpanded, onToggleExpanded, activeTab, onTabChange, isFullHeight = false, onToggleFullHeight, onSettingsClick }) {
+function LeftPanel({ isActive = true, isExpanded, onToggleExpanded, activeTab, onTabChange, isFullHeight = false, onToggleFullHeight, onSettingsClick }) {
   const tabs = [
     { id: 'assets', label: 'Assets', icon: FolderOpen },
     { id: 'text', label: 'Text', icon: Type },
@@ -40,9 +40,9 @@ function LeftPanel({ isExpanded, onToggleExpanded, activeTab, onTabChange, isFul
       case 'effects':
         return <EffectsPanel />
       case 'assets':
-        return <AssetsPanel />
+        return <AssetsPanel isActive={isActive} />
       default:
-        return <AssetsPanel />
+        return <AssetsPanel isActive={isActive} />
     }
   }
 

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -18,6 +18,7 @@ import useViewportClampedPosition from '../hooks/useViewportClampedPosition'
 import { getAllKeyframeTimes } from '../utils/keyframes'
 import { TRANSITION_TYPES, TRANSITION_DURATIONS, FRAME_RATE } from '../constants/transitions'
 import { getAudioClipFadeValues } from '../utils/audioClipFades'
+import { getSpriteFramePosition } from '../services/thumbnailSprites'
 import { getEffectTypeDefinition } from '../utils/effects'
 import { isTextEditingElement } from '../utils/keyboardFocus'
 import {
@@ -46,6 +47,8 @@ const MARQUEE_AUTO_SCROLL_STEP_PX = 24
 const PLAYHEAD_SCRUB_AUTO_SCROLL_EDGE_PX = 40
 const PLAYHEAD_SCRUB_AUTO_SCROLL_MAX_STEP_PX = 28
 const MIN_INTERACTIVE_CLIP_WIDTH_PX = 24
+const TIMELINE_VIDEO_THUMB_WIDTH_PX = 90
+const MAX_TIMELINE_VIDEO_THUMBNAILS = 12
 
 // Resolve-style audio track/waveform colors
 const AUDIO_TRACK_BG = '#2d4038'
@@ -1158,6 +1161,63 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
     }
     // Fallback to clip's stored URL
     return clip.url
+  }
+
+  const renderTimelineVideoFilmstrip = (clip, renderedClipWidth, thumbCount, contentHeight) => {
+    const asset = clip?.assetId ? assetsById.get(clip.assetId) : null
+    const sprite = asset?.sprite
+    const tileWidth = renderedClipWidth / Math.max(1, thumbCount)
+    const tileHeight = Math.max(1, contentHeight - 3)
+
+    if (sprite?.url && Array.isArray(sprite.frames) && sprite.frames.length > 0) {
+      const duration = Math.max(0, Number(clip?.duration) || 0)
+      const trimStart = Number(clip?.trimStart) || 0
+      const timeScale = clip?.sourceTimeScale || (clip?.timelineFps && clip?.sourceFps
+        ? clip.timelineFps / clip.sourceFps
+        : 1)
+      const spriteDuration = Math.max(0, Number(sprite.duration) || 0)
+
+      return Array.from({ length: thumbCount }).map((_, i) => {
+        const sampleRatio = thumbCount <= 1 ? 0.5 : i / Math.max(1, thumbCount - 1)
+        const clipTime = duration * sampleRatio
+        const sourceTime = Math.max(0, Math.min(spriteDuration || Infinity, trimStart + clipTime * timeScale))
+        const frame = getSpriteFramePosition(sprite, sourceTime) || sprite.frames[0]
+        if (!frame) return null
+
+        const scale = Math.max(tileWidth / Math.max(1, frame.width), tileHeight / Math.max(1, frame.height))
+        const scaledFrameWidth = frame.width * scale
+        const scaledFrameHeight = frame.height * scale
+        const x = -frame.x * scale + (tileWidth - scaledFrameWidth) / 2
+        const y = -frame.y * scale + (tileHeight - scaledFrameHeight) / 2
+
+        return (
+          <div
+            key={i}
+            className="flex-shrink-0 h-full relative overflow-hidden"
+            style={{ width: `${tileWidth}px` }}
+          >
+            <div
+              className="absolute inset-0 opacity-80 pointer-events-none"
+              style={{
+                backgroundImage: `url(${sprite.url})`,
+                backgroundRepeat: 'no-repeat',
+                backgroundSize: `${sprite.width * scale}px ${sprite.height * scale}px`,
+                backgroundPosition: `${x}px ${y}px`,
+              }}
+            />
+          </div>
+        )
+      })
+    }
+
+    return (
+      <div className="absolute inset-0 top-[3px] flex items-center overflow-hidden bg-[#162226]">
+        <div className="flex h-full w-full items-center gap-2 px-2 text-[9px] uppercase tracking-[0.16em] text-white/35">
+          <Video className="h-3 w-3 flex-shrink-0" />
+          <span className="truncate">Video</span>
+        </div>
+      </div>
+    )
   }
 
   const handleAddAdjustmentLayer = () => {
@@ -5019,7 +5079,7 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
                   const interactiveClipWidth = Math.max(MIN_INTERACTIVE_CLIP_WIDTH_PX, renderedClipWidth)
                   const interactiveClipOffset = Math.max(0, (interactiveClipWidth - renderedClipWidth) / 2)
                   // Calculate how many thumbnail frames to show (roughly one per 60px)
-                  const thumbCount = Math.max(1, Math.floor(renderedClipWidth / 60))
+                  const thumbCount = Math.max(1, Math.min(MAX_TIMELINE_VIDEO_THUMBNAILS, Math.ceil(renderedClipWidth / TIMELINE_VIDEO_THUMB_WIDTH_PX)))
                   const isTextClip = clip.type === 'text'
                   const isAdjustmentClip = clip.type === 'adjustment'
                   const clipEnabled = isClipEnabled(clip)
@@ -5302,27 +5362,10 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
                           }}
                         />
                         
-                        {/* Filmstrip thumbnails */}
-                        {clipMediaUrl && (
+                        {/* Filmstrip thumbnails: render cached sprite frames, never live video elements. */}
+                        {shouldRenderClipThumbnails && (
                           <div className="absolute inset-0 top-[3px] flex overflow-hidden">
-                            {Array.from({ length: thumbCount }).map((_, i) => (
-                              <div 
-                                key={i} 
-                                className="flex-shrink-0 h-full relative overflow-hidden"
-                                style={{ width: `${renderedClipWidth / thumbCount}px` }}
-                              >
-                                <video
-                                  src={clipMediaUrl}
-                                  className="absolute inset-0 w-full h-full object-cover opacity-80 pointer-events-none"
-                                  muted
-                                  style={{
-                                    // Offset each thumbnail to show different part of video
-                                    objectPosition: `${(i / Math.max(1, thumbCount - 1)) * 100}% center`
-                                  }}
-                                  onContextMenu={(e) => e.preventDefault()}
-                                />
-                              </div>
-                            ))}
+                            {renderTimelineVideoFilmstrip(clip, renderedClipWidth, thumbCount, contentHeight)}
                           </div>
                         )}
                         

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -1163,9 +1163,59 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
     return clip.url
   }
 
+  const getTimelineClipPosterUrl = (clip, asset) => {
+    const directPoster = asset?.posterUrl
+      || asset?.thumbnailUrl
+      || asset?.coverUrl
+      || asset?.settings?.posterUrl
+      || asset?.settings?.thumbnailUrl
+      || asset?.settings?.keyframeUrl
+    if (directPoster) return directPoster
+
+    const keyframeAssetId = asset?.settings?.keyframeAssetId
+      || asset?.settings?.inputAssetId
+      || asset?.yolo?.keyframeAssetId
+      || asset?.shortFilm?.keyframeAssetId
+      || clip?.metadata?.keyframeAssetId
+    if (keyframeAssetId) {
+      const posterAsset = assetsById.get(keyframeAssetId)
+      if (posterAsset?.type === 'image' && posterAsset?.url) return posterAsset.url
+    }
+
+    const variantKeys = new Set([
+      asset?.yolo?.variantKey,
+      asset?.yolo?.key,
+      clip?.metadata?.musicVideoAssembly?.variantKey,
+    ].filter(Boolean).map(String))
+    if (variantKeys.size > 0) {
+      const posterAsset = assets.find((candidate) => {
+        if (candidate?.type !== 'image' || !candidate?.url) return false
+        if (candidate?.yolo?.stage !== 'storyboard') return false
+        return [candidate?.yolo?.variantKey, candidate?.yolo?.key]
+          .filter(Boolean)
+          .some((key) => variantKeys.has(String(key)))
+      })
+      if (posterAsset?.url) return posterAsset.url
+    }
+
+    const shotId = asset?.shortFilm?.shotId || clip?.metadata?.shortFilm?.shotId
+    if (shotId) {
+      const posterAsset = assets.find((candidate) => (
+        candidate?.type === 'image'
+        && candidate?.url
+        && candidate?.shortFilm?.kind === 'shot-keyframe'
+        && String(candidate.shortFilm.shotId || '') === String(shotId)
+      ))
+      if (posterAsset?.url) return posterAsset.url
+    }
+
+    return null
+  }
+
   const renderTimelineVideoFilmstrip = (clip, renderedClipWidth, thumbCount, contentHeight) => {
     const asset = clip?.assetId ? assetsById.get(clip.assetId) : null
     const sprite = asset?.sprite
+    const posterUrl = getTimelineClipPosterUrl(clip, asset)
     const tileWidth = renderedClipWidth / Math.max(1, thumbCount)
     const tileHeight = Math.max(1, contentHeight - 3)
 
@@ -1208,6 +1258,21 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
           </div>
         )
       })
+    }
+
+    if (posterUrl) {
+      return (
+        <div className="absolute inset-0 top-[3px] overflow-hidden bg-[#162226]">
+          <img
+            src={posterUrl}
+            alt={asset?.name || clip?.name || 'Video keyframe'}
+            className="absolute inset-0 h-full w-full object-cover opacity-80 pointer-events-none"
+            draggable={false}
+            loading="lazy"
+            onContextMenu={(e) => e.preventDefault()}
+          />
+        </div>
+      )
     }
 
     return (

--- a/src/components/generate/MusicVideoEasyMode.jsx
+++ b/src/components/generate/MusicVideoEasyMode.jsx
@@ -250,6 +250,22 @@ function getAssetUrl(asset) {
   return asset?.url || asset?.thumbnailUrl || asset?.proxyUrl || asset?.path || ''
 }
 
+function ShotVideoPreview({ hasVideo, keyframeUrl, placeholderLabel = "Needs keyframe" }) {
+  if (keyframeUrl) {
+    return <img src={keyframeUrl} alt="" className="h-full w-full object-cover opacity-70" loading="lazy" decoding="async" />
+  }
+
+  if (hasVideo) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-sf-dark-800 text-sf-text-muted">
+        <Play className="h-5 w-5 opacity-70" />
+      </div>
+    )
+  }
+
+  return <span className="flex h-full w-full items-center justify-center text-[10px] text-sf-text-muted">{placeholderLabel}</span>
+}
+
 function getVideoWorkflowScopedKey(variantKey, workflowId) {
   const key = String(variantKey || '').trim()
   const workflow = String(workflowId || '').trim()
@@ -1813,13 +1829,7 @@ export default function MusicVideoEasyMode({
                         ? 'bg-red-950/30'
                         : 'bg-sf-dark-800'
                   }`}>
-                    {videoUrl ? (
-                      <video src={videoUrl} className="h-full w-full object-cover" muted playsInline preload="metadata" />
-                    ) : keyframeUrl ? (
-                      <img src={keyframeUrl} alt="" className="h-full w-full object-cover opacity-70" />
-                    ) : (
-                      <span className="text-[10px] text-sf-text-muted">Needs keyframe</span>
-                    )}
+                    <ShotVideoPreview hasVideo={Boolean(videoUrl)} keyframeUrl={keyframeUrl} />
                     {cardState.state === 'generating' && (
                       <div className="absolute inset-0 animate-pulse bg-gradient-to-r from-transparent via-white/10 to-transparent" />
                     )}

--- a/src/components/panels/AssetsPanel.jsx
+++ b/src/components/panels/AssetsPanel.jsx
@@ -8,6 +8,7 @@ import { enqueuePlaybackTranscode } from '../../services/playbackCache'
 import { enqueueProxyTranscode, isProxyPlaybackEnabled } from '../../services/proxyCache'
 import { unstitchSequenceAsset } from '../../services/comfyAutoImport'
 import { deleteSpriteFromProject } from '../../services/thumbnailSprites'
+import { deleteVideoPosterFromProject } from '../../services/thumbnailPosters'
 import MaskGenerationDialog from '../MaskGenerationDialog'
 import OverlayGeneratorModal from '../OverlayGeneratorModal'
 import TopazVideoUpscaleDialog from '../TopazVideoUpscaleDialog'
@@ -51,22 +52,23 @@ const assetMatchesSearch = (asset, normalizedQuery) => {
     || normalizeSearchText(asset?.prompt).includes(normalizedQuery)
 }
 
-function LazyAssetThumbnail({
+function VideoAssetThumbnail({
   asset,
   Icon,
   isActive = true,
+  onVisible = null,
   iconClassName = 'w-3.5 h-3.5 text-sf-text-muted',
   imageAlt = '',
-  videoClassName = 'w-full h-full object-cover',
   imageClassName = 'w-full h-full object-cover',
-  videoProps = {},
 }) {
   const containerRef = useRef(null)
   const [shouldLoad, setShouldLoad] = useState(false)
+  const didNotifyVisibleRef = useRef(false)
 
   useEffect(() => {
     if (!isActive) {
       setShouldLoad(false)
+      didNotifyVisibleRef.current = false
       return undefined
     }
 
@@ -86,12 +88,43 @@ function LazyAssetThumbnail({
     return () => observer.disconnect()
   }, [isActive])
 
+  useEffect(() => {
+    if (!shouldLoad || didNotifyVisibleRef.current || typeof onVisible !== 'function' || !asset?.id) return
+    didNotifyVisibleRef.current = true
+    onVisible(asset)
+  }, [asset, onVisible, shouldLoad])
+
   const fallback = Icon ? <Icon className={iconClassName} /> : null
+  const poster = asset?.poster
+  const sprite = asset?.sprite
+  const posterReady = shouldLoad && asset?.type === 'video' && poster?.url
+  const spriteReady = shouldLoad && asset?.type === 'video' && !poster?.url && sprite?.url && Array.isArray(sprite?.frames) && sprite.frames.length > 0
+  const spriteFrame = spriteReady ? sprite.frames[0] : null
+  const spriteStyle = spriteReady ? {
+    width: `${spriteFrame.width}px`,
+    height: `${spriteFrame.height}px`,
+    backgroundImage: `url(${sprite.url})`,
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: `${sprite.width}px ${sprite.height}px`,
+    backgroundPosition: `${-spriteFrame.x}px ${-spriteFrame.y}px`,
+  } : null
 
   return (
     <div ref={containerRef} className="w-full h-full flex items-center justify-center">
-      {shouldLoad && asset?.type === 'video' && asset?.url ? (
-        <video src={asset.url} className={videoClassName} muted preload="none" {...videoProps} />
+      {posterReady ? (
+        <img
+          src={poster.url}
+          alt={imageAlt}
+          className={imageClassName}
+          loading="lazy"
+          decoding="async"
+        />
+      ) : spriteReady ? (
+        <div
+          className="flex-shrink-0 overflow-hidden bg-sf-dark-700"
+          style={spriteStyle}
+          aria-hidden="true"
+        />
       ) : shouldLoad && asset?.type === 'image' && asset?.url ? (
         <img src={asset.url} alt={imageAlt} className={imageClassName} loading="lazy" decoding="async" />
       ) : fallback}
@@ -297,7 +330,8 @@ function AssetsPanel({ isActive = true }) {
     moveAssetToFolder,
     moveAssetsToFolder,
     generateAssetSprite,
-    getAssetSprite,
+    generateAssetPoster,
+    hydrateAssetBrowserMedia,
     setAssetAudioEnabled,
   } = useAssetsStore()
   const { currentProject, currentProjectHandle, currentTimelineId, switchTimeline, renameTimeline, setTimelineColor, moveTimelineToFolder, duplicateTimeline, deleteTimeline, getCurrentTimelineSettings } = useProjectStore()
@@ -389,6 +423,9 @@ function AssetsPanel({ isActive = true }) {
           // Generate sprites asynchronously (don't await)
           generateAssetSprite(newAsset.id, projectPath).catch(err => {
             console.warn('Auto-sprite generation failed:', err)
+          })
+          generateAssetPoster(newAsset.id, projectPath).catch(err => {
+            console.warn('Auto-poster generation failed:', err)
           })
         }
       } catch (err) {
@@ -575,6 +612,7 @@ function AssetsPanel({ isActive = true }) {
       addPath(remainingRelativePaths, asset?.proxyPath)
       if (!asset?.path) addPath(remainingAbsolutePaths, asset?.absolutePath)
       addPath(remainingAbsolutePaths, asset?.sprite?.spritePath)
+      addPath(remainingAbsolutePaths, asset?.poster?.posterPath)
     }
 
     const deleteRelativePath = async (relativePath) => {
@@ -621,6 +659,16 @@ function AssetsPanel({ isActive = true }) {
         }
       } else if (asset?.sprite?.spritePath) {
         await deleteAbsolutePath(asset.sprite.spritePath)
+      }
+
+      if (isElectron() && typeof currentProjectHandle === 'string' && asset?.poster) {
+        try {
+          await deleteVideoPosterFromProject(currentProjectHandle, asset.id)
+        } catch (_) {
+          // Ignore poster cleanup failures.
+        }
+      } else if (asset?.poster?.posterPath) {
+        await deleteAbsolutePath(asset.poster.posterPath)
       }
     }
   }, [assets, currentProjectHandle])
@@ -694,6 +742,7 @@ function AssetsPanel({ isActive = true }) {
     
     try {
       await generateAssetSprite(assetId, projectPath)
+      await generateAssetPoster(assetId, projectPath)
     } catch (err) {
       console.error('Failed to generate thumbnails:', err)
     }
@@ -1278,7 +1327,7 @@ function AssetsPanel({ isActive = true }) {
   useEffect(() => {
     setSelectedSequenceId(currentTimelineId || null)
   }, [currentTimelineId])
-  
+
   // Get thumbnail size config
   const sizeConfig = THUMBNAIL_SIZES[thumbnailSize]
   const folderTileIconSize = FOLDER_TILE_ICON_SIZES[thumbnailSize] || FOLDER_TILE_ICON_SIZES.medium
@@ -1567,7 +1616,7 @@ function AssetsPanel({ isActive = true }) {
                 >
                   <div className="flex items-center gap-2 min-w-0">
                     <div className="w-6 h-6 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-                      <LazyAssetThumbnail
+                      <VideoAssetThumbnail
                         asset={asset}
                         Icon={Icon}
                         isActive={isActive}
@@ -1944,19 +1993,18 @@ function AssetsPanel({ isActive = true }) {
                 >
                   {/* Thumbnail */}
                   <div className="aspect-video bg-sf-dark-700 flex items-center justify-center relative overflow-hidden">
-                    <LazyAssetThumbnail
+                    <VideoAssetThumbnail
+                      key={asset.poster?.url || asset.sprite?.url || asset.id}
                       asset={asset}
                       Icon={Icon}
                       isActive={isActive}
+                      onVisible={(visibleAsset) => {
+                        hydrateAssetBrowserMedia(visibleAsset.id, currentProjectHandle).catch((err) => {
+                          console.warn('[AssetsPanel] visible asset hydration failed:', err)
+                        })
+                      }}
                       iconClassName={`${sizeConfig.iconSize} text-sf-text-muted`}
                       imageAlt={asset.name}
-                      videoProps={{
-                        onMouseEnter: (e) => e.target.play(),
-                        onMouseLeave: (e) => {
-                          e.target.pause()
-                          e.target.currentTime = 0
-                        },
-                      }}
                     />
                     
                     {/* Badge - AI, Imported, or Mask */}
@@ -1977,9 +2025,9 @@ function AssetsPanel({ isActive = true }) {
                     )}
 
                     {/* Sprite badge - shows if thumbnails are ready */}
-                    {asset.type === 'video' && asset.sprite?.url && (
-                      <div className={`absolute bottom-0.5 left-0.5 px-1 py-0.5 rounded ${sizeConfig.badgeSize} text-white font-medium bg-sf-blue/90`} title="Thumbnails ready for fast scrubbing">
-                        <Film className="w-2 h-2 inline-block" />
+                    {asset.type === 'video' && asset.poster?.url && (
+                      <div className={`absolute bottom-0.5 left-0.5 px-1 py-0.5 rounded ${sizeConfig.badgeSize} text-white font-medium bg-sf-blue/90`} title="Video poster ready">
+                        <Image className="w-2 h-2 inline-block" />
                       </div>
                     )}
                     
@@ -2131,10 +2179,16 @@ function AssetsPanel({ isActive = true }) {
                   {/* Name + thumbnail */}
                   <div className="flex items-center gap-2 min-w-0">
                     <div className="w-7 h-7 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-                      <LazyAssetThumbnail
+                      <VideoAssetThumbnail
+                        key={asset.poster?.url || asset.sprite?.url || asset.id}
                         asset={asset}
                         Icon={Icon}
                         isActive={isActive}
+                        onVisible={(visibleAsset) => {
+                          hydrateAssetBrowserMedia(visibleAsset.id, currentProjectHandle).catch((err) => {
+                            console.warn('[AssetsPanel] visible asset hydration failed:', err)
+                          })
+                        }}
                         iconClassName="w-3.5 h-3.5 text-sf-text-muted"
                         imageAlt=""
                       />
@@ -2187,10 +2241,16 @@ function AssetsPanel({ isActive = true }) {
           <div className="flex items-center gap-2 min-w-0">
             <div className="w-10 h-7 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
               {DragPreviewIcon && (
-                <LazyAssetThumbnail
+                <VideoAssetThumbnail
+                  key={dragPreviewAsset.poster?.url || dragPreviewAsset.sprite?.url || dragPreviewAsset.id}
                   asset={dragPreviewAsset}
                   Icon={DragPreviewIcon}
                   isActive={isActive}
+                  onVisible={(visibleAsset) => {
+                    hydrateAssetBrowserMedia(visibleAsset.id, currentProjectHandle).catch((err) => {
+                      console.warn('[AssetsPanel] visible asset hydration failed:', err)
+                    })
+                  }}
                   iconClassName="w-4 h-4 text-sf-text-muted"
                   imageAlt=""
                 />

--- a/src/components/panels/AssetsPanel.jsx
+++ b/src/components/panels/AssetsPanel.jsx
@@ -51,7 +51,55 @@ const assetMatchesSearch = (asset, normalizedQuery) => {
     || normalizeSearchText(asset?.prompt).includes(normalizedQuery)
 }
 
-function AssetsPanel() {
+function LazyAssetThumbnail({
+  asset,
+  Icon,
+  isActive = true,
+  iconClassName = 'w-3.5 h-3.5 text-sf-text-muted',
+  imageAlt = '',
+  videoClassName = 'w-full h-full object-cover',
+  imageClassName = 'w-full h-full object-cover',
+  videoProps = {},
+}) {
+  const containerRef = useRef(null)
+  const [shouldLoad, setShouldLoad] = useState(false)
+
+  useEffect(() => {
+    if (!isActive) {
+      setShouldLoad(false)
+      return undefined
+    }
+
+    const element = containerRef.current
+    if (!element) return undefined
+    if (typeof IntersectionObserver === 'undefined') {
+      setShouldLoad(true)
+      return undefined
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const visible = entries.some((entry) => entry.isIntersecting || entry.intersectionRatio > 0)
+      setShouldLoad(visible)
+    }, { root: null, rootMargin: '600px 0px', threshold: 0.01 })
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [isActive])
+
+  const fallback = Icon ? <Icon className={iconClassName} /> : null
+
+  return (
+    <div ref={containerRef} className="w-full h-full flex items-center justify-center">
+      {shouldLoad && asset?.type === 'video' && asset?.url ? (
+        <video src={asset.url} className={videoClassName} muted preload="none" {...videoProps} />
+      ) : shouldLoad && asset?.type === 'image' && asset?.url ? (
+        <img src={asset.url} alt={imageAlt} className={imageClassName} loading="lazy" decoding="async" />
+      ) : fallback}
+    </div>
+  )
+}
+
+function AssetsPanel({ isActive = true }) {
   const [viewMode, setViewMode] = useState('grid')
   const [thumbnailSize, setThumbnailSize] = useState('medium')
   const [assetDeleteMode, setAssetDeleteMode] = useState(() => {
@@ -1519,13 +1567,13 @@ function AssetsPanel() {
                 >
                   <div className="flex items-center gap-2 min-w-0">
                     <div className="w-6 h-6 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-                      {asset.type === 'video' && asset.url ? (
-                        <video src={asset.url} className="w-full h-full object-cover" muted preload="metadata" />
-                      ) : asset.type === 'image' && asset.url ? (
-                        <img src={asset.url} alt="" className="w-full h-full object-cover" />
-                      ) : (
-                        <Icon className="w-3.5 h-3.5 text-sf-text-muted" />
-                      )}
+                      <LazyAssetThumbnail
+                        asset={asset}
+                        Icon={Icon}
+                        isActive={isActive}
+                        iconClassName="w-3.5 h-3.5 text-sf-text-muted"
+                        imageAlt=""
+                      />
                     </div>
                     {isEditingAsset ? (
                       <form onSubmit={saveEdit} className="min-w-0 flex-1" onClick={(e) => e.stopPropagation()}>
@@ -1896,26 +1944,20 @@ function AssetsPanel() {
                 >
                   {/* Thumbnail */}
                   <div className="aspect-video bg-sf-dark-700 flex items-center justify-center relative overflow-hidden">
-                    {asset.type === 'video' && asset.url ? (
-                      <video
-                        src={asset.url}
-                        className="w-full h-full object-cover"
-                        muted
-                        onMouseEnter={(e) => e.target.play()}
-                        onMouseLeave={(e) => {
+                    <LazyAssetThumbnail
+                      asset={asset}
+                      Icon={Icon}
+                      isActive={isActive}
+                      iconClassName={`${sizeConfig.iconSize} text-sf-text-muted`}
+                      imageAlt={asset.name}
+                      videoProps={{
+                        onMouseEnter: (e) => e.target.play(),
+                        onMouseLeave: (e) => {
                           e.target.pause()
                           e.target.currentTime = 0
-                        }}
-                      />
-                    ) : asset.type === 'image' && asset.url ? (
-                      <img
-                        src={asset.url}
-                        alt={asset.name}
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      <Icon className={`${sizeConfig.iconSize} text-sf-text-muted`} />
-                    )}
+                        },
+                      }}
+                    />
                     
                     {/* Badge - AI, Imported, or Mask */}
                     <div className={`absolute top-0.5 left-0.5 px-1 py-0.5 rounded ${sizeConfig.badgeSize} text-white font-medium ${
@@ -2089,13 +2131,13 @@ function AssetsPanel() {
                   {/* Name + thumbnail */}
                   <div className="flex items-center gap-2 min-w-0">
                     <div className="w-7 h-7 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-                      {asset.type === 'video' && asset.url ? (
-                        <video src={asset.url} className="w-full h-full object-cover" muted preload="metadata" />
-                      ) : asset.type === 'image' && asset.url ? (
-                        <img src={asset.url} alt="" className="w-full h-full object-cover" />
-                      ) : (
-                        <Icon className="w-3.5 h-3.5 text-sf-text-muted" />
-                      )}
+                      <LazyAssetThumbnail
+                        asset={asset}
+                        Icon={Icon}
+                        isActive={isActive}
+                        iconClassName="w-3.5 h-3.5 text-sf-text-muted"
+                        imageAlt=""
+                      />
                     </div>
                     {isEditingAsset ? (
                       <form onSubmit={saveEdit} className="min-w-0 flex-1" onClick={(e) => e.stopPropagation()}>
@@ -2144,12 +2186,14 @@ function AssetsPanel() {
         >
           <div className="flex items-center gap-2 min-w-0">
             <div className="w-10 h-7 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-              {dragPreviewAsset.type === 'video' && dragPreviewAsset.url ? (
-                <video src={dragPreviewAsset.url} className="w-full h-full object-cover" muted preload="metadata" />
-              ) : dragPreviewAsset.type === 'image' && dragPreviewAsset.url ? (
-                <img src={dragPreviewAsset.url} alt="" className="w-full h-full object-cover" />
-              ) : (
-                DragPreviewIcon && <DragPreviewIcon className="w-4 h-4 text-sf-text-muted" />
+              {DragPreviewIcon && (
+                <LazyAssetThumbnail
+                  asset={dragPreviewAsset}
+                  Icon={DragPreviewIcon}
+                  isActive={isActive}
+                  iconClassName="w-4 h-4 text-sf-text-muted"
+                  imageAlt=""
+                />
               )}
             </div>
             <div className="min-w-0">

--- a/src/services/thumbnailPosters.js
+++ b/src/services/thumbnailPosters.js
@@ -1,0 +1,111 @@
+import { isElectron } from './fileSystem'
+
+const POSTER_IMAGE_SUFFIX = '_poster.jpg'
+const POSTER_META_SUFFIX = '_poster.json'
+
+function normalizeSignature(signature = null) {
+  if (!signature || typeof signature !== 'object') return null
+  return {
+    sourcePath: String(signature.sourcePath || '').trim() || null,
+    sourceSize: Number(signature.sourceSize) || 0,
+    sourceModified: Number(signature.sourceModified) || 0,
+  }
+}
+
+function signaturesMatch(left, right) {
+  const a = normalizeSignature(left)
+  const b = normalizeSignature(right)
+  if (!a || !b) return false
+  return a.sourcePath === b.sourcePath
+    && a.sourceSize === b.sourceSize
+    && a.sourceModified === b.sourceModified
+}
+
+export function buildPosterSignature(fileInfo, sourcePath) {
+  return normalizeSignature({
+    sourcePath,
+    sourceSize: Number(fileInfo?.info?.size) || 0,
+    sourceModified: fileInfo?.info?.modified ? new Date(fileInfo.info.modified).getTime() : 0,
+  })
+}
+
+export async function loadVideoPosterFromProject(projectPath, assetId, expectedSignature = null) {
+  if (!isElectron() || !projectPath || !assetId) return null
+  const api = window.electronAPI
+  try {
+    const posterDir = await api.pathJoin(projectPath, 'thumbnails')
+    const posterPath = await api.pathJoin(posterDir, `${assetId}${POSTER_IMAGE_SUFFIX}`)
+    const metaPath = await api.pathJoin(posterDir, `${assetId}${POSTER_META_SUFFIX}`)
+    if (!await api.exists(posterPath)) return null
+
+    let posterMeta = null
+    if (await api.exists(metaPath)) {
+      const metaResult = await api.readFile(metaPath, { encoding: 'utf8' })
+      if (metaResult?.success && metaResult.data) {
+        try {
+          posterMeta = JSON.parse(metaResult.data)
+        } catch (_) {
+          posterMeta = null
+        }
+      }
+    }
+
+    if (expectedSignature && posterMeta?.sourceSignature && !signaturesMatch(posterMeta.sourceSignature, expectedSignature)) {
+      return null
+    }
+
+    const url = await api.getFileUrlDirect(posterPath)
+    return {
+      posterPath,
+      metaPath,
+      url,
+      posterData: {
+        url,
+        posterPath,
+        sourceSignature: posterMeta?.sourceSignature || null,
+        width: posterMeta?.width || null,
+        height: posterMeta?.height || null,
+        created: posterMeta?.created || null,
+      },
+    }
+  } catch (err) {
+    console.warn('Failed to load video poster:', err)
+    return null
+  }
+}
+
+export async function generateVideoPosterInProject(projectPath, assetId, sourcePath, sourceSignature, options = {}) {
+  if (!isElectron() || !projectPath || !assetId || !sourcePath) return null
+  const api = window.electronAPI
+  const posterDir = await api.pathJoin(projectPath, 'thumbnails')
+  await api.createDirectory(posterDir)
+  const posterPath = await api.pathJoin(posterDir, `${assetId}${POSTER_IMAGE_SUFFIX}`)
+  const metaPath = await api.pathJoin(posterDir, `${assetId}${POSTER_META_SUFFIX}`)
+
+  const result = await api.extractVideoPoster(sourcePath, posterPath, options)
+  if (!result?.success) {
+    throw new Error(result?.error || 'Failed to extract video poster')
+  }
+
+  const posterUrl = await api.getFileUrlDirect(posterPath)
+  const posterData = {
+    url: posterUrl,
+    posterPath,
+    sourceSignature: normalizeSignature(sourceSignature),
+    width: result.width || null,
+    height: result.height || null,
+    created: new Date().toISOString(),
+  }
+  await api.writeFile(metaPath, JSON.stringify(posterData, null, 2))
+  return { posterPath, metaPath, url: posterUrl, posterData }
+}
+
+export async function deleteVideoPosterFromProject(projectPath, assetId) {
+  if (!isElectron() || !projectPath || !assetId) return
+  const api = window.electronAPI
+  const posterDir = await api.pathJoin(projectPath, 'thumbnails')
+  const posterPath = await api.pathJoin(posterDir, `${assetId}${POSTER_IMAGE_SUFFIX}`)
+  const metaPath = await api.pathJoin(posterDir, `${assetId}${POSTER_META_SUFFIX}`)
+  try { await api.deleteFile(posterPath) } catch (_) {}
+  try { await api.deleteFile(metaPath) } catch (_) {}
+}

--- a/src/services/thumbnailSprites.js
+++ b/src/services/thumbnailSprites.js
@@ -260,25 +260,42 @@ export async function loadSpriteFromProject(projectPath, assetId, spriteIndex = 
   
   try {
     const thumbDir = await getThumbnailDirectory(projectPath)
-    const indexedSprite = spriteIndex?.[assetId] || (spriteIndex ? null : (await loadSpriteIndex(projectPath))[assetId])
-    const spritePath = indexedSprite?.spritePath || await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
-    const metaPath = indexedSprite?.metaPath || await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
-    
-    // Check if files exist
-    if (!await api.exists(spritePath)) {
-      return null
+    const loadedIndex = spriteIndex || await loadSpriteIndex(projectPath)
+    const indexedSprite = loadedIndex?.[assetId] || null
+    const legacySpritePath = await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
+    const legacyMetaPath = await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
+    const indexedSpritePath = indexedSprite?.spritePath || null
+    const indexedMetaPath = indexedSprite?.metaPath || null
+    const spriteCandidates = [indexedSpritePath, legacySpritePath].filter(Boolean)
+    let resolvedSpritePath = null
+    for (const candidate of spriteCandidates) {
+      if (await api.exists(candidate)) {
+        resolvedSpritePath = candidate
+        break
+      }
     }
+    if (!resolvedSpritePath) return null
 
-    let spriteData = indexedSprite || null
-    if (!spriteData) {
-      if (!await api.exists(metaPath)) return null
-      const metaResult = await api.readFile(metaPath, { encoding: 'utf8' })
-      if (!metaResult.success) return null
-      spriteData = JSON.parse(metaResult.data)
+    let spriteData = null
+    if (indexedSprite && indexedSpritePath === resolvedSpritePath) {
+      spriteData = indexedSprite
+    } else {
+      const metaCandidates = [
+        resolvedSpritePath === indexedSpritePath ? indexedMetaPath : null,
+        legacyMetaPath,
+      ].filter(Boolean)
+      for (const candidate of metaCandidates) {
+        if (!await api.exists(candidate)) continue
+        const metaResult = await api.readFile(candidate, { encoding: 'utf8' })
+        if (!metaResult.success) continue
+        spriteData = JSON.parse(metaResult.data)
+        break
+      }
     }
+    if (!spriteData) return null
     
     // Get URL for sprite image
-    const spriteUrl = await api.getFileUrlDirect(spritePath)
+    const spriteUrl = await api.getFileUrlDirect(resolvedSpritePath)
     
     return { spriteUrl, spriteData: { ...spriteData, url: spriteUrl } }
   } catch (err) {

--- a/src/services/thumbnailSprites.js
+++ b/src/services/thumbnailSprites.js
@@ -26,6 +26,38 @@ const SPRITE_CONFIG = {
   minDuration: 0.5,       // Don't generate sprites for clips shorter than this
 }
 
+const SPRITE_INDEX_FILE = 'sprite_index.json'
+
+async function getThumbnailDirectory(projectPath) {
+  const api = window.electronAPI
+  return await api.pathJoin(projectPath, 'thumbnails')
+}
+
+export async function loadSpriteIndex(projectPath) {
+  if (!isElectron()) return {}
+  const api = window.electronAPI
+  try {
+    const thumbDir = await getThumbnailDirectory(projectPath)
+    const indexPath = await api.pathJoin(thumbDir, SPRITE_INDEX_FILE)
+    if (!await api.exists(indexPath)) return {}
+    const result = await api.readFile(indexPath, { encoding: 'utf8' })
+    if (!result.success) return {}
+    const parsed = JSON.parse(result.data)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch (_) {
+    return {}
+  }
+}
+
+async function saveSpriteIndex(projectPath, index) {
+  if (!isElectron()) return
+  const api = window.electronAPI
+  const thumbDir = await getThumbnailDirectory(projectPath)
+  await api.createDirectory(thumbDir)
+  const indexPath = await api.pathJoin(thumbDir, SPRITE_INDEX_FILE)
+  await api.writeFile(indexPath, JSON.stringify(index || {}, null, 2))
+}
+
 /**
  * Generate a thumbnail sprite for a video file
  * Uses canvas-based frame extraction (works in both Electron and web)
@@ -178,7 +210,7 @@ export async function saveSpriteToProject(projectPath, assetId, spriteBlob, spri
   const api = window.electronAPI
   
   // Create thumbnails directory
-  const thumbDir = await api.pathJoin(projectPath, 'thumbnails')
+  const thumbDir = await getThumbnailDirectory(projectPath)
   await api.createDirectory(thumbDir)
   
   // Save sprite image
@@ -196,6 +228,18 @@ export async function saveSpriteToProject(projectPath, assetId, spriteBlob, spri
     createdAt: new Date().toISOString(),
   }
   await api.writeFile(metaPath, JSON.stringify(metaToSave, null, 2))
+
+  try {
+    const index = await loadSpriteIndex(projectPath)
+    index[assetId] = {
+      ...metaToSave,
+      spritePath,
+      metaPath,
+    }
+    await saveSpriteIndex(projectPath, index)
+  } catch (err) {
+    console.warn('Failed to update sprite index:', err)
+  }
   
   return { spritePath, metaPath, spriteData: metaToSave }
 }
@@ -207,7 +251,7 @@ export async function saveSpriteToProject(projectPath, assetId, spriteBlob, spri
  * @param {string} assetId - Asset ID
  * @returns {Promise<{spriteUrl: string, spriteData: object}|null>}
  */
-export async function loadSpriteFromProject(projectPath, assetId) {
+export async function loadSpriteFromProject(projectPath, assetId, spriteIndex = null) {
   if (!isElectron()) {
     return null
   }
@@ -215,19 +259,23 @@ export async function loadSpriteFromProject(projectPath, assetId) {
   const api = window.electronAPI
   
   try {
-    const thumbDir = await api.pathJoin(projectPath, 'thumbnails')
-    const spritePath = await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
-    const metaPath = await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
+    const thumbDir = await getThumbnailDirectory(projectPath)
+    const indexedSprite = spriteIndex?.[assetId] || (spriteIndex ? null : (await loadSpriteIndex(projectPath))[assetId])
+    const spritePath = indexedSprite?.spritePath || await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
+    const metaPath = indexedSprite?.metaPath || await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
     
     // Check if files exist
-    if (!await api.exists(spritePath) || !await api.exists(metaPath)) {
+    if (!await api.exists(spritePath)) {
       return null
     }
-    
-    // Load metadata
-    const metaResult = await api.readFile(metaPath, { encoding: 'utf8' })
-    if (!metaResult.success) return null
-    const spriteData = JSON.parse(metaResult.data)
+
+    let spriteData = indexedSprite || null
+    if (!spriteData) {
+      if (!await api.exists(metaPath)) return null
+      const metaResult = await api.readFile(metaPath, { encoding: 'utf8' })
+      if (!metaResult.success) return null
+      spriteData = JSON.parse(metaResult.data)
+    }
     
     // Get URL for sprite image
     const spriteUrl = await api.getFileUrlDirect(spritePath)
@@ -251,12 +299,22 @@ export async function deleteSpriteFromProject(projectPath, assetId) {
   const api = window.electronAPI
   
   try {
-    const thumbDir = await api.pathJoin(projectPath, 'thumbnails')
+    const thumbDir = await getThumbnailDirectory(projectPath)
     const spritePath = await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
     const metaPath = await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
     
     await api.deleteFile(spritePath)
     await api.deleteFile(metaPath)
+
+    try {
+      const index = await loadSpriteIndex(projectPath)
+      if (index && Object.prototype.hasOwnProperty.call(index, assetId)) {
+        delete index[assetId]
+        await saveSpriteIndex(projectPath, index)
+      }
+    } catch (_) {
+      // Ignore index cleanup failures.
+    }
   } catch (err) {
     // Ignore errors (files may not exist)
   }
@@ -320,6 +378,7 @@ export default {
   saveSpriteToProject,
   loadSpriteFromProject,
   deleteSpriteFromProject,
+  loadSpriteIndex,
   getSpriteFramePosition,
   getSpriteFrameStyle,
   SPRITE_CONFIG,

--- a/src/stores/assetsStore.js
+++ b/src/stores/assetsStore.js
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware'
 const SPRITE_GENERATION_CONCURRENCY = 2
 let activeSpriteGenerationCount = 0
 const pendingSpriteGenerationQueue = []
+let posterProjectSaveTimer = null
 
 const runWithSpriteGenerationSlot = async (task) => {
   if (activeSpriteGenerationCount >= SPRITE_GENERATION_CONCURRENCY) {
@@ -17,6 +18,25 @@ const runWithSpriteGenerationSlot = async (task) => {
     const next = pendingSpriteGenerationQueue.shift()
     if (next) next()
   }
+}
+
+const queueProjectPosterSave = (projectPath, delayMs = 1200) => {
+  if (!projectPath) return
+  if (posterProjectSaveTimer) {
+    clearTimeout(posterProjectSaveTimer)
+  }
+  posterProjectSaveTimer = setTimeout(async () => {
+    posterProjectSaveTimer = null
+    try {
+      const { useProjectStore } = await import('./projectStore')
+      const state = useProjectStore.getState()
+      if (state.currentProjectHandle === projectPath && typeof state.saveProject === 'function') {
+        await state.saveProject()
+      }
+    } catch (err) {
+      console.warn('Failed to persist poster metadata:', err)
+    }
+  }, delayMs)
 }
 
 /**
@@ -458,115 +478,49 @@ export const useAssetsStore = create(
       },
     })
 
+    const fileSystemHelpers = await import('../services/fileSystem')
+    const { getProjectFileUrl, getAbsoluteFileUrl, isElectron: isElectronMode } = fileSystemHelpers
+
     // Load assets - URLs need to be regenerated for imported assets
-    const assetsWithUrls = []
+    const assetsWithUrls = new Array(sourceAssets.length)
     let loadedAssetCount = 0
-    
-    for (const asset of sourceAssets) {
+
+    const hydrateAsset = async (asset, index) => {
       const needsUrlRefresh = asset?.url?.startsWith?.('blob:')
       const hasPath = !!asset?.path
       const hasAbsolutePath = !!asset?.absolutePath
 
-      if ((asset.isImported || needsUrlRefresh || hasPath || hasAbsolutePath) && projectHandle) {
-        // For imported assets (or stale blob URLs), regenerate URL from file
+      if ((asset?.isImported || needsUrlRefresh || hasPath || hasAbsolutePath) && projectHandle) {
         try {
-          const { getProjectFileUrl, getAbsoluteFileUrl, isElectron } = await import('../services/fileSystem')
           let url = null
-          if (isElectron() && hasAbsolutePath) {
+          if (isElectronMode() && hasAbsolutePath) {
             url = await getAbsoluteFileUrl(asset.absolutePath)
           } else if (hasPath) {
             url = await getProjectFileUrl(projectHandle, asset.path)
           }
-          // Regenerate playback cache URL if we have a cached transcode
-          let playbackCacheUrl = null
+
           let playbackCachePath = asset.playbackCachePath
           let playbackCacheStatus = asset.playbackCacheStatus
-          if (asset.playbackCachePath) {
-            try {
-              // Validate playback cache exists before generating a file:// URL.
-              // Missing cache files lead to networkState=3 and black flicker during playback.
-              let canUsePlaybackCache = true
-              if (
-                isElectron() &&
-                typeof projectHandle === 'string' &&
-                window.electronAPI?.pathJoin &&
-                window.electronAPI?.exists
-              ) {
-                const absolutePlaybackCachePath = await window.electronAPI.pathJoin(projectHandle, asset.playbackCachePath)
-                canUsePlaybackCache = await window.electronAPI.exists(absolutePlaybackCachePath)
-              }
 
-              if (canUsePlaybackCache) {
-                playbackCacheUrl = await getProjectFileUrl(projectHandle, asset.playbackCachePath)
-              } else {
-                playbackCachePath = null
-                playbackCacheStatus = 'failed'
-                console.warn(`[PlaybackCache] Missing cache file for ${asset.name}; falling back to source`, {
-                  assetId: asset.id,
-                  playbackCachePath: asset.playbackCachePath,
-                })
-              }
-            } catch (e) {
-              playbackCachePath = null
-              playbackCacheStatus = 'failed'
-              console.warn(`Could not load playback cache for ${asset.name}:`, e)
-            }
-          }
-          // Regenerate proxy URL (low-res NLE-style proxy) the same way.
-          // Kept separate from playbackCache so both tiers can coexist:
-          // proxy is strongly preferred for multi-layer preview, playback
-          // cache is used when proxy is missing/disabled.
-          let proxyUrl = null
-          let proxyPath = asset.proxyPath
-          let proxyStatus = asset.proxyStatus
-          if (asset.proxyPath) {
-            try {
-              let canUseProxy = true
-              if (
-                isElectron() &&
-                typeof projectHandle === 'string' &&
-                window.electronAPI?.pathJoin &&
-                window.electronAPI?.exists
-              ) {
-                const absoluteProxyPath = await window.electronAPI.pathJoin(projectHandle, asset.proxyPath)
-                canUseProxy = await window.electronAPI.exists(absoluteProxyPath)
-              }
-
-              if (canUseProxy) {
-                proxyUrl = await getProjectFileUrl(projectHandle, asset.proxyPath)
-              } else {
-                proxyPath = null
-                proxyStatus = 'failed'
-                console.warn(`[ProxyCache] Missing proxy file for ${asset.name}; falling back to source`, {
-                  assetId: asset.id,
-                  proxyPath: asset.proxyPath,
-                })
-              }
-            } catch (e) {
-              proxyPath = null
-              proxyStatus = 'failed'
-              console.warn(`Could not load proxy for ${asset.name}:`, e)
-            }
-          }
-          assetsWithUrls.push({
+          assetsWithUrls[index] = {
             ...asset,
             url,
             playbackCachePath: playbackCachePath ?? undefined,
             playbackCacheStatus,
-            playbackCacheUrl: playbackCacheUrl ?? undefined,
-            proxyPath: proxyPath ?? undefined,
-            proxyStatus,
-            proxyUrl: proxyUrl ?? undefined,
-          })
+            playbackCacheUrl: undefined,
+            proxyPath: asset.proxyPath ?? undefined,
+            proxyStatus: asset.proxyStatus,
+            proxyUrl: undefined,
+            poster: asset.poster || undefined,
+          }
         } catch (err) {
           console.warn(`Could not load asset ${asset.name}:`, err)
-          // Keep asset but mark URL as null
-          assetsWithUrls.push({ ...asset, url: null })
+          assetsWithUrls[index] = { ...asset, url: null }
         }
       } else {
-        // For AI/external assets, keep the URL as-is (may need ComfyUI to be running)
-        assetsWithUrls.push(asset)
+        assetsWithUrls[index] = asset
       }
+
       loadedAssetCount += 1
       set({
         mediaPreparation: {
@@ -579,6 +533,20 @@ export const useAssetsStore = create(
         },
       })
     }
+
+    const concurrency = Math.max(1, Math.min(8, Math.floor(Number(sourceAssets.length > 120 ? 8 : 4))))
+    let cursor = 0
+    const worker = async () => {
+      while (cursor < sourceAssets.length) {
+        const index = cursor
+        cursor += 1
+        const asset = sourceAssets[index]
+        await hydrateAsset(asset, index)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      }
+    }
+
+    await Promise.all(Array.from({ length: Math.min(concurrency, sourceAssets.length) }, () => worker()))
     
     const nextState = {
       assets: assetsWithUrls,
@@ -643,6 +611,22 @@ export const useAssetsStore = create(
       ),
       currentPreview: state.currentPreview?.id === assetId 
         ? { ...state.currentPreview, sprite: spriteData }
+        : state.currentPreview
+    }))
+  },
+
+  /**
+   * Update asset's poster data
+   * @param {string} assetId - The asset ID
+   * @param {object} posterData - Poster metadata { url, posterPath, sourceSignature, ... }
+   */
+  updateAssetPoster: (assetId, posterData) => {
+    set((state) => ({
+      assets: state.assets.map(a =>
+        a.id === assetId ? { ...a, poster: posterData } : a
+      ),
+      currentPreview: state.currentPreview?.id === assetId
+        ? { ...state.currentPreview, poster: posterData }
         : state.currentPreview
     }))
   },
@@ -725,6 +709,122 @@ export const useAssetsStore = create(
   },
 
   /**
+   * Generate a single-frame poster for a video asset.
+   * Posters are used by the Assets panel as the static preview image.
+   * @param {string} assetId - The asset ID
+   * @param {string} projectPath - Project directory path (for saving)
+   */
+  generateAssetPoster: async (assetId, projectPath) => {
+    const asset = get().assets.find(a => a.id === assetId)
+    if (!asset || asset.type !== 'video' || !asset.absolutePath || !projectPath) {
+      return null
+    }
+
+    try {
+      const { loadVideoPosterFromProject, generateVideoPosterInProject, buildPosterSignature } = await import('../services/thumbnailPosters')
+      const sourcePath = asset.absolutePath
+      const sourceInfo = await window.electronAPI?.getFileInfo?.(sourcePath)
+      const sourceSignature = buildPosterSignature(sourceInfo, sourcePath)
+      const existing = await loadVideoPosterFromProject(projectPath, assetId, sourceSignature)
+      if (existing?.posterData) {
+        get().updateAssetPoster(assetId, existing.posterData)
+        queueProjectPosterSave(projectPath)
+        return existing.posterData
+      }
+
+      const result = await generateVideoPosterInProject(projectPath, assetId, sourcePath, sourceSignature)
+      if (result?.posterData) {
+        get().updateAssetPoster(assetId, result.posterData)
+        queueProjectPosterSave(projectPath)
+        return result.posterData
+      }
+    } catch (err) {
+      console.warn('Failed to generate poster:', err)
+    }
+
+    return null
+  },
+
+  /**
+   * Hydrate the browser-facing media for a single video asset when it becomes visible.
+   * This is intentionally called lazily from the Assets panel so we only touch
+   * derived paths for tiles the user can actually see.
+   * @param {string} assetId - The asset ID
+   * @param {string} projectPath - Project directory path
+   */
+  hydrateAssetBrowserMedia: async (assetId, projectPath) => {
+    if (!assetId || !projectPath || typeof window === 'undefined' || !window.electronAPI?.isElectron) return null
+    const asset = get().assets.find(a => a.id === assetId)
+    if (!asset || asset.type !== 'video') return null
+
+    const { getProjectFileUrl, getAbsoluteFileUrl } = await import('../services/fileSystem')
+    const { loadVideoPosterFromProject, generateVideoPosterInProject, buildPosterSignature } = await import('../services/thumbnailPosters')
+
+    let poster = asset.poster || null
+    let posterChanged = false
+    let playbackCacheUrl = asset.playbackCacheUrl || undefined
+    let proxyUrl = asset.proxyUrl || undefined
+
+    if (!poster && asset.absolutePath) {
+      try {
+        const sourceInfo = await window.electronAPI.getFileInfo(asset.absolutePath)
+        const sourceSignature = buildPosterSignature(sourceInfo, asset.absolutePath)
+        const existing = await loadVideoPosterFromProject(projectPath, assetId, sourceSignature)
+        if (existing?.posterData) {
+          poster = existing.posterData
+          posterChanged = true
+        } else {
+          const generated = await generateVideoPosterInProject(projectPath, assetId, asset.absolutePath, sourceSignature)
+          if (generated?.posterData) {
+            poster = generated.posterData
+            posterChanged = true
+            queueProjectPosterSave(projectPath)
+          }
+        }
+      } catch (err) {
+        console.warn('Failed to hydrate poster for visible asset:', err)
+      }
+    }
+
+    if (!playbackCacheUrl && asset.playbackCachePath) {
+      try {
+        const absolutePlaybackCachePath = await window.electronAPI.pathJoin(projectPath, asset.playbackCachePath)
+        const exists = await window.electronAPI.exists(absolutePlaybackCachePath)
+        if (exists) {
+          playbackCacheUrl = await getProjectFileUrl(projectPath, asset.playbackCachePath)
+        }
+      } catch (err) {
+        console.warn('Failed to hydrate playback cache URL for visible asset:', err)
+      }
+    }
+
+    if (!proxyUrl && asset.proxyPath) {
+      try {
+        const absoluteProxyPath = await window.electronAPI.pathJoin(projectPath, asset.proxyPath)
+        const exists = await window.electronAPI.exists(absoluteProxyPath)
+        if (exists) {
+          proxyUrl = await getProjectFileUrl(projectPath, asset.proxyPath)
+        }
+      } catch (err) {
+        console.warn('Failed to hydrate proxy URL for visible asset:', err)
+      }
+    }
+
+    if (!posterChanged && !playbackCacheUrl && !proxyUrl) return null
+
+    const updates = {}
+    if (posterChanged) updates.poster = poster || undefined
+    if (typeof playbackCacheUrl !== 'undefined') updates.playbackCacheUrl = playbackCacheUrl
+    if (typeof proxyUrl !== 'undefined') updates.proxyUrl = proxyUrl
+
+    if (Object.keys(updates).length > 0) {
+      get().updateAsset(assetId, updates)
+    }
+
+    return updates
+  },
+
+  /**
    * Load saved thumbnail sprites for video assets without flooding the renderer.
    * Startup intentionally does not call this; use it for explicit/on-demand
    * warming where bounded background work is acceptable.
@@ -797,6 +897,97 @@ export const useAssetsStore = create(
     try {
       await Promise.all(Array.from({ length: Math.min(concurrency, videoAssets.length) }, () => worker()))
     } finally {
+      get().clearMediaPreparation()
+    }
+  },
+
+  /**
+   * Load or generate posters for video assets without flooding the renderer.
+   * Used by the Assets panel so video tiles show a static thumbnail even
+   * without a timeline preview.
+   * @param {string} projectPath - Project directory path
+   * @param {object} options - { concurrency?: number, limit?: number, assetIds?: string[] }
+   */
+  loadPostersFromProject: async (projectPath, options = {}) => {
+    if (!projectPath) return
+
+    const { loadVideoPosterFromProject, generateVideoPosterInProject, buildPosterSignature } = await import('../services/thumbnailPosters')
+    const state = get()
+    const targetIds = Array.isArray(options.assetIds) && options.assetIds.length > 0
+      ? new Set(options.assetIds)
+      : null
+    const limit = Number.isFinite(Number(options.limit)) && Number(options.limit) > 0
+      ? Math.floor(Number(options.limit))
+      : null
+    const concurrency = Math.max(1, Math.min(4, Math.floor(Number(options.concurrency) || 2)))
+    const videoAssets = state.assets
+      .filter((asset) => asset?.type === 'video' && (!targetIds || targetIds.has(asset.id)))
+      .slice(0, limit || undefined)
+
+    if (videoAssets.length === 0) {
+      return
+    }
+
+    let completed = 0
+    const updateProgress = () => {
+      set({
+        mediaPreparation: {
+          active: true,
+          phase: 'posters',
+          label: `Loading video thumbnails (${concurrency} at a time)...`,
+          completed,
+          total: videoAssets.length,
+          critical: false,
+        },
+      })
+    }
+    updateProgress()
+
+    let cursor = 0
+    let updatedAnyPoster = false
+    const loadOne = async (asset) => {
+      try {
+        if (asset?.poster?.url) {
+          return
+        }
+        const sourcePath = asset?.absolutePath || null
+        if (!sourcePath) return
+        const sourceInfo = await window.electronAPI?.getFileInfo?.(sourcePath)
+        const sourceSignature = buildPosterSignature(sourceInfo, sourcePath)
+        const loaded = await loadVideoPosterFromProject(projectPath, asset.id, sourceSignature)
+        if (loaded?.posterData) {
+          get().updateAssetPoster(asset.id, loaded.posterData)
+          updatedAnyPoster = true
+          return
+        }
+        const generated = await generateVideoPosterInProject(projectPath, asset.id, sourcePath, sourceSignature)
+        if (generated?.posterData) {
+          get().updateAssetPoster(asset.id, generated.posterData)
+          updatedAnyPoster = true
+        }
+      } catch (err) {
+        console.warn('[AssetsStore] poster load failed:', err)
+      } finally {
+        completed += 1
+        updateProgress()
+      }
+    }
+
+    const worker = async () => {
+      while (cursor < videoAssets.length) {
+        const asset = videoAssets[cursor]
+        cursor += 1
+        await loadOne(asset)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      }
+    }
+
+    try {
+      await Promise.all(Array.from({ length: Math.min(concurrency, videoAssets.length) }, () => worker()))
+    } finally {
+      if (updatedAnyPoster) {
+        queueProjectPosterSave(projectPath)
+      }
       get().clearMediaPreparation()
     }
   },

--- a/src/stores/assetsStore.js
+++ b/src/stores/assetsStore.js
@@ -562,28 +562,17 @@ export const useAssetsStore = create(
       })
     }
     
-    const videoAssetCount = assetsWithUrls.filter((asset) => asset?.type === 'video').length
-    const willLoadSprites = typeof projectHandle === 'string' && videoAssetCount > 0
     const nextState = {
       assets: assetsWithUrls,
       assetCounter: (projectAssets?.length || 0) + 1,
-      mediaPreparation: willLoadSprites
-        ? {
-            active: true,
-            phase: 'sprites',
-            label: 'Loading video thumbnails...',
-            completed: 0,
-            total: videoAssetCount,
-            critical: false,
-          }
-        : {
-            active: false,
-            phase: 'idle',
-            label: '',
-            completed: 0,
-            total: 0,
-            critical: false,
-          },
+      mediaPreparation: {
+        active: false,
+        phase: 'idle',
+        label: '',
+        completed: 0,
+        total: 0,
+        critical: false,
+      },
     }
     // Restore folder structure from project file so folders persist across sessions
     if (Array.isArray(projectFolders)) {

--- a/src/stores/assetsStore.js
+++ b/src/stores/assetsStore.js
@@ -1,6 +1,24 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
+const SPRITE_GENERATION_CONCURRENCY = 2
+let activeSpriteGenerationCount = 0
+const pendingSpriteGenerationQueue = []
+
+const runWithSpriteGenerationSlot = async (task) => {
+  if (activeSpriteGenerationCount >= SPRITE_GENERATION_CONCURRENCY) {
+    await new Promise((resolve) => pendingSpriteGenerationQueue.push(resolve))
+  }
+  activeSpriteGenerationCount += 1
+  try {
+    return await task()
+  } finally {
+    activeSpriteGenerationCount = Math.max(0, activeSpriteGenerationCount - 1)
+    const next = pendingSpriteGenerationQueue.shift()
+    if (next) next()
+  }
+}
+
 /**
  * Store for managing generated and imported assets
  * Persisted to localStorage for data survival across refreshes
@@ -661,8 +679,9 @@ export const useAssetsStore = create(
     try {
       const { generateThumbnailSprite, saveSpriteToProject } = await import('../services/thumbnailSprites')
       
-      // Generate sprite
-      const result = await generateThumbnailSprite(asset.url, asset.duration || 5)
+      // Generate sprite. This uses a hidden video element and canvas seeks,
+      // so keep generation bounded across imports/manual actions.
+      const result = await runWithSpriteGenerationSlot(() => generateThumbnailSprite(asset.url, asset.duration || 5))
       if (!result) {
         throw new Error('Failed to generate sprite')
       }
@@ -706,55 +725,80 @@ export const useAssetsStore = create(
   },
 
   /**
-   * Load sprites for all video assets from project
+   * Load saved thumbnail sprites for video assets without flooding the renderer.
+   * Startup intentionally does not call this; use it for explicit/on-demand
+   * warming where bounded background work is acceptable.
    * @param {string} projectPath - Project directory path
+   * @param {object} options - { concurrency?: number, limit?: number, assetIds?: string[] }
    */
-  loadSpritesFromProject: async (projectPath) => {
+  loadSpritesFromProject: async (projectPath, options = {}) => {
     if (!projectPath) return
 
-    const { loadSpriteFromProject } = await import('../services/thumbnailSprites')
+    const { loadSpriteFromProject, loadSpriteIndex } = await import('../services/thumbnailSprites')
+    const spriteIndex = await loadSpriteIndex(projectPath)
     const state = get()
-    
-    const videoAssets = state.assets.filter(a => a.type === 'video')
+    const targetIds = Array.isArray(options.assetIds) && options.assetIds.length > 0
+      ? new Set(options.assetIds)
+      : null
+    const limit = Number.isFinite(Number(options.limit)) && Number(options.limit) > 0
+      ? Math.floor(Number(options.limit))
+      : null
+    const concurrency = Math.max(1, Math.min(4, Math.floor(Number(options.concurrency) || 2)))
+    const videoAssets = state.assets
+      .filter((asset) => asset?.type === 'video' && (!targetIds || targetIds.has(asset.id)))
+      .slice(0, limit || undefined)
+
     if (videoAssets.length === 0) {
       get().clearMediaPreparation()
       return
     }
 
-    set({
-      mediaPreparation: {
-        active: true,
-        phase: 'sprites',
-        label: 'Loading video thumbnails...',
-        completed: 0,
-        total: videoAssets.length,
-        critical: false,
-      },
-    })
-    
-    for (const [index, asset] of videoAssets.entries()) {
+    let completed = 0
+    const updateProgress = () => {
+      set({
+        mediaPreparation: {
+          active: true,
+          phase: 'sprites',
+          label: `Loading video thumbnails (${concurrency} at a time)...`,
+          completed,
+          total: videoAssets.length,
+          critical: false,
+        },
+      })
+    }
+    updateProgress()
+
+    let cursor = 0
+    const loadOne = async (asset) => {
       try {
-        const sprite = await loadSpriteFromProject(projectPath, asset.id)
+        const sprite = await loadSpriteFromProject(projectPath, asset.id, spriteIndex)
         if (sprite) {
           get().updateAssetSprite(asset.id, sprite.spriteData)
           console.log(`Loaded sprite for ${asset.name}`)
         }
       } catch (err) {
-        // Sprite might not exist yet, that's OK
+        // Sprite might not exist yet, that's OK.
       } finally {
-        set({
-          mediaPreparation: {
-            active: true,
-            phase: 'sprites',
-            label: 'Loading video thumbnails...',
-            completed: index + 1,
-            total: videoAssets.length,
-            critical: false,
-          },
-        })
+        completed += 1
+        updateProgress()
       }
     }
-    get().clearMediaPreparation()
+
+    const worker = async () => {
+      while (cursor < videoAssets.length) {
+        const asset = videoAssets[cursor]
+        cursor += 1
+        await loadOne(asset)
+        // Yield between items so tab switches and paint are not starved.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      }
+    }
+
+    try {
+      await Promise.all(Array.from({ length: Math.min(concurrency, videoAssets.length) }, () => worker()))
+    } finally {
+      get().clearMediaPreparation()
+    }
   },
 
   /**

--- a/src/stores/projectStore.js
+++ b/src/stores/projectStore.js
@@ -300,41 +300,9 @@ export const useProjectStore = create(
           if (storedProject) {
             const isValid = await verifyPermission(storedProject)
             if (isValid) {
-              // Load project data
               const projectData = await loadProjectFromFile(storedProject)
               if (projectData) {
-                // Get the current/first timeline
-                const currentTimelineId = projectData.currentTimelineId || projectData.timelines?.[0]?.id
-                const currentTimeline = projectData.timelines?.find(t => t.id === currentTimelineId) || projectData.timelines?.[0]
-                
-                // Load timeline data (normalize clip timebases with asset fps)
-                if (currentTimeline) {
-                  const timelineFps = currentTimeline?.fps || projectData?.settings?.fps || 24
-                  useTimelineStore.getState().loadFromProject(currentTimeline, projectData.assets || [], timelineFps)
-                }
-                
-                // Regenerate asset URLs from project files; restore folder structure
-                if (projectData.assets) {
-                  await useAssetsStore.getState().loadFromProject(
-                    projectData.assets,
-                    storedProject,
-                    projectData.folders,
-                    projectData.folderCounter
-                  )
-                }
-                
-                // Load thumbnail sprites in background (Electron only)
-                if (typeof storedProject === 'string') {
-                  useAssetsStore.getState().loadSpritesFromProject(storedProject).catch(err => {
-                    console.warn('Failed to load sprites:', err)
-                  })
-                }
-                
-                set({
-                  currentProject: projectData,
-                  currentProjectHandle: storedProject,
-                  currentTimelineId: currentTimelineId,
-                })
+                await hydrateOpenedProjectSession(storedProject, projectData, set)
               }
             }
           }

--- a/src/stores/projectStore.js
+++ b/src/stores/projectStore.js
@@ -163,11 +163,11 @@ const hydrateOpenedProjectSession = async (projectHandleOrPath, rawProjectData, 
     projectData.folderCounter
   )
 
-  if (typeof projectHandleOrPath === 'string') {
-    useAssetsStore.getState().loadSpritesFromProject(projectHandleOrPath).catch((err) => {
-      console.warn('Failed to load sprites:', err)
-    })
-  }
+  // Do not eagerly load every saved video thumbnail sprite on project open.
+  // Large projects can contain hundreds of videos; walking all thumbnail
+  // metadata here blocks startup and can make Electron appear as a black
+  // screen. Thumbnails are loaded/generated on demand from the asset browser
+  // and timeline paths instead.
 
   const recentProject = {
     name: projectData.name,


### PR DESCRIPTION
## Summary

This PR improves performance and stability in media-heavy projects by reducing eager video/thumbnail work in scroll-heavy views and when switching workspaces.

## Changes

- Lazy-load asset browser thumbnails so offscreen media does not mount immediately.
- Stop eager project-wide video sprite loading during project open.
- Bound and cache video sprite loading to avoid flooding the renderer with thumbnail work.
- Release editor video resources when leaving the editor, including pausing timeline playback and clearing the video cache.
- Use keyframe/poster previews in timeline strips where available instead of relying on heavier video thumbnail behavior.
- Replace embedded video previews in the Music Video shot grid with static keyframe/poster placeholders.

## Why

Large music-video projects can contain hundreds of videos and keyframes. Loading video thumbnails or mounting video elements across hidden/offscreen views can cause slow project opens, scroll jank, high memory pressure, or frozen/black Electron windows.

This keeps scroll surfaces lightweight and avoids doing expensive video work until it is actually needed.

## Validation

- `npm run build`

## Scope Notes

This PR is intentionally limited to media loading, scroll performance, and editor memory pressure.