### PR TITLE
Add support for people wizard during music video generation option.

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -2119,6 +2119,67 @@ ipcMain.handle('media:getAudioWaveform', async (event, mediaInput, options = {})
   })
 })
 
+ipcMain.handle('media:extractVideoPoster', async (event, inputPath, outputPath, options = {}) => {
+  if (!ffmpegPath) {
+    return { success: false, error: 'FFmpeg binary not available.' }
+  }
+  if (!inputPath || !outputPath) {
+    return { success: false, error: 'Missing inputPath or outputPath.' }
+  }
+
+  let stat
+  try {
+    stat = await fs.stat(inputPath)
+  } catch (err) {
+    return { success: false, error: `Video file not found: ${err.message}` }
+  }
+
+  const seekSeconds = Math.max(0, Math.min(10, Number(options?.seekSeconds) || 0.1))
+  const posterWidth = Math.max(240, Math.min(1280, Math.round(Number(options?.width) || 640)))
+  const quality = Math.max(2, Math.min(31, Math.round(Number(options?.quality) || 3)))
+
+  try {
+    await fs.mkdir(path.dirname(outputPath), { recursive: true })
+  } catch (err) {
+    return { success: false, error: `Could not create poster directory: ${err.message}` }
+  }
+
+  return await new Promise((resolve) => {
+    const args = [
+      '-y',
+      '-ss', String(seekSeconds),
+      '-i', inputPath,
+      '-frames:v', '1',
+      '-vf', `scale=${posterWidth}:-2:force_original_aspect_ratio=decrease`,
+      '-q:v', String(quality),
+      outputPath,
+    ]
+
+    const proc = spawn(ffmpegPath, args, { windowsHide: true })
+    let stderr = ''
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+    proc.on('error', (err) => {
+      resolve({ success: false, error: err.message })
+    })
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve({
+          success: true,
+          width: posterWidth,
+          height: null,
+          sourceSize: stat.size,
+          sourceModified: stat.mtimeMs,
+        })
+      } else {
+        resolve({ success: false, error: stderr || `FFmpeg exited with code ${code}` })
+      }
+    })
+  })
+})
+
 // Mix the full timeline's program audio (video-embedded audio + audio clips) into
 // a single mono 16 kHz WAV file using FFmpeg in the main process. This exists as
 // a dedicated handler (not part of export:mixAudio) because:

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -287,6 +287,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAudioWaveform: (mediaInput, options = {}) => ipcRenderer.invoke('media:getAudioWaveform', mediaInput, options),
 
   /**
+   * Extract a poster image from the first frames of a video via ffmpeg.
+   * @param {string} inputPath - Absolute source file path
+   * @param {string} outputPath - Absolute poster destination path
+   * @param {object} options - { seekSeconds?: number, width?: number, quality?: number }
+   * @returns {Promise<{success: boolean, width?: number, height?: number, error?: string}>}
+   */
+  extractVideoPoster: (inputPath, outputPath, options = {}) => ipcRenderer.invoke('media:extractVideoPoster', inputPath, outputPath, options),
+
+  /**
    * Mix the full timeline's program audio into a single mono 16 kHz WAV file
    * via FFmpeg in the main process. Required for timeline-scope transcription
    * (decoding long videos in the renderer via Web Audio causes renderer OOMs).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,8 @@ import WelcomeScreen from './components/WelcomeScreen'
 import BottomBar from './components/BottomBar'
 import useProjectStore from './stores/projectStore'
 import useAssetsStore from './stores/assetsStore'
+import useTimelineStore from './stores/timelineStore'
+import videoCache from './services/videoCache'
 import { WORKFLOW_SETUP_SECTION_ID } from './services/workflowSetupManager'
 import {
   COMFY_CONNECTION_CHANGED_EVENT,
@@ -118,7 +120,16 @@ function App() {
   }, [])
 
   useEffect(() => {
+    const previousTab = mainTabRef.current
     mainTabRef.current = mainTab
+    if (previousTab === 'editor' && mainTab !== 'editor') {
+      try {
+        useTimelineStore.getState().shuttlePause?.()
+        videoCache.clear()
+      } catch (_) {
+        // Best-effort release of hidden editor media resources.
+      }
+    }
   }, [mainTab])
 
   // Auto-import outputs from custom workflows run while the embedded
@@ -451,11 +462,17 @@ function App() {
         >
           <ExportPanel />
         </div>
-        {mainTab === 'stock' ? (
+        {mainTab === "stock" && (
           <StockPanel />
-        ) : mainTab === 'llm-assistant' ? (
+        )}
+        {mainTab === "llm-assistant" && (
           <LLMAssistantWorkspace />
-        ) : mainTab === 'comfyui' || mainTab === 'generate' || mainTab === 'flow-ai' || mainTab === 'mog' || mainTab === 'export' ? null : (
+        )}
+        {/* Editor tab: unmount when hidden so video/canvas preview resources are released before Generate opens. */}
+        {mainTab === "editor" && (
+        <div
+          className="flex-1 flex min-h-0 overflow-hidden bg-sf-dark-950"
+        >
           <>
             {/* Left Panel - Full Height Mode (spans entire left side) */}
             {leftPanelFullHeight && (
@@ -613,6 +630,7 @@ function App() {
               </div>
             </div>
           </>
+        </div>
         )}
       </div>
       

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -465,6 +465,7 @@ function App() {
                   className="flex-shrink-0 transition-[width] duration-200 ease-out h-full"
                 >
                   <LeftPanel 
+                    isActive={mainTab === 'editor'}
                     isExpanded={leftPanelExpanded}
                     onToggleExpanded={handleToggleLeftPanelExpanded}
                     activeTab={leftPanelTab}
@@ -496,6 +497,7 @@ function App() {
                       className="flex-shrink-0 transition-[width] duration-200 ease-out"
                     >
                       <LeftPanel 
+                        isActive={mainTab === 'editor'}
                         isExpanded={leftPanelExpanded}
                         onToggleExpanded={handleToggleLeftPanelExpanded}
                         activeTab={leftPanelTab}

--- a/src/components/GenerateWorkspace.jsx
+++ b/src/components/GenerateWorkspace.jsx
@@ -8494,7 +8494,9 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             duration: jobDuration,
             fps: jobFps,
             resolution: jobResolution ? `${jobResolution.width}x${jobResolution.height}` : undefined,
-            seed: jobSeed
+            seed: jobSeed,
+            inputAssetId: job?.inputAssetId || undefined,
+            keyframeAssetId: job?.inputAssetId || shortFilmMeta?.keyframeAssetId || undefined,
           }
         }, generatedVideoFolderPath)
         if (newAsset) importedAssets.push(newAsset)
@@ -8518,7 +8520,13 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           yolo: directorMeta || undefined,
           shortFilm: shortFilmMeta || undefined,
           folderId: generatedVideoFolderId,
-          settings: { duration: jobDuration, fps: jobFps, seed: jobSeed }
+          settings: {
+            duration: jobDuration,
+            fps: jobFps,
+            seed: jobSeed,
+            inputAssetId: job?.inputAssetId || undefined,
+            keyframeAssetId: job?.inputAssetId || shortFilmMeta?.keyframeAssetId || undefined,
+          }
         })
         if (fallbackAsset) importedAssets.push(fallbackAsset)
         didImportAny = true

--- a/src/components/GenerateWorkspace.jsx
+++ b/src/components/GenerateWorkspace.jsx
@@ -5056,6 +5056,106 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
     setGenerationQueue(prev => [...prev, job])
   }, [])
 
+  const queuePeopleWizardJob = useCallback((overrides = {}) => {
+    const workflowId = String(overrides.workflowId || 'z-image-turbo').trim()
+    const peopleWizard = overrides.peopleWizard || null
+    const inputAssetId = overrides.inputAssetId || null
+    const referenceAssetId1 = overrides.referenceAssetId1 || null
+    const referenceAssetId2 = overrides.referenceAssetId2 || null
+    const jobId = `job_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    const seedValue = Number.isFinite(Number(overrides.seed)) ? Number(overrides.seed) : Number(seed) || Math.floor(Math.random() * 1000000000)
+    const resolutionValue = overrides.resolution || imageResolution
+    const assetPrefix = String(peopleWizard?.assetPrefix || overrides.assetPrefix || '').trim()
+    const imageAssetLookup = (assetId) => (assetId ? snapshotGenerationAsset(assets.find((asset) => asset?.id === assetId) || null) : null)
+    const job = {
+      id: jobId,
+      createdAt: Date.now(),
+      category: 'image',
+      workflowId,
+      workflowLabel: String(overrides.workflowLabel || getWorkflowDisplayLabel(workflowId) || workflowId || 'People Wizard').trim(),
+      needsImage: Boolean(overrides.needsImage ?? workflowId !== 'z-image-turbo'),
+      inputAssetType: workflowId === 'z-image-turbo' ? null : 'image',
+      prompt: String(overrides.prompt || '').trim(),
+      negativePrompt: String(overrides.negativePrompt || '').trim(),
+      tags: [],
+      seed: seedValue,
+      duration: 0,
+      fps: 0,
+      interpolationMultiplier: 4,
+      enableFpsMultiplier: false,
+      resolution: resolutionValue,
+      wanQualityPreset: 'balanced',
+      editSteps: editSteps,
+      editCfg: editCfg,
+      musicTags: '',
+      lyrics: '',
+      musicDuration: 0,
+      bpm: 0,
+      keyscale: '',
+      inputAssetId,
+      inputAssetName: inputAssetId ? (assets.find((asset) => asset?.id === inputAssetId)?.name || '') : '',
+      audioAssetId: null,
+      audioAssetName: '',
+      assetFieldIds: {},
+      inputFromTimelineFrame: false,
+      referenceAssetId1,
+      referenceAssetId2,
+      peopleWizard: {
+        ...(peopleWizard || {}),
+        assetPrefix,
+      },
+      frameTime: 0,
+      status: 'queued',
+      progress: 0,
+      promptId: null,
+      node: null,
+      error: null,
+      originProject: currentProjectHandle ? {
+        handle: currentProjectHandle,
+        name: currentProject?.name || '',
+        path: typeof currentProjectHandle === 'string' ? currentProjectHandle : null,
+        created: currentProject?.created || null,
+      } : null,
+      sourceAssets: {
+        input: imageAssetLookup(inputAssetId),
+        reference1: imageAssetLookup(referenceAssetId1),
+        reference2: imageAssetLookup(referenceAssetId2),
+        audio: null,
+        assetFields: {},
+      },
+    }
+    enqueueJob(job)
+    return job
+  }, [
+    assets,
+    currentProject,
+    currentProjectHandle,
+    editCfg,
+    editSteps,
+    enqueueJob,
+    imageResolution,
+    seed,
+  ])
+
+  const buildPeopleWizardAssetName = useCallback((prefix, suffix, fallbackName) => {
+    const base = slugifyNameToken(prefix || '', { fallback: '', maxLength: 48 })
+    if (!base) return fallbackName || ''
+    const safeSuffix = String(suffix || '').trim()
+    return safeSuffix ? `${base}_${safeSuffix}` : base
+  }, [])
+
+  const inferPeopleWizardAssetPrefix = useCallback((asset, fallbackValue = '') => {
+    const metadataPrefix = slugifyNameToken(asset?.peopleWizard?.assetPrefix || '', { fallback: '', maxLength: 48 })
+    if (metadataPrefix) return metadataPrefix
+    const rawName = String(asset?.name || '').trim()
+    if (!rawName) return slugifyNameToken(fallbackValue || '', { fallback: '', maxLength: 48 })
+    const baseName = rawName
+      .replace(/\.[a-z0-9]{1,8}$/i, '')
+      .replace(/_I\d+$/i, '')
+      .replace(/_(image|sheet)$/i, '')
+    return slugifyNameToken(baseName || fallbackValue || '', { fallback: '', maxLength: 48 })
+  }, [])
+
   const requestConfirm = useCallback(({
     title = 'Confirm action',
     message = '',
@@ -8556,6 +8656,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
       const shortFilmKeyframeName = shortFilmMeta?.kind === 'shot-keyframe'
         ? `KF ${String((Number(shortFilmMeta.shotIndex) || 0) + 1).padStart(2, '0')} - ${shortFilmMeta.shotTitle || 'Shot'}`
         : ''
+      const peopleWizardAssetPrefix = String(job?.peopleWizard?.assetPrefix || '').trim()
       for (let imageIndex = 0; imageIndex < imageItems.length; imageIndex += 1) {
         const img = imageItems[imageIndex]
         if (markImportedSignature('image', img.filename, img.subfolder, img.outputType)) continue
@@ -8566,7 +8667,8 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           const imageFile = await comfyui.downloadImage(img.filename, img.subfolder, img.outputType)
           const assetInfo = await importAsset(targetProjectHandle, imageFile, 'images')
           const blobUrl = importsIntoActiveProject ? URL.createObjectURL(imageFile) : null
-          const baseImageName = shortFilmKeyframeName || resolvedName
+          const wizardImageName = peopleWizardAssetPrefix ? buildPeopleWizardAssetName(peopleWizardAssetPrefix, 'image', resolvedName) : ''
+          const baseImageName = wizardImageName || shortFilmKeyframeName || resolvedName
           const imageName = imageItems.length > 1 ? `${baseImageName}_I${imageIndex + 1}` : baseImageName
           const newAsset = await saveImportedAssetRecord({
             ...assetInfo,
@@ -8577,6 +8679,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             isImported: true,
             yolo: directorMeta || undefined,
             shortFilm: shortFilmMeta || undefined,
+            peopleWizard: job?.peopleWizard || undefined,
             folderId: generatedImageFolderId,
           }, generatedImageFolderPath)
           if (newAsset) importedAssets.push(newAsset)
@@ -8585,7 +8688,8 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           console.warn('Failed to save image:', err)
           if (!importsIntoActiveProject) throw err
           const url = comfyui.getMediaUrl(img.filename, img.subfolder, img.outputType)
-          const baseImageName = shortFilmKeyframeName || resolvedName
+          const wizardImageName = peopleWizardAssetPrefix ? buildPeopleWizardAssetName(peopleWizardAssetPrefix, 'image', resolvedName) : ''
+          const baseImageName = wizardImageName || shortFilmKeyframeName || resolvedName
           const imageName = imageItems.length > 1 ? `${baseImageName}_I${imageIndex + 1}` : baseImageName
           const fallbackAsset = addAsset({
             name: imageName,
@@ -8594,6 +8698,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             prompt: jobPrompt,
             yolo: directorMeta || undefined,
             shortFilm: shortFilmMeta || undefined,
+            peopleWizard: job?.peopleWizard || undefined,
             folderId: generatedImageFolderId,
           })
           if (fallbackAsset) importedAssets.push(fallbackAsset)
@@ -8672,9 +8777,14 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
       addComfyLog('error', 'Open or create a project before creating an angle sheet.')
       return
     }
-    const imageAssets = job.resultAssetIds
-      .map((id) => assets.find((asset) => asset?.id === id) || null)
-      .filter((asset) => asset?.type === 'image')
+    const directResultAssets = Array.isArray(job?.resultAssets)
+      ? job.resultAssets.filter((asset) => asset?.type === 'image')
+      : []
+    const imageAssets = directResultAssets.length > 0
+      ? directResultAssets
+      : job.resultAssetIds
+        .map((id) => assets.find((asset) => asset?.id === id) || null)
+        .filter((asset) => asset?.type === 'image')
     if (imageAssets.length === 0) {
       addComfyLog('error', 'No generated image angles found for this job.')
       return
@@ -8721,24 +8831,40 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
         canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('Failed to export angle sheet'))), 'image/png')
       })
       const stamp = new Date().toISOString().replace(/[:.]/g, '-')
-      const file = new File([sheetBlob], `angle_sheet_${stamp}.png`, { type: 'image/png' })
+      const sourceAsset = imageAssets[0] || null
+      const peopleWizardAssetPrefix = slugifyNameToken(
+        job?.peopleWizard?.assetPrefix
+          || inferPeopleWizardAssetPrefix(sourceAsset, '')
+          || '',
+        { fallback: '', maxLength: 48 }
+      )
+      const sheetBaseName = peopleWizardAssetPrefix
+        ? buildPeopleWizardAssetName(peopleWizardAssetPrefix, 'sheet', 'angle_sheet')
+        : `angle_sheet_${stamp}`
+      const file = new File([sheetBlob], `${sheetBaseName}.png`, { type: 'image/png' })
       const assetInfo = await importAsset(targetProjectHandle, file, 'images')
       const newAsset = addAsset({
-        name: assetInfo.fileName,
+        name: `${sheetBaseName}.png`,
         type: 'image',
         path: assetInfo.path,
         url: areProjectHandlesSame(targetProjectHandle, currentProjectHandle) ? URL.createObjectURL(file) : null,
+        peopleWizard: job?.peopleWizard ? {
+          ...job.peopleWizard,
+          assetPrefix: peopleWizardAssetPrefix || job.peopleWizard.assetPrefix || '',
+        } : undefined,
       })
       if (!newAsset) throw new Error('Failed to register angle sheet in assets')
       await saveProject?.()
       updateJob(job.id, { angleSheetAssetId: newAsset.id, isCombiningAngles: false, combineError: null })
       addComfyLog('ok', `Angle sheet created: ${assetInfo.fileName}`)
+      return newAsset
     } catch (error) {
       const message = error?.message || 'Failed to create angle sheet'
       updateJob(job.id, { isCombiningAngles: false, combineError: message })
       addComfyLog('error', message)
+      return null
     }
-  }, [addAsset, addComfyLog, assets, currentProjectHandle, saveProject, updateJob])
+  }, [addAsset, addComfyLog, assets, buildPeopleWizardAssetName, currentProjectHandle, inferPeopleWizardAssetPrefix, saveProject, updateJob])
 
   const runJob = useCallback(async (job) => {
     updateJob(job.id, { status: 'uploading', progress: 5, error: null })
@@ -8839,10 +8965,26 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             ? `image/comfystudio_${outputToken}`
             : (
               job.workflowId === 'sonilo-v2m' || job.workflowId === ELEVENLABS_TTS_WORKFLOW_ID
-                ? `audio/comfystudio_${outputToken}`
+              ? `audio/comfystudio_${outputToken}`
                 : ''
             )
       )
+      const peopleWizardPrefix = slugifyNameToken(job?.peopleWizard?.assetPrefix || '', { fallback: '', maxLength: 48 })
+    const peopleWizardImagePrefix = peopleWizardPrefix ? `image/${peopleWizardPrefix}_${outputToken}` : ''
+      const maybeFinalizePeopleWizardJob = async (jobRecord, currentImportedAssets) => {
+        if (!jobRecord?.peopleWizard?.autoCreateAngleSheet) return currentImportedAssets
+        if (!['multi-angles', 'multi-angles-scene'].includes(String(jobRecord.workflowId || '').trim())) return currentImportedAssets
+        const resultAssetIds = (currentImportedAssets || []).map((asset) => asset?.id).filter(Boolean)
+        if (resultAssetIds.length === 0) return currentImportedAssets
+        const sheetAsset = await handleCreateAngleSheetForJob({
+          ...jobRecord,
+          resultAssetIds,
+          resultAssets: currentImportedAssets,
+        })
+        if (!sheetAsset) return currentImportedAssets
+        updateJob(jobRecord.id, { resultAssetIds: [sheetAsset.id] })
+        return [sheetAsset]
+      }
 
       if (job.promptId) {
         markPromptHandledByApp(job.promptId)
@@ -8866,6 +9008,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           if (!saveResult?.didImportAny) {
             throw new Error('Generation returned a stale/duplicate output; job was not imported. Queue paused for safety.')
           }
+          importedAssets = await maybeFinalizePeopleWizardJob(job, importedAssets)
           rememberLatestWorkflowPreview(job, importedAssets)
           updateJob(job.id, {
             status: 'done',
@@ -9196,7 +9339,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             seed: job.seed,
             width: job.resolution?.width,
             height: job.resolution?.height,
-            filenamePrefix: outputPrefix || 'image/z_image_turbo',
+            filenamePrefix: peopleWizardImagePrefix || outputPrefix || 'image/z_image_turbo',
           })
           break
         case 'longcat-text-to-image':
@@ -9234,7 +9377,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             width: job.resolution?.width,
             height: job.resolution?.height,
             referenceImages: referenceFilenames,
-            filenamePrefix: outputPrefix || 'image/nano_banana_2',
+            filenamePrefix: peopleWizardImagePrefix || outputPrefix || 'image/nano_banana_2',
           })
           break
         case 'gpt-image-2-t2i':
@@ -9243,7 +9386,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             seed: job.seed,
             width: job.resolution?.width,
             height: job.resolution?.height,
-            filenamePrefix: outputPrefix || 'image/gpt_image_2',
+            filenamePrefix: peopleWizardImagePrefix || outputPrefix || 'image/gpt_image_2',
           })
           break
         case 'gpt-image-2-edit':
@@ -9253,7 +9396,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             seed: job.seed,
             width: job.resolution?.width,
             height: job.resolution?.height,
-            filenamePrefix: outputPrefix || 'image/gpt_image_2_edit',
+            filenamePrefix: peopleWizardImagePrefix || outputPrefix || 'image/gpt_image_2_edit',
           })
           break
         case 'grok-text-to-image':
@@ -9262,7 +9405,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             seed: job.seed,
             width: job.resolution?.width,
             height: job.resolution?.height,
-            filenamePrefix: outputPrefix || 'image/grok_text_to_image',
+            filenamePrefix: peopleWizardImagePrefix || outputPrefix || 'image/grok_text_to_image',
           })
           break
         case 'seedream-5-lite-image-edit':
@@ -9273,7 +9416,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
             width: job.resolution?.width,
             height: job.resolution?.height,
             referenceImages: referenceFilenames,
-            filenamePrefix: outputPrefix || 'image/seedream_5_lite',
+            filenamePrefix: peopleWizardImagePrefix || outputPrefix || 'image/seedream_5_lite',
           })
           break
         case 'sonilo-v2m':
@@ -9335,6 +9478,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
         if (!saveResult?.didImportAny) {
           throw new Error('Generation returned a stale/duplicate output; job was not imported. Queue paused for safety.')
         }
+        importedAssets = await maybeFinalizePeopleWizardJob(job, importedAssets)
         rememberLatestWorkflowPreview(job, importedAssets)
         updateJob(job.id, {
           status: 'done',
@@ -10189,6 +10333,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                     setYoloMusicScript={setYoloMusicScript}
                     yoloMusicCast={yoloMusicCast}
                     yoloMusicResolvedCast={yoloMusicResolvedCast}
+                    setYoloMusicCast={setYoloMusicCast}
                     yoloMusicKeyframeWorkflowId={yoloStoryboardWorkflowId}
                     setYoloMusicKeyframeWorkflowId={setYoloMusicKeyframeWorkflowId}
                     yoloMusicKeyframeWorkflowOptions={YOLO_MUSIC_KEYFRAME_WORKFLOW_OPTIONS}
@@ -10201,6 +10346,8 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                     handleYoloMusicCastSlugChange={handleYoloMusicCastSlugChange}
                     handleYoloMusicCastLabelChange={handleYoloMusicCastLabelChange}
                     handleYoloMusicCastRoleChange={handleYoloMusicCastRoleChange}
+                    queuePeopleWizardJob={queuePeopleWizardJob}
+                    canUsePeopleWizardGeneration={Boolean(BUILTIN_WORKFLOW_PATHS['z-image-turbo'] && BUILTIN_WORKFLOW_PATHS['multi-angles'])}
                     generationQueue={generationQueue}
                     yoloActivePlan={yoloActivePlan}
                     yoloQueueVariants={yoloQueueVariants}
@@ -10475,7 +10622,11 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                           </div>
                           {yoloMusicCast.length === 0 ? (
                             <div className="mt-1 rounded-lg border border-dashed border-sf-dark-600 bg-sf-dark-800/40 px-3 py-3 text-[11px] text-sf-text-muted">
-                              No cast yet. Click <span className="text-sf-text-secondary">+ Add cast member</span> to pick an image asset (a still of the singer / band member) and give them a short handle like <span className="font-mono text-sf-text-secondary">rose</span>. You can then reference them in your script with <span className="font-mono text-sf-text-secondary">Artist: rose</span> or in lyrics with <span className="font-mono text-sf-text-secondary">[Rose]</span> tag lines. Leave it empty for reference-free shots (the model will improvise the singer's look).
+                              No cast yet. Click <span className="text-sf-text-secondary">+ Add cast member</span> to pick
+                              an image asset (a still of the singer / band member) and give them a short handle like
+                              <span className="font-mono text-sf-text-secondary">rose</span>. You can then reference them in
+                              your script with <span className="font-mono text-sf-text-secondary">Artist: rose</span> or in
+                              lyrics with <span className="font-mono text-sf-text-secondary">[Rose]</span> tag lines.
                             </div>
                           ) : (
                             <div className="mt-1 space-y-1.5">
@@ -10548,7 +10699,14 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                           )}
                           <div className="mt-2 text-[10px] text-sf-text-muted">
                             <div>
-                              Reference cast in your script with <span className="font-mono text-sf-text-secondary">Artist: rose</span>, <span className="font-mono text-sf-text-secondary">Artist: jake</span>, or <span className="font-mono text-sf-text-secondary">Artist: both</span> (also <span className="font-mono">all</span> / <span className="font-mono">band</span>). In lyrics, drop a tag line above the verse: <span className="font-mono text-sf-text-secondary">[Rose]</span>, <span className="font-mono text-sf-text-secondary">[Jake]</span>, <span className="font-mono text-sf-text-secondary">[Rose, Jake]</span>. Section markers like <span className="font-mono">[Chorus]</span> and <span className="font-mono">[Verse 1]</span> are ignored.
+                              Reference cast in your script with <span className="font-mono text-sf-text-secondary">Artist: rose</span>,
+                              <span className="font-mono text-sf-text-secondary">Artist: jake</span>, or
+                              <span className="font-mono text-sf-text-secondary">Artist: both</span> (also
+                              <span className="font-mono">all</span> / <span className="font-mono">band</span>). In lyrics, drop a tag line above the verse:
+                              <span className="font-mono text-sf-text-secondary">[Rose]</span>,
+                              <span className="font-mono text-sf-text-secondary">[Jake]</span>, or
+                              <span className="font-mono text-sf-text-secondary">[Rose, Jake]</span>.
+                              Section markers like <span className="font-mono">[Chorus]</span> and <span className="font-mono">[Verse 1]</span> are ignored.
                             </div>
                           </div>
                         </div>

--- a/src/components/LeftPanel.jsx
+++ b/src/components/LeftPanel.jsx
@@ -7,7 +7,7 @@ import AssetsPanel from './panels/AssetsPanel'
 import TextPanel from './panels/TextPanel'
 import EffectsPanel from './panels/EffectsPanel'
 
-function LeftPanel({ isExpanded, onToggleExpanded, activeTab, onTabChange, isFullHeight = false, onToggleFullHeight, onSettingsClick }) {
+function LeftPanel({ isActive = true, isExpanded, onToggleExpanded, activeTab, onTabChange, isFullHeight = false, onToggleFullHeight, onSettingsClick }) {
   const tabs = [
     { id: 'assets', label: 'Assets', icon: FolderOpen },
     { id: 'text', label: 'Text', icon: Type },
@@ -40,9 +40,9 @@ function LeftPanel({ isExpanded, onToggleExpanded, activeTab, onTabChange, isFul
       case 'effects':
         return <EffectsPanel />
       case 'assets':
-        return <AssetsPanel />
+        return <AssetsPanel isActive={isActive} />
       default:
-        return <AssetsPanel />
+        return <AssetsPanel isActive={isActive} />
     }
   }
 

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -18,6 +18,7 @@ import useViewportClampedPosition from '../hooks/useViewportClampedPosition'
 import { getAllKeyframeTimes } from '../utils/keyframes'
 import { TRANSITION_TYPES, TRANSITION_DURATIONS, FRAME_RATE } from '../constants/transitions'
 import { getAudioClipFadeValues } from '../utils/audioClipFades'
+import { getSpriteFramePosition } from '../services/thumbnailSprites'
 import { getEffectTypeDefinition } from '../utils/effects'
 import { isTextEditingElement } from '../utils/keyboardFocus'
 import {
@@ -46,6 +47,8 @@ const MARQUEE_AUTO_SCROLL_STEP_PX = 24
 const PLAYHEAD_SCRUB_AUTO_SCROLL_EDGE_PX = 40
 const PLAYHEAD_SCRUB_AUTO_SCROLL_MAX_STEP_PX = 28
 const MIN_INTERACTIVE_CLIP_WIDTH_PX = 24
+const TIMELINE_VIDEO_THUMB_WIDTH_PX = 90
+const MAX_TIMELINE_VIDEO_THUMBNAILS = 12
 
 // Resolve-style audio track/waveform colors
 const AUDIO_TRACK_BG = '#2d4038'
@@ -1158,6 +1161,63 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
     }
     // Fallback to clip's stored URL
     return clip.url
+  }
+
+  const renderTimelineVideoFilmstrip = (clip, renderedClipWidth, thumbCount, contentHeight) => {
+    const asset = clip?.assetId ? assetsById.get(clip.assetId) : null
+    const sprite = asset?.sprite
+    const tileWidth = renderedClipWidth / Math.max(1, thumbCount)
+    const tileHeight = Math.max(1, contentHeight - 3)
+
+    if (sprite?.url && Array.isArray(sprite.frames) && sprite.frames.length > 0) {
+      const duration = Math.max(0, Number(clip?.duration) || 0)
+      const trimStart = Number(clip?.trimStart) || 0
+      const timeScale = clip?.sourceTimeScale || (clip?.timelineFps && clip?.sourceFps
+        ? clip.timelineFps / clip.sourceFps
+        : 1)
+      const spriteDuration = Math.max(0, Number(sprite.duration) || 0)
+
+      return Array.from({ length: thumbCount }).map((_, i) => {
+        const sampleRatio = thumbCount <= 1 ? 0.5 : i / Math.max(1, thumbCount - 1)
+        const clipTime = duration * sampleRatio
+        const sourceTime = Math.max(0, Math.min(spriteDuration || Infinity, trimStart + clipTime * timeScale))
+        const frame = getSpriteFramePosition(sprite, sourceTime) || sprite.frames[0]
+        if (!frame) return null
+
+        const scale = Math.max(tileWidth / Math.max(1, frame.width), tileHeight / Math.max(1, frame.height))
+        const scaledFrameWidth = frame.width * scale
+        const scaledFrameHeight = frame.height * scale
+        const x = -frame.x * scale + (tileWidth - scaledFrameWidth) / 2
+        const y = -frame.y * scale + (tileHeight - scaledFrameHeight) / 2
+
+        return (
+          <div
+            key={i}
+            className="flex-shrink-0 h-full relative overflow-hidden"
+            style={{ width: `${tileWidth}px` }}
+          >
+            <div
+              className="absolute inset-0 opacity-80 pointer-events-none"
+              style={{
+                backgroundImage: `url(${sprite.url})`,
+                backgroundRepeat: 'no-repeat',
+                backgroundSize: `${sprite.width * scale}px ${sprite.height * scale}px`,
+                backgroundPosition: `${x}px ${y}px`,
+              }}
+            />
+          </div>
+        )
+      })
+    }
+
+    return (
+      <div className="absolute inset-0 top-[3px] flex items-center overflow-hidden bg-[#162226]">
+        <div className="flex h-full w-full items-center gap-2 px-2 text-[9px] uppercase tracking-[0.16em] text-white/35">
+          <Video className="h-3 w-3 flex-shrink-0" />
+          <span className="truncate">Video</span>
+        </div>
+      </div>
+    )
   }
 
   const handleAddAdjustmentLayer = () => {
@@ -5019,7 +5079,7 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
                   const interactiveClipWidth = Math.max(MIN_INTERACTIVE_CLIP_WIDTH_PX, renderedClipWidth)
                   const interactiveClipOffset = Math.max(0, (interactiveClipWidth - renderedClipWidth) / 2)
                   // Calculate how many thumbnail frames to show (roughly one per 60px)
-                  const thumbCount = Math.max(1, Math.floor(renderedClipWidth / 60))
+                  const thumbCount = Math.max(1, Math.min(MAX_TIMELINE_VIDEO_THUMBNAILS, Math.ceil(renderedClipWidth / TIMELINE_VIDEO_THUMB_WIDTH_PX)))
                   const isTextClip = clip.type === 'text'
                   const isAdjustmentClip = clip.type === 'adjustment'
                   const clipEnabled = isClipEnabled(clip)
@@ -5302,27 +5362,10 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
                           }}
                         />
                         
-                        {/* Filmstrip thumbnails */}
-                        {clipMediaUrl && (
+                        {/* Filmstrip thumbnails: render cached sprite frames, never live video elements. */}
+                        {shouldRenderClipThumbnails && (
                           <div className="absolute inset-0 top-[3px] flex overflow-hidden">
-                            {Array.from({ length: thumbCount }).map((_, i) => (
-                              <div 
-                                key={i} 
-                                className="flex-shrink-0 h-full relative overflow-hidden"
-                                style={{ width: `${renderedClipWidth / thumbCount}px` }}
-                              >
-                                <video
-                                  src={clipMediaUrl}
-                                  className="absolute inset-0 w-full h-full object-cover opacity-80 pointer-events-none"
-                                  muted
-                                  style={{
-                                    // Offset each thumbnail to show different part of video
-                                    objectPosition: `${(i / Math.max(1, thumbCount - 1)) * 100}% center`
-                                  }}
-                                  onContextMenu={(e) => e.preventDefault()}
-                                />
-                              </div>
-                            ))}
+                            {renderTimelineVideoFilmstrip(clip, renderedClipWidth, thumbCount, contentHeight)}
                           </div>
                         )}
                         

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -1163,9 +1163,59 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
     return clip.url
   }
 
+  const getTimelineClipPosterUrl = (clip, asset) => {
+    const directPoster = asset?.posterUrl
+      || asset?.thumbnailUrl
+      || asset?.coverUrl
+      || asset?.settings?.posterUrl
+      || asset?.settings?.thumbnailUrl
+      || asset?.settings?.keyframeUrl
+    if (directPoster) return directPoster
+
+    const keyframeAssetId = asset?.settings?.keyframeAssetId
+      || asset?.settings?.inputAssetId
+      || asset?.yolo?.keyframeAssetId
+      || asset?.shortFilm?.keyframeAssetId
+      || clip?.metadata?.keyframeAssetId
+    if (keyframeAssetId) {
+      const posterAsset = assetsById.get(keyframeAssetId)
+      if (posterAsset?.type === 'image' && posterAsset?.url) return posterAsset.url
+    }
+
+    const variantKeys = new Set([
+      asset?.yolo?.variantKey,
+      asset?.yolo?.key,
+      clip?.metadata?.musicVideoAssembly?.variantKey,
+    ].filter(Boolean).map(String))
+    if (variantKeys.size > 0) {
+      const posterAsset = assets.find((candidate) => {
+        if (candidate?.type !== 'image' || !candidate?.url) return false
+        if (candidate?.yolo?.stage !== 'storyboard') return false
+        return [candidate?.yolo?.variantKey, candidate?.yolo?.key]
+          .filter(Boolean)
+          .some((key) => variantKeys.has(String(key)))
+      })
+      if (posterAsset?.url) return posterAsset.url
+    }
+
+    const shotId = asset?.shortFilm?.shotId || clip?.metadata?.shortFilm?.shotId
+    if (shotId) {
+      const posterAsset = assets.find((candidate) => (
+        candidate?.type === 'image'
+        && candidate?.url
+        && candidate?.shortFilm?.kind === 'shot-keyframe'
+        && String(candidate.shortFilm.shotId || '') === String(shotId)
+      ))
+      if (posterAsset?.url) return posterAsset.url
+    }
+
+    return null
+  }
+
   const renderTimelineVideoFilmstrip = (clip, renderedClipWidth, thumbCount, contentHeight) => {
     const asset = clip?.assetId ? assetsById.get(clip.assetId) : null
     const sprite = asset?.sprite
+    const posterUrl = getTimelineClipPosterUrl(clip, asset)
     const tileWidth = renderedClipWidth / Math.max(1, thumbCount)
     const tileHeight = Math.max(1, contentHeight - 3)
 
@@ -1208,6 +1258,21 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
           </div>
         )
       })
+    }
+
+    if (posterUrl) {
+      return (
+        <div className="absolute inset-0 top-[3px] overflow-hidden bg-[#162226]">
+          <img
+            src={posterUrl}
+            alt={asset?.name || clip?.name || 'Video keyframe'}
+            className="absolute inset-0 h-full w-full object-cover opacity-80 pointer-events-none"
+            draggable={false}
+            loading="lazy"
+            onContextMenu={(e) => e.preventDefault()}
+          />
+        </div>
+      )
     }
 
     return (

--- a/src/components/generate/MusicVideoEasyMode.jsx
+++ b/src/components/generate/MusicVideoEasyMode.jsx
@@ -250,6 +250,22 @@ function getAssetUrl(asset) {
   return asset?.url || asset?.thumbnailUrl || asset?.proxyUrl || asset?.path || ''
 }
 
+function ShotVideoPreview({ hasVideo, keyframeUrl, placeholderLabel = "Needs keyframe" }) {
+  if (keyframeUrl) {
+    return <img src={keyframeUrl} alt="" className="h-full w-full object-cover opacity-70" loading="lazy" decoding="async" />
+  }
+
+  if (hasVideo) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-sf-dark-800 text-sf-text-muted">
+        <Play className="h-5 w-5 opacity-70" />
+      </div>
+    )
+  }
+
+  return <span className="flex h-full w-full items-center justify-center text-[10px] text-sf-text-muted">{placeholderLabel}</span>
+}
+
 function getVideoWorkflowScopedKey(variantKey, workflowId) {
   const key = String(variantKey || '').trim()
   const workflow = String(workflowId || '').trim()
@@ -1813,13 +1829,7 @@ export default function MusicVideoEasyMode({
                         ? 'bg-red-950/30'
                         : 'bg-sf-dark-800'
                   }`}>
-                    {videoUrl ? (
-                      <video src={videoUrl} className="h-full w-full object-cover" muted playsInline preload="metadata" />
-                    ) : keyframeUrl ? (
-                      <img src={keyframeUrl} alt="" className="h-full w-full object-cover opacity-70" />
-                    ) : (
-                      <span className="text-[10px] text-sf-text-muted">Needs keyframe</span>
-                    )}
+                    <ShotVideoPreview hasVideo={Boolean(videoUrl)} keyframeUrl={keyframeUrl} />
                     {cardState.state === 'generating' && (
                       <div className="absolute inset-0 animate-pulse bg-gradient-to-r from-transparent via-white/10 to-transparent" />
                     )}

--- a/src/components/generate/MusicVideoEasyMode.jsx
+++ b/src/components/generate/MusicVideoEasyMode.jsx
@@ -1838,7 +1838,6 @@ export default function MusicVideoEasyMode({
           )}
           {(yoloMusicCast || []).map((entry, index) => {
             const entryAsset = imageAssets.find((asset) => asset?.id === entry?.assetId) || null
-            const entryAssetUrl = getAssetUrl(entryAsset)
             return (
               <div key={entry.id || index} className="grid gap-2 rounded-lg border border-sf-dark-700 bg-sf-dark-950/50 p-3 lg:grid-cols-[1fr_1fr_1fr_auto_auto]">
                 <div>
@@ -1863,21 +1862,8 @@ export default function MusicVideoEasyMode({
                 </div>
                 <div>
                   <FieldLabel>Reference</FieldLabel>
-                  <div className="mt-1 flex min-h-[44px] items-center gap-3 rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary">
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-sf-dark-600 bg-sf-dark-900">
-                      {entryAssetUrl ? (
-                        <img
-                          src={entryAssetUrl}
-                          alt={entryAsset?.name || entry?.label || 'Reference image'}
-                          className="h-full w-full object-cover"
-                        />
-                      ) : (
-                        <ImageIcon className="h-4 w-4 text-sf-text-muted" />
-                      )}
-                    </div>
-                    <div className="min-w-0 flex-1 truncate">
-                      {entryAsset?.name || 'No reference image'}
-                    </div>
+                  <div className="mt-1 rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary">
+                    {entryAsset?.name || 'No reference image'}
                   </div>
                 </div>
                 <div className="flex items-end gap-2">

--- a/src/components/generate/MusicVideoEasyMode.jsx
+++ b/src/components/generate/MusicVideoEasyMode.jsx
@@ -525,7 +525,7 @@ export default function MusicVideoEasyMode({
     setPeopleWizard({
       sessionId,
       mode: entry ? 'edit' : 'create',
-      step: entry?.assetId ? 'existing' : 'basic',
+      step: 'person',
       entryId: entry?.id || null,
       name: String(entry?.label || ''),
       slug: String(entry?.slug || ''),
@@ -1065,7 +1065,7 @@ export default function MusicVideoEasyMode({
   const handlePeopleWizardSelectAsset = (assetId) => {
     updatePeopleWizard({
       assetId: assetId || '',
-      step: 'existing',
+      step: 'image',
     })
   }
 
@@ -1139,7 +1139,7 @@ export default function MusicVideoEasyMode({
       ? peopleWizardSheetAsset?.id || ''
       : peopleWizard.step === 'image'
         ? peopleWizardGeneratedImageAsset?.id || ''
-        : peopleWizardSelectedAsset?.id || peopleWizardSheetAsset?.id || peopleWizardGeneratedImageAsset?.id || ''
+      : peopleWizardSelectedAsset?.id || peopleWizardSheetAsset?.id || peopleWizardGeneratedImageAsset?.id || ''
     if (!trimmedName || !normalizedSlug || !finalAssetId) return
     const nextEntry = {
       id: peopleWizard.entryId || `cast-${Date.now()}`,
@@ -1375,39 +1375,56 @@ export default function MusicVideoEasyMode({
   const renderPeopleWizardModal = () => {
     if (!peopleWizard) return null
 
-    const wizardStep = peopleWizard.step || 'basic'
+    const wizardStep = peopleWizard.step || 'person'
     const trimmedName = String(peopleWizard.name || '').trim()
     const normalizedSlug = normalizeCastSlug(String(peopleWizard.slug || '').trim())
     const selectedPreviewAsset = wizardStep === 'sheet'
-      ? peopleWizardSheetAsset || null
+      ? peopleWizardSheetAsset || peopleWizardGeneratedImageAsset || peopleWizardSelectedAsset || null
       : wizardStep === 'image'
         ? peopleWizardGeneratedImageAsset || peopleWizardSelectedAsset || null
         : peopleWizardSelectedAsset || null
     const peopleWizardSaveAssetId = wizardStep === 'sheet'
       ? peopleWizardSheetAsset?.id || ''
       : wizardStep === 'image'
-        ? peopleWizardGeneratedImageAsset?.id || ''
-        : peopleWizardSelectedAsset?.id || peopleWizardSheetAsset?.id || peopleWizardGeneratedImageAsset?.id || ''
+        ? peopleWizardGeneratedImageAsset?.id || peopleWizardSelectedAsset?.id || ''
+        : ''
+    const canContinueToImageStep = Boolean(trimmedName && normalizedSlug)
+    const canEnterSheetStep = Boolean(peopleWizardGeneratedImageAsset || peopleWizardSelectedAsset)
     const canSavePeopleWizard = Boolean(trimmedName && normalizedSlug && peopleWizardSaveAssetId && !peopleWizardActiveJob)
-    const previewTitle = selectedPreviewAsset?.name || (
-      wizardStep === 'sheet'
-        ? 'Waiting for character sheet'
-        : peopleWizard.name || 'No preview yet'
-    )
-    const previewEmptyText = wizardStep === 'sheet'
-      ? 'Character sheet preview will appear here after generation.'
-      : 'No preview available yet'
-    const wizardStepLabelMap = {
-      basic: 'Basic info',
-      existing: 'Existing image',
-      image: 'New image',
-      sheet: 'Character sheet',
-    }
-    const currentWizardStepLabel = wizardStepLabelMap[wizardStep] || 'Basic info'
-    const sheetBackStep = peopleWizardGeneratedImageAsset ? 'image' : 'existing'
-    const statusText = peopleWizardActiveJob
-      ? `${getWorkflowDisplayLabel(peopleWizardActiveJob.workflowId)} is ${peopleWizardActiveJob.status || 'running'}…`
+    const previewTitle = selectedPreviewAsset?.name || 'Preview'
+    const wizardStages = [
+      { id: 'person', label: '1', title: 'Person data', helper: 'Name, slug, and role.' },
+      { id: 'image', label: '2', title: 'Image', helper: 'Create or pick a portrait.', disabled: !canContinueToImageStep },
+      { id: 'sheet', label: '3', title: 'Character sheet', helper: 'Generate the full sheet.', disabled: !canEnterSheetStep },
+    ]
+    const previewJob = peopleWizardActiveJob
+      && (
+        peopleWizardActiveJob.workflowId === 'z-image-turbo'
+        || peopleWizardActiveJob.workflowId === 'multi-angles'
+      )
+      ? peopleWizardActiveJob
+      : null
+    const previewJobProgress = Math.min(100, Math.max(0, Number(previewJob?.progress) || 0))
+    const statusText = previewJob
+      ? `${getWorkflowDisplayLabel(previewJob.workflowId)} is ${previewJob.status || 'running'}...`
       : ''
+    const wizardPrimaryAction = wizardStep === 'person'
+      ? {
+          label: 'Continue to image step',
+          onClick: () => updatePeopleWizard({ step: 'image' }),
+          disabled: !canContinueToImageStep,
+        }
+      : wizardStep === 'image'
+        ? {
+            label: 'Continue to character sheet',
+            onClick: () => updatePeopleWizard({ step: 'sheet' }),
+            disabled: !canEnterSheetStep,
+          }
+        : {
+            label: peopleWizardActiveJob ? 'Generating…' : 'Save',
+            onClick: handlePeopleWizardSave,
+            disabled: !canSavePeopleWizard,
+          }
 
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center p-3">
@@ -1436,261 +1453,256 @@ export default function MusicVideoEasyMode({
 
           <div className="grid min-h-0 flex-1 overflow-hidden lg:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
             <div className="space-y-4 overflow-y-auto p-4">
-              <div className="inline-flex items-center rounded-full border border-sf-dark-700 bg-sf-dark-900/80 px-3 py-1 text-[10px] uppercase tracking-[0.14em] text-sf-text-secondary">
-                {currentWizardStepLabel}
-              </div>
-
-              <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4">
-                <div className="grid gap-3 md:grid-cols-3">
-                  <div>
-                    <FieldLabel>Name *</FieldLabel>
-                    <input
-                      type="text"
-                      value={peopleWizard.name}
-                      required
-                      onChange={(event) => handlePeopleWizardFieldChange('name', event.target.value)}
-                      className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                      placeholder="Ava"
-                    />
-                  </div>
-                  <div>
-                    <FieldLabel>Slug *</FieldLabel>
-                    <input
-                      type="text"
-                      value={peopleWizard.slug}
-                      required
-                      onChange={(event) => handlePeopleWizardFieldChange('slug', event.target.value)}
-                      className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 font-mono text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                      placeholder="ava"
-                    />
-                  </div>
-                  <div>
-                    <FieldLabel>Role</FieldLabel>
-                    <select
-                      value={peopleWizard.role}
-                      onChange={(event) => handlePeopleWizardFieldChange('role', event.target.value)}
-                      className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                    >
-                      {MUSIC_VIDEO_CAST_ROLE_OPTIONS.map((role) => (
-                        <option key={role.id} value={role.id}>{role.label}</option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-                <div className="mt-3 max-w-md">
-                  <FieldLabel>Asset Prefix</FieldLabel>
-                  <input
-                    type="text"
-                    value={peopleWizard.assetPrefix}
-                    onChange={(event) => handlePeopleWizardFieldChange('assetPrefix', normalizeCastSlug(event.target.value) || '')}
-                    className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 font-mono text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                    placeholder="ava_headshot"
-                  />
-                  <p className="mt-1 text-[10px] text-sf-text-muted">
-                    Used for the generated image and sheet file names.
-                  </p>
-                </div>
-                <div className="mt-3 text-[11px] text-sf-text-muted">
-                  Name and slug are required before you can save this person.
-                </div>
-                <div className="mt-4 text-xs text-sf-text-secondary">
-                  Pick a path to attach an image to this person.
-                </div>
-                <div className="mt-3 grid gap-3 md:grid-cols-2">
-                  <button
-                    type="button"
-                    onClick={() => updatePeopleWizard({ step: 'existing' })}
-                    className={`rounded-xl border p-4 text-left transition-colors ${
-                      peopleWizard.step === 'existing'
-                        ? 'border-sf-accent bg-sf-accent/10'
-                        : 'border-sf-dark-600 bg-sf-dark-950 hover:border-sf-dark-500'
-                    }`}
-                  >
-                    <div className="flex items-center gap-2 text-sm font-semibold text-sf-text-primary">
-                      <ImageIcon className="h-4 w-4 text-sf-accent" />
-                      Use existing image
-                    </div>
-                    <p className="mt-1 text-[11px] text-sf-text-muted">
-                      Pick an image already in the project and save immediately, or continue into a sheet.
-                    </p>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (!peopleWizardGenerationEnabled) return
-                      updatePeopleWizard({ step: 'image' })
-                    }}
-                    disabled={!peopleWizardGenerationEnabled}
-                    className={`rounded-xl border p-4 text-left transition-colors ${
-                      peopleWizard.step === 'image'
-                        ? 'border-sf-accent bg-sf-accent/10'
-                        : 'border-sf-dark-600 bg-sf-dark-950 hover:border-sf-dark-500'
-                    } ${!peopleWizardGenerationEnabled ? 'cursor-not-allowed opacity-50' : ''}`}
-                  >
-                    <div className="flex items-center gap-2 text-sm font-semibold text-sf-text-primary">
-                      <Wand2 className="h-4 w-4 text-sf-accent" />
-                      Create new image
-                    </div>
-                    <p className="mt-1 text-[11px] text-sf-text-muted">
-                      Generate a new portrait first, then optionally make a sheet from it.
-                    </p>
-                  </button>
+              <div className="rounded-2xl border border-sf-dark-700 bg-sf-dark-900/70 p-3">
+                <div className="grid gap-2 md:grid-cols-3">
+                  {wizardStages.map((stage, index) => {
+                    const active = wizardStep === stage.id
+                    const disabled = Boolean(stage.disabled)
+                    return (
+                      <button
+                        key={stage.id}
+                        type="button"
+                        onClick={() => {
+                          if (disabled) return
+                          updatePeopleWizard({ step: stage.id })
+                        }}
+                        disabled={disabled}
+                        className={`rounded-xl border px-3 py-3 text-left transition-all duration-300 ease-out ${
+                          active
+                            ? 'border-sf-accent bg-sf-accent/20 shadow-[0_0_0_1px_rgba(96,165,250,0.25)]'
+                            : disabled
+                              ? 'border-sf-dark-800 bg-black/70 text-sf-text-muted'
+                              : 'border-sf-accent/30 bg-sf-accent/8 text-sf-text-primary hover:-translate-y-0.5 hover:border-sf-accent/50 hover:bg-sf-accent/12'
+                        } ${disabled ? 'cursor-not-allowed' : ''}`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <div className={`flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-semibold ${
+                            active
+                              ? 'border-sf-accent bg-sf-accent text-white'
+                              : disabled
+                                ? 'border-sf-dark-700 bg-black/80 text-sf-text-muted'
+                                : 'border-sf-accent/40 bg-sf-accent/15 text-sf-text-primary'
+                          }`}>
+                            {index + 1}
+                          </div>
+                          <div className="min-w-0">
+                            <div className={`text-xs font-semibold ${disabled ? 'text-sf-text-muted' : 'text-sf-text-primary'}`}>{stage.title}</div>
+                            <div className={`text-[10px] ${disabled ? 'text-sf-text-muted/80' : 'text-sf-text-muted'}`}>{stage.helper}</div>
+                          </div>
+                        </div>
+                      </button>
+                    )
+                  })}
                 </div>
               </div>
 
-              {wizardStep === 'existing' && (
+              {wizardStep === 'person' && (
                 <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4 space-y-3">
-                  <div className="flex items-start justify-between gap-3">
+                  <div className="text-sm font-semibold text-sf-text-primary">1. Person data</div>
+                  <p className="text-xs text-sf-text-secondary">
+                    Start with the name, slug, and role. Then move to the image step to either create a portrait or select one you already have.
+                  </p>
+                  <div className="grid gap-3 md:grid-cols-3">
                     <div>
-                      <div className="text-sm font-semibold text-sf-text-primary">Existing image</div>
-                      <p className="mt-1 text-xs text-sf-text-secondary">
-                        Choose a project image and either save now or continue into character-sheet generation.
-                      </p>
+                      <FieldLabel>Name *</FieldLabel>
+                      <input
+                        type="text"
+                        value={peopleWizard.name}
+                        required
+                        onChange={(event) => handlePeopleWizardFieldChange('name', event.target.value)}
+                        className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                        placeholder="Ava"
+                      />
                     </div>
-                    <div className="text-[10px] text-sf-text-muted">
-                      {canUsePeopleWizardGeneration ? 'Sheet path enabled' : 'Sheet path unavailable'}
+                    <div>
+                      <FieldLabel>Slug *</FieldLabel>
+                      <input
+                        type="text"
+                        value={peopleWizard.slug}
+                        required
+                        onChange={(event) => handlePeopleWizardFieldChange('slug', event.target.value)}
+                        className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 font-mono text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                        placeholder="ava"
+                      />
+                    </div>
+                    <div>
+                      <FieldLabel>Role</FieldLabel>
+                      <select
+                        value={peopleWizard.role}
+                        onChange={(event) => handlePeopleWizardFieldChange('role', event.target.value)}
+                        className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                      >
+                        {MUSIC_VIDEO_CAST_ROLE_OPTIONS.map((role) => (
+                          <option key={role.id} value={role.id}>{role.label}</option>
+                        ))}
+                      </select>
                     </div>
                   </div>
-                  <select
-                    value={peopleWizard.assetId || ''}
-                    onChange={(event) => handlePeopleWizardSelectAsset(event.target.value || '')}
-                    className="w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                  >
-                    <option value="">Select image asset</option>
-                    {imageAssets.map((asset) => (
-                      <option key={asset.id} value={asset.id}>{asset.name || asset.id}</option>
-                    ))}
-                  </select>
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        if (!peopleWizardGenerationEnabled || !peopleWizardSelectedAsset) return
-                        updatePeopleWizard({ step: 'sheet' })
-                      }}
-                      disabled={!peopleWizardGenerationEnabled || !peopleWizardSelectedAsset}
-                      className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      Create character sheet
-                    </button>
+                  <div className="max-w-md">
+                    <FieldLabel>Asset Prefix</FieldLabel>
+                    <input
+                      type="text"
+                      value={peopleWizard.assetPrefix}
+                      onChange={(event) => handlePeopleWizardFieldChange('assetPrefix', normalizeCastSlug(event.target.value) || '')}
+                      className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 font-mono text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                      placeholder="ava_headshot"
+                    />
+                    <p className="mt-1 text-[10px] text-sf-text-muted">
+                      Used for the generated image and sheet file names.
+                    </p>
                   </div>
                 </div>
               )}
 
               {wizardStep === 'image' && (
-                <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4 space-y-3">
-                  <div>
-                    <div className="text-sm font-semibold text-sf-text-primary">New image</div>
-                    <p className="mt-1 text-xs text-sf-text-secondary">
-                      Generate a new character image before moving to the sheet step.
-                    </p>
-                  </div>
-                  <div>
-                    <FieldLabel>Prompt</FieldLabel>
-                    <textarea
-                      value={peopleWizard.imagePrompt}
-                      onChange={(event) => handlePeopleWizardFieldChange('imagePrompt', event.target.value)}
-                      rows={4}
-                      className="mt-1 w-full resize-y rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                      placeholder="Describe the character portrait."
-                    />
-                  </div>
-                  <div className="flex flex-col gap-3 md:flex-row md:items-end">
-                    <div className="flex-1">
-                      <FieldLabel>Image Size</FieldLabel>
-                      <div className="mt-2 inline-flex rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-1">
-                        {PEOPLE_WIZARD_IMAGE_SIZE_OPTIONS.map((option) => (
-                          <button
-                            key={option.id}
-                            type="button"
-                            onClick={() => handlePeopleWizardFieldChange('imageSize', option.id)}
-                            title={`${option.label} image size`}
-                            aria-label={`${option.label} image size`}
-                            className={`inline-flex h-10 min-w-[3.25rem] items-center justify-center rounded-lg border px-3 text-xs font-semibold transition-colors ${buttonClass(peopleWizard.imageSize === option.id)}`}
-                          >
-                            <span>{option.label}</span>
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                    <div className="flex-1">
-                      <FieldLabel>Orientation</FieldLabel>
-                      <div className="mt-2 inline-flex rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-1">
-                        {PEOPLE_WIZARD_IMAGE_ORIENTATION_OPTIONS.map((option) => (
-                          <button
-                            key={option.id}
-                            type="button"
-                            onClick={() => handlePeopleWizardFieldChange('imageOrientation', option.id)}
-                            title={`${option.label} orientation`}
-                            aria-label={`${option.label} orientation`}
-                            className={`inline-flex h-10 min-w-[5.75rem] items-center justify-center rounded-lg border px-3 text-xs font-semibold transition-colors ${buttonClass(peopleWizard.imageOrientation === option.id)}`}
-                          >
-                            <span>{option.label}</span>
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="rounded-lg border border-sf-dark-700 bg-sf-dark-950/60 p-3 text-[11px] text-sf-text-secondary">
-                    <span className="text-sf-text-muted">Canvas:</span> {formatResolutionLabel(resolvePeopleWizardImageResolution(peopleWizard.imageSize, peopleWizard.imageOrientation))}
-                  </div>
-                  <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+                <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4 space-y-4">
+                  <div className="flex items-start justify-between gap-3">
                     <div>
-                      <FieldLabel>Seed</FieldLabel>
-                      <input
-                        type="number"
-                        value={peopleWizard.imageSeed}
-                        onChange={(event) => handlePeopleWizardFieldChange('imageSeed', Number(event.target.value))}
-                        className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                      />
+                      <div className="text-sm font-semibold text-sf-text-primary">2. Image selection / creation</div>
+                      <p className="mt-1 text-xs text-sf-text-secondary">
+                        Choose an existing portrait or create a new one. Once an image is selected, you can continue to the sheet step.
+                      </p>
                     </div>
-                    <div className="flex items-end">
-                      <button
-                        type="button"
-                        onClick={() => handlePeopleWizardFieldChange('imageSeed', Math.floor(Math.random() * 1000000000))}
-                        className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                    <div className="text-[10px] text-sf-text-muted">
+                      {canUsePeopleWizardGeneration ? 'Portrait generation enabled' : 'Portrait generation unavailable'}
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                    <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-3 space-y-3">
+                      <div className="flex items-center gap-2 text-sm font-semibold text-sf-text-primary">
+                        <ImageIcon className="h-4 w-4 text-sf-accent" />
+                        Select existing image
+                      </div>
+                      <select
+                        value={peopleWizard.assetId || ''}
+                        onChange={(event) => handlePeopleWizardSelectAsset(event.target.value || '')}
+                        className="w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
                       >
-                        Randomize
-                      </button>
+                        <option value="">Select image asset</option>
+                        {imageAssets.map((asset) => (
+                          <option key={asset.id} value={asset.id}>{asset.name || asset.id}</option>
+                        ))}
+                      </select>
+                      <div className="text-[11px] text-sf-text-muted">
+                        {peopleWizardSelectedAsset ? `Selected: ${peopleWizardSelectedAsset.name || peopleWizardSelectedAsset.id}` : 'Pick a portrait from the project.'}
+                      </div>
+                    </div>
+
+                    <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-3 space-y-3">
+                      <div className="flex items-center gap-2 text-sm font-semibold text-sf-text-primary">
+                        <Wand2 className="h-4 w-4 text-sf-accent" />
+                        Create new image
+                      </div>
+                      <div>
+                        <FieldLabel>Prompt</FieldLabel>
+                        <textarea
+                          value={peopleWizard.imagePrompt}
+                          onChange={(event) => handlePeopleWizardFieldChange('imagePrompt', event.target.value)}
+                          rows={4}
+                          className="mt-1 w-full resize-y rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                          placeholder="Describe the character portrait."
+                        />
+                      </div>
+                      <div className="grid gap-3 md:grid-cols-2">
+                        <div>
+                          <FieldLabel>Image Size</FieldLabel>
+                          <div className="mt-2 inline-flex rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-1">
+                            {PEOPLE_WIZARD_IMAGE_SIZE_OPTIONS.map((option) => (
+                              <button
+                                key={option.id}
+                                type="button"
+                                onClick={() => handlePeopleWizardFieldChange('imageSize', option.id)}
+                                title={`${option.label} image size`}
+                                aria-label={`${option.label} image size`}
+                                className={`inline-flex h-10 min-w-[3.25rem] items-center justify-center rounded-lg border px-3 text-xs font-semibold transition-colors ${buttonClass(peopleWizard.imageSize === option.id)}`}
+                              >
+                                <span>{option.label}</span>
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                        <div>
+                          <FieldLabel>Orientation</FieldLabel>
+                          <div className="mt-2 inline-flex rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-1">
+                            {PEOPLE_WIZARD_IMAGE_ORIENTATION_OPTIONS.map((option) => (
+                              <button
+                                key={option.id}
+                                type="button"
+                                onClick={() => handlePeopleWizardFieldChange('imageOrientation', option.id)}
+                                title={`${option.label} orientation`}
+                                aria-label={`${option.label} orientation`}
+                                className={`inline-flex h-10 w-10 items-center justify-center rounded-lg border text-xs font-semibold transition-all duration-300 ease-out ${buttonClass(peopleWizard.imageOrientation === option.id)}`}
+                              >
+                                <span
+                                  className={`flex items-center justify-center rounded-sm border ${
+                                    option.id === 'portrait'
+                                      ? 'h-5 w-4'
+                                      : 'h-4 w-6'
+                                  } ${
+                                    peopleWizard.imageOrientation === option.id
+                                      ? 'border-white/80 bg-white/15'
+                                      : 'border-current/60 bg-current/10'
+                                  }`}
+                                  aria-hidden="true"
+                                />
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="rounded-lg border border-sf-dark-700 bg-sf-dark-950/60 p-3 text-[11px] text-sf-text-secondary">
+                        <span className="text-sf-text-muted">Canvas:</span> {formatResolutionLabel(resolvePeopleWizardImageResolution(peopleWizard.imageSize, peopleWizard.imageOrientation))}
+                      </div>
+                      <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+                        <div>
+                          <FieldLabel>Seed</FieldLabel>
+                          <input
+                            type="number"
+                            value={peopleWizard.imageSeed}
+                            onChange={(event) => handlePeopleWizardFieldChange('imageSeed', Number(event.target.value))}
+                            className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                          />
+                        </div>
+                        <div className="flex items-end">
+                          <button
+                            type="button"
+                            onClick={() => handlePeopleWizardFieldChange('imageSeed', Math.floor(Math.random() * 1000000000))}
+                            className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                          >
+                            Randomize
+                          </button>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => updatePeopleWizard({ step: 'person' })}
+                          className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                        >
+                          Back
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handlePeopleWizardCreateImage}
+                          disabled={!peopleWizardGenerationEnabled || Boolean(peopleWizardActiveJob)}
+                          className="rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {peopleWizardActiveJob && peopleWizardActiveJob.workflowId === 'z-image-turbo' ? 'Generating…' : 'Generate image'}
+                        </button>
+                      </div>
                     </div>
                   </div>
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      onClick={() => updatePeopleWizard({ step: 'basic' })}
-                      className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
-                    >
-                      Back
-                    </button>
-                    <button
-                      type="button"
-                      onClick={handlePeopleWizardCreateImage}
-                      disabled={!peopleWizardGenerationEnabled || Boolean(peopleWizardActiveJob)}
-                      className="rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {peopleWizardActiveJob ? 'Generating…' : 'Generate'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        if (!peopleWizardGeneratedImageAsset) return
-                        updatePeopleWizard({ step: 'sheet' })
-                      }}
-                      disabled={!peopleWizardGeneratedImageAsset}
-                      className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      Next
-                    </button>
-                  </div>
+
                 </div>
               )}
 
               {wizardStep === 'sheet' && (
                 <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4 space-y-3">
                   <div>
-                    <div className="text-sm font-semibold text-sf-text-primary">Character sheet</div>
+                    <div className="text-sm font-semibold text-sf-text-primary">3. Character sheet creation</div>
                     <p className="mt-1 text-xs text-sf-text-secondary">
-                      Use the previous image as the reference, then turn it into a multi-angle character sheet.
+                      Use the selected or generated image as the reference, then turn it into a multi-angle character sheet.
                     </p>
                   </div>
                   <div className="rounded-lg border border-sf-dark-700 bg-sf-dark-950/60 p-3 text-xs text-sf-text-secondary">
@@ -1720,18 +1732,11 @@ export default function MusicVideoEasyMode({
                   <div className="flex flex-wrap gap-2">
                     <button
                       type="button"
-                      onClick={() => updatePeopleWizard({ step: sheetBackStep })}
-                      className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
-                    >
-                      Back
-                    </button>
-                    <button
-                      type="button"
                       onClick={handlePeopleWizardCreateSheet}
-                      disabled={!peopleWizardGenerationEnabled || Boolean(peopleWizardActiveJob) || !(peopleWizardGeneratedImageAsset || peopleWizardSelectedAsset || peopleWizard.assetId)}
+                      disabled={!peopleWizardGenerationEnabled || Boolean(peopleWizardActiveJob) || !canEnterSheetStep}
                       className="rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
                     >
-                      {peopleWizardActiveJob ? 'Generating…' : 'Generate'}
+                      {peopleWizardActiveJob && peopleWizardActiveJob.workflowId === 'multi-angles' ? 'Generating…' : 'Generate sheet'}
                     </button>
                   </div>
                 </div>
@@ -1747,11 +1752,6 @@ export default function MusicVideoEasyMode({
                       {previewTitle}
                     </div>
                   </div>
-                  {statusText && (
-                    <span className="rounded-full border border-sf-dark-600 bg-sf-dark-900 px-2 py-1 text-[10px] text-sf-text-muted">
-                      {statusText}
-                    </span>
-                  )}
                 </div>
                 <div className="mt-3 aspect-[4/5] overflow-hidden rounded-lg border border-sf-dark-700 bg-sf-dark-950">
                   {selectedPreviewAsset?.url ? (
@@ -1760,13 +1760,22 @@ export default function MusicVideoEasyMode({
                       alt={selectedPreviewAsset.name || 'People wizard preview'}
                       className="h-full w-full object-contain"
                     />
-                  ) : (
-                    <div className="flex h-full flex-col items-center justify-center gap-2 text-xs text-sf-text-muted">
-                      <ImageIcon className="h-8 w-8 opacity-60" />
-                      <span>{previewEmptyText}</span>
-                    </div>
-                  )}
+                  ) : null}
                 </div>
+                {statusText && (
+                  <div className="mt-3 rounded-lg border border-sf-dark-700 bg-sf-dark-900/80 p-3">
+                    <div className="flex items-center justify-between gap-3 text-[11px] text-sf-text-secondary">
+                      <span>{statusText}</span>
+                      <span className="font-mono text-sf-text-muted">{Math.round(previewJobProgress)}%</span>
+                    </div>
+                    <div className="mt-2 h-2 overflow-hidden rounded-full bg-sf-dark-800">
+                      <div
+                        className="h-full rounded-full bg-sf-accent transition-all duration-300 ease-out"
+                        style={{ width: `${previewJobProgress}%` }}
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
 
               <div className="mt-3 space-y-2 rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-3 text-xs text-sf-text-secondary">
@@ -1778,26 +1787,32 @@ export default function MusicVideoEasyMode({
               </div>
             </div>
           </div>
-          <div className="flex items-center justify-between gap-3 border-t border-sf-dark-700 bg-sf-dark-950 px-4 py-3">
-            <div className="text-[11px] text-sf-text-muted">
-              Save is available when name, slug, and a final image or sheet are ready.
-            </div>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={closePeopleWizard}
-                className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handlePeopleWizardSave}
-                disabled={!canSavePeopleWizard}
-                className="rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Save
-              </button>
+          <div className="border-t border-sf-dark-700 bg-sf-dark-950 px-4 py-3">
+            <div className="flex items-center justify-between gap-3">
+              <div />
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={closePeopleWizard}
+                  className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={wizardPrimaryAction.onClick}
+                  disabled={wizardPrimaryAction.disabled}
+                  className={`rounded-lg px-3 py-2 text-xs font-semibold text-white transition-all duration-300 ease-out ${
+                    wizardStep === 'sheet'
+                      ? 'bg-sf-accent hover:bg-sf-accent/90 disabled:opacity-50'
+                      : wizardPrimaryAction.disabled
+                        ? 'cursor-not-allowed border border-sf-dark-800 bg-black/70 text-sf-text-muted'
+                        : 'bg-sf-accent/90 hover:bg-sf-accent'
+                  }`}
+                >
+                  {wizardPrimaryAction.label}
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/generate/MusicVideoEasyMode.jsx
+++ b/src/components/generate/MusicVideoEasyMode.jsx
@@ -2,8 +2,10 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   CheckCircle2,
   Clipboard,
+  Edit3,
   FileText,
   Film,
+  Image as ImageIcon,
   Loader2,
   Maximize2,
   Music,
@@ -19,7 +21,12 @@ import {
   MUSIC_VIDEO_SHOT_WORKFLOW_ID,
   getMusicVideoAudioKindOption,
   getMusicVideoShotTypeOption,
+  normalizeCastSlug,
 } from '../../config/musicVideoShotConfig'
+import {
+  getWorkflowDisplayLabel,
+} from '../../config/generateWorkspaceConfig'
+import { BUILTIN_WORKFLOW_PATHS } from '../../config/workflowRegistry'
 
 const DRAFT_STORAGE_KEY = 'comfystudio-music-video-easy-mode-draft-v1'
 
@@ -40,6 +47,16 @@ const ASPECT_RATIO_OPTIONS = [
 const RESOLUTION_OPTIONS = [
   { id: '720p', label: '720p' },
   { id: '1080p', label: '1080p' },
+]
+
+const PEOPLE_WIZARD_IMAGE_SIZE_OPTIONS = [
+  { id: 'hd', label: 'HD', resolution: { width: 720, height: 1280 }, landscapeResolution: { width: 1280, height: 720 } },
+  { id: 'fhd', label: 'FHD', resolution: { width: 1080, height: 1920 }, landscapeResolution: { width: 1920, height: 1080 } },
+]
+
+const PEOPLE_WIZARD_IMAGE_ORIENTATION_OPTIONS = [
+  { id: 'portrait', label: 'Portrait' },
+  { id: 'landscape', label: 'Landscape' },
 ]
 
 const FPS_OPTIONS = [24, 25, 30]
@@ -229,6 +246,13 @@ function resolveOutputResolution(aspectRatio, resolutionPreset) {
   return is1080 ? { width: 1920, height: 1080 } : { width: 1280, height: 720 }
 }
 
+function resolvePeopleWizardImageResolution(sizeId, orientationId) {
+  const size = PEOPLE_WIZARD_IMAGE_SIZE_OPTIONS.find((option) => option.id === String(sizeId || '').trim())
+    || PEOPLE_WIZARD_IMAGE_SIZE_OPTIONS[0]
+  const isLandscape = String(orientationId || '').trim() === 'landscape'
+  return isLandscape ? size.landscapeResolution : size.resolution
+}
+
 function workflowSupports1080Resolution(workflowId) {
   return String(workflowId || '').trim() === MUSIC_VIDEO_SHOT_WORKFLOW_ID
 }
@@ -264,6 +288,18 @@ function ShotVideoPreview({ hasVideo, keyframeUrl, placeholderLabel = "Needs key
   }
 
   return <span className="flex h-full w-full items-center justify-center text-[10px] text-sf-text-muted">{placeholderLabel}</span>
+}
+
+function inferPeopleWizardAssetPrefix(asset, fallbackValue = '') {
+  const metadataPrefix = normalizeCastSlug(asset?.peopleWizard?.assetPrefix || '')
+  if (metadataPrefix) return metadataPrefix
+  const rawName = String(asset?.name || '').trim()
+  if (!rawName) return normalizeCastSlug(fallbackValue || '')
+  const baseName = rawName
+    .replace(/\.[a-z0-9]{1,8}$/i, '')
+    .replace(/_I\d+$/i, '')
+    .replace(/_(image|sheet)$/i, '')
+  return normalizeCastSlug(baseName || fallbackValue || '')
 }
 
 function getVideoWorkflowScopedKey(variantKey, workflowId) {
@@ -382,12 +418,15 @@ export default function MusicVideoEasyMode({
   setYoloMusicScript,
   yoloMusicCast,
   yoloMusicResolvedCast,
+  setYoloMusicCast,
   handleYoloMusicCastAdd,
   handleYoloMusicCastRemove,
   handleYoloMusicCastAssetChange,
   handleYoloMusicCastSlugChange,
   handleYoloMusicCastLabelChange,
   handleYoloMusicCastRoleChange,
+  queuePeopleWizardJob,
+  canUsePeopleWizardGeneration = false,
   yoloMusicKeyframeWorkflowId = 'nano-banana-2',
   setYoloMusicKeyframeWorkflowId,
   yoloMusicKeyframeWorkflowOptions = DEFAULT_KEYFRAME_WORKFLOW_OPTIONS,
@@ -435,6 +474,9 @@ export default function MusicVideoEasyMode({
   const [isQueuingVideos, setIsQueuingVideos] = useState(false)
   const [isAssemblingTimeline, setIsAssemblingTimeline] = useState(false)
   const [mediaPreview, setMediaPreview] = useState(null)
+  const [peopleWizard, setPeopleWizard] = useState(null)
+
+  const peopleWizardGenerationEnabled = Boolean(canUsePeopleWizardGeneration && BUILTIN_WORKFLOW_PATHS['z-image-turbo'] && BUILTIN_WORKFLOW_PATHS['multi-angles'])
 
   useEffect(() => {
     if (typeof localStorage === 'undefined') return
@@ -470,6 +512,38 @@ export default function MusicVideoEasyMode({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [mediaPreview])
 
+  const closePeopleWizard = () => setPeopleWizard(null)
+  const handlePeopleWizardBackdropClick = (event) => {
+    if (event.target !== event.currentTarget) return
+    if (!peopleWizard) return
+    const confirmed = window.confirm('Discard this wizard draft and close the people dialog?')
+    if (confirmed) closePeopleWizard()
+  }
+  const openPeopleWizard = (entry = null) => {
+    const sessionId = `people-wizard-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+    const entryAsset = entry?.assetId ? assets.find((asset) => asset?.id === entry.assetId) || null : null
+    setPeopleWizard({
+      sessionId,
+      mode: entry ? 'edit' : 'create',
+      step: entry?.assetId ? 'existing' : 'basic',
+      entryId: entry?.id || null,
+      name: String(entry?.label || ''),
+      slug: String(entry?.slug || ''),
+      role: String(entry?.role || 'lead'),
+      assetPrefix: normalizeCastSlug(entry?.slug || entry?.label || entry?.assetId || 'person') || 'person',
+      assetId: entry?.assetId || '',
+      imagePrompt: String(entryAsset?.name || entry?.label || 'Portrait of a character').trim() || 'Portrait of a character',
+      imageSize: 'hd',
+      imageOrientation: 'portrait',
+      imageSeed: Math.floor(Math.random() * 1000000000),
+      imageJobId: null,
+      sheetJobId: null,
+      sheetSeed: Math.floor(Math.random() * 1000000000),
+      imageWorkflow: 'z-image-turbo',
+      sheetWorkflow: 'multi-angles',
+    })
+  }
+
   useEffect(() => {
     if (audioDefaultMigratedRef.current) return
     audioDefaultMigratedRef.current = true
@@ -482,6 +556,32 @@ export default function MusicVideoEasyMode({
     () => assets.filter((asset) => asset?.type === 'image'),
     [assets]
   )
+  const peopleWizardSelectedAsset = useMemo(() => {
+    if (!peopleWizard?.assetId) return null
+    return imageAssets.find((asset) => asset?.id === peopleWizard.assetId) || null
+  }, [imageAssets, peopleWizard?.assetId])
+  const peopleWizardGeneratedImageAsset = useMemo(() => {
+    if (!peopleWizard?.sessionId) return null
+    const matches = imageAssets.filter((asset) => asset?.peopleWizard?.wizardId === peopleWizard.sessionId && asset?.peopleWizard?.stage === 'image')
+    return matches[0] || null
+  }, [imageAssets, peopleWizard?.sessionId])
+  const peopleWizardSheetAsset = useMemo(() => {
+    if (!peopleWizard?.sessionId) return null
+    const matches = imageAssets.filter((asset) => asset?.peopleWizard?.wizardId === peopleWizard.sessionId && asset?.peopleWizard?.stage === 'sheet')
+    return matches[0] || null
+  }, [imageAssets, peopleWizard?.sessionId])
+  const peopleWizardActiveJob = useMemo(() => {
+    if (!peopleWizard?.sessionId) return null
+    const busyJobs = generationQueue.filter((job) => (
+      job?.peopleWizard?.wizardId === peopleWizard.sessionId
+      && job.status !== 'done'
+      && job.status !== 'error'
+      && job.status !== 'failed'
+      && job.status !== 'cancelled'
+      && job.status !== 'canceled'
+    ))
+    return busyJobs[busyJobs.length - 1] || null
+  }, [generationQueue, peopleWizard?.sessionId])
   const flatShots = useMemo(() => flattenPlanShots(yoloActivePlan), [yoloActivePlan])
   const variantByShotKey = useMemo(() => {
     const map = new Map()
@@ -946,6 +1046,121 @@ export default function MusicVideoEasyMode({
     }
   }
 
+  const updatePeopleWizard = (updater) => {
+    setPeopleWizard((prev) => {
+      if (!prev) return prev
+      const next = typeof updater === 'function' ? updater(prev) : { ...prev, ...updater }
+      return next
+    })
+  }
+
+  const handleOpenPeopleWizard = (entry = null) => {
+    openPeopleWizard(entry)
+  }
+
+  const handlePeopleWizardFieldChange = (field, value) => {
+    updatePeopleWizard({ [field]: value })
+  }
+
+  const handlePeopleWizardSelectAsset = (assetId) => {
+    updatePeopleWizard({
+      assetId: assetId || '',
+      step: 'existing',
+    })
+  }
+
+  const handlePeopleWizardCreateImage = () => {
+    if (!peopleWizardGenerationEnabled) return
+    if (!queuePeopleWizardJob) return
+    const prompt = String(peopleWizard?.imagePrompt || '').trim() || `${peopleWizard?.name || 'Character'} portrait`
+    const resolution = resolvePeopleWizardImageResolution(peopleWizard?.imageSize, peopleWizard?.imageOrientation)
+    const job = queuePeopleWizardJob({
+      workflowId: 'z-image-turbo',
+      workflowLabel: 'Z Image Turbo',
+      prompt,
+      seed: peopleWizard?.imageSeed,
+      resolution,
+      needsImage: false,
+      peopleWizard: {
+        wizardId: peopleWizard?.sessionId,
+        stage: 'image',
+        entryId: peopleWizard?.entryId || null,
+        mode: peopleWizard?.mode || 'create',
+        assetPrefix: normalizeCastSlug(peopleWizard?.assetPrefix || peopleWizard?.slug || peopleWizard?.name || 'person') || 'person',
+        imageSize: peopleWizard?.imageSize || 'hd',
+        imageOrientation: peopleWizard?.imageOrientation || 'portrait',
+      },
+    })
+    updatePeopleWizard({
+      step: 'image',
+      imageJobId: job.id,
+    })
+  }
+
+  const handlePeopleWizardCreateSheet = () => {
+    if (!peopleWizardGenerationEnabled) return
+    if (!queuePeopleWizardJob) return
+    const baseAsset = peopleWizardGeneratedImageAsset || peopleWizardSelectedAsset || null
+    const baseAssetId = baseAsset?.id || peopleWizard?.assetId || ''
+    if (!baseAssetId) return
+    const prompt = `${peopleWizard?.name || 'Character'} character sheet with front, side, 3/4, expressions, and wardrobe consistency.`
+    const inheritedAssetPrefix = inferPeopleWizardAssetPrefix(
+      baseAsset,
+      peopleWizard?.assetPrefix || peopleWizard?.slug || peopleWizard?.name || 'person'
+    ) || 'person'
+    const job = queuePeopleWizardJob({
+      workflowId: 'multi-angles',
+      workflowLabel: 'Multiple Angles (Characters)',
+      prompt,
+      seed: peopleWizard?.sheetSeed,
+      needsImage: true,
+      inputAssetId: baseAssetId,
+      peopleWizard: {
+        wizardId: peopleWizard?.sessionId,
+        stage: 'sheet',
+        entryId: peopleWizard?.entryId || null,
+        mode: peopleWizard?.mode || 'create',
+        baseAssetId,
+        autoCreateAngleSheet: true,
+        assetPrefix: inheritedAssetPrefix,
+      },
+    })
+    updatePeopleWizard({
+      step: 'sheet',
+      sheetJobId: job.id,
+    })
+  }
+
+  const handlePeopleWizardSave = () => {
+    if (!peopleWizard) return
+    const trimmedName = String(peopleWizard.name || '').trim()
+    const normalizedSlug = normalizeCastSlug(String(peopleWizard.slug || '').trim())
+    const finalAssetId = peopleWizard.step === 'sheet'
+      ? peopleWizardSheetAsset?.id || ''
+      : peopleWizard.step === 'image'
+        ? peopleWizardGeneratedImageAsset?.id || ''
+        : peopleWizardSelectedAsset?.id || peopleWizardSheetAsset?.id || peopleWizardGeneratedImageAsset?.id || ''
+    if (!trimmedName || !normalizedSlug || !finalAssetId) return
+    const nextEntry = {
+      id: peopleWizard.entryId || `cast-${Date.now()}`,
+      label: trimmedName,
+      slug: normalizedSlug,
+      assetId: finalAssetId,
+      role: String(peopleWizard.role || 'lead'),
+    }
+    setYoloMusicCast((prev) => {
+      const list = Array.isArray(prev) ? [...prev] : []
+      const index = list.findIndex((entry) => entry?.id === nextEntry.id)
+      if (index >= 0) {
+        list[index] = nextEntry
+      } else {
+        list.push(nextEntry)
+      }
+      return list
+    })
+    closePeopleWizard()
+  }
+
   const renderStepHeader = (title, helper) => (
     <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
       <div>
@@ -1157,6 +1372,439 @@ export default function MusicVideoEasyMode({
     </div>
   )
 
+  const renderPeopleWizardModal = () => {
+    if (!peopleWizard) return null
+
+    const wizardStep = peopleWizard.step || 'basic'
+    const trimmedName = String(peopleWizard.name || '').trim()
+    const normalizedSlug = normalizeCastSlug(String(peopleWizard.slug || '').trim())
+    const selectedPreviewAsset = wizardStep === 'sheet'
+      ? peopleWizardSheetAsset || null
+      : wizardStep === 'image'
+        ? peopleWizardGeneratedImageAsset || peopleWizardSelectedAsset || null
+        : peopleWizardSelectedAsset || null
+    const peopleWizardSaveAssetId = wizardStep === 'sheet'
+      ? peopleWizardSheetAsset?.id || ''
+      : wizardStep === 'image'
+        ? peopleWizardGeneratedImageAsset?.id || ''
+        : peopleWizardSelectedAsset?.id || peopleWizardSheetAsset?.id || peopleWizardGeneratedImageAsset?.id || ''
+    const canSavePeopleWizard = Boolean(trimmedName && normalizedSlug && peopleWizardSaveAssetId && !peopleWizardActiveJob)
+    const previewTitle = selectedPreviewAsset?.name || (
+      wizardStep === 'sheet'
+        ? 'Waiting for character sheet'
+        : peopleWizard.name || 'No preview yet'
+    )
+    const previewEmptyText = wizardStep === 'sheet'
+      ? 'Character sheet preview will appear here after generation.'
+      : 'No preview available yet'
+    const wizardStepLabelMap = {
+      basic: 'Basic info',
+      existing: 'Existing image',
+      image: 'New image',
+      sheet: 'Character sheet',
+    }
+    const currentWizardStepLabel = wizardStepLabelMap[wizardStep] || 'Basic info'
+    const sheetBackStep = peopleWizardGeneratedImageAsset ? 'image' : 'existing'
+    const statusText = peopleWizardActiveJob
+      ? `${getWorkflowDisplayLabel(peopleWizardActiveJob.workflowId)} is ${peopleWizardActiveJob.status || 'running'}…`
+      : ''
+
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-3">
+        <button
+          type="button"
+          aria-label="Close people wizard overlay"
+          className="absolute inset-0 bg-black/70"
+          onClick={handlePeopleWizardBackdropClick}
+        />
+        <div className="relative z-10 flex max-h-[calc(100vh-6rem)] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-sf-dark-700 bg-sf-dark-950 shadow-2xl">
+          <div className="flex items-center justify-between gap-3 border-b border-sf-dark-700 px-4 py-3">
+            <div>
+              <div className="text-[10px] uppercase tracking-[0.14em] text-sf-accent">People Wizard</div>
+              <h3 className="text-base font-semibold text-sf-text-primary">
+                {peopleWizard.mode === 'edit' ? 'Edit person' : 'Add person'}
+              </h3>
+            </div>
+            <button
+              type="button"
+              onClick={closePeopleWizard}
+              className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+            >
+              Close
+            </button>
+          </div>
+
+          <div className="grid min-h-0 flex-1 overflow-hidden lg:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
+            <div className="space-y-4 overflow-y-auto p-4">
+              <div className="inline-flex items-center rounded-full border border-sf-dark-700 bg-sf-dark-900/80 px-3 py-1 text-[10px] uppercase tracking-[0.14em] text-sf-text-secondary">
+                {currentWizardStepLabel}
+              </div>
+
+              <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4">
+                <div className="grid gap-3 md:grid-cols-3">
+                  <div>
+                    <FieldLabel>Name *</FieldLabel>
+                    <input
+                      type="text"
+                      value={peopleWizard.name}
+                      required
+                      onChange={(event) => handlePeopleWizardFieldChange('name', event.target.value)}
+                      className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                      placeholder="Ava"
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel>Slug *</FieldLabel>
+                    <input
+                      type="text"
+                      value={peopleWizard.slug}
+                      required
+                      onChange={(event) => handlePeopleWizardFieldChange('slug', event.target.value)}
+                      className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 font-mono text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                      placeholder="ava"
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel>Role</FieldLabel>
+                    <select
+                      value={peopleWizard.role}
+                      onChange={(event) => handlePeopleWizardFieldChange('role', event.target.value)}
+                      className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                    >
+                      {MUSIC_VIDEO_CAST_ROLE_OPTIONS.map((role) => (
+                        <option key={role.id} value={role.id}>{role.label}</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+                <div className="mt-3 max-w-md">
+                  <FieldLabel>Asset Prefix</FieldLabel>
+                  <input
+                    type="text"
+                    value={peopleWizard.assetPrefix}
+                    onChange={(event) => handlePeopleWizardFieldChange('assetPrefix', normalizeCastSlug(event.target.value) || '')}
+                    className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 font-mono text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                    placeholder="ava_headshot"
+                  />
+                  <p className="mt-1 text-[10px] text-sf-text-muted">
+                    Used for the generated image and sheet file names.
+                  </p>
+                </div>
+                <div className="mt-3 text-[11px] text-sf-text-muted">
+                  Name and slug are required before you can save this person.
+                </div>
+                <div className="mt-4 text-xs text-sf-text-secondary">
+                  Pick a path to attach an image to this person.
+                </div>
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  <button
+                    type="button"
+                    onClick={() => updatePeopleWizard({ step: 'existing' })}
+                    className={`rounded-xl border p-4 text-left transition-colors ${
+                      peopleWizard.step === 'existing'
+                        ? 'border-sf-accent bg-sf-accent/10'
+                        : 'border-sf-dark-600 bg-sf-dark-950 hover:border-sf-dark-500'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 text-sm font-semibold text-sf-text-primary">
+                      <ImageIcon className="h-4 w-4 text-sf-accent" />
+                      Use existing image
+                    </div>
+                    <p className="mt-1 text-[11px] text-sf-text-muted">
+                      Pick an image already in the project and save immediately, or continue into a sheet.
+                    </p>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (!peopleWizardGenerationEnabled) return
+                      updatePeopleWizard({ step: 'image' })
+                    }}
+                    disabled={!peopleWizardGenerationEnabled}
+                    className={`rounded-xl border p-4 text-left transition-colors ${
+                      peopleWizard.step === 'image'
+                        ? 'border-sf-accent bg-sf-accent/10'
+                        : 'border-sf-dark-600 bg-sf-dark-950 hover:border-sf-dark-500'
+                    } ${!peopleWizardGenerationEnabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                  >
+                    <div className="flex items-center gap-2 text-sm font-semibold text-sf-text-primary">
+                      <Wand2 className="h-4 w-4 text-sf-accent" />
+                      Create new image
+                    </div>
+                    <p className="mt-1 text-[11px] text-sf-text-muted">
+                      Generate a new portrait first, then optionally make a sheet from it.
+                    </p>
+                  </button>
+                </div>
+              </div>
+
+              {wizardStep === 'existing' && (
+                <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4 space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-semibold text-sf-text-primary">Existing image</div>
+                      <p className="mt-1 text-xs text-sf-text-secondary">
+                        Choose a project image and either save now or continue into character-sheet generation.
+                      </p>
+                    </div>
+                    <div className="text-[10px] text-sf-text-muted">
+                      {canUsePeopleWizardGeneration ? 'Sheet path enabled' : 'Sheet path unavailable'}
+                    </div>
+                  </div>
+                  <select
+                    value={peopleWizard.assetId || ''}
+                    onChange={(event) => handlePeopleWizardSelectAsset(event.target.value || '')}
+                    className="w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                  >
+                    <option value="">Select image asset</option>
+                    {imageAssets.map((asset) => (
+                      <option key={asset.id} value={asset.id}>{asset.name || asset.id}</option>
+                    ))}
+                  </select>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!peopleWizardGenerationEnabled || !peopleWizardSelectedAsset) return
+                        updatePeopleWizard({ step: 'sheet' })
+                      }}
+                      disabled={!peopleWizardGenerationEnabled || !peopleWizardSelectedAsset}
+                      className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Create character sheet
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {wizardStep === 'image' && (
+                <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4 space-y-3">
+                  <div>
+                    <div className="text-sm font-semibold text-sf-text-primary">New image</div>
+                    <p className="mt-1 text-xs text-sf-text-secondary">
+                      Generate a new character image before moving to the sheet step.
+                    </p>
+                  </div>
+                  <div>
+                    <FieldLabel>Prompt</FieldLabel>
+                    <textarea
+                      value={peopleWizard.imagePrompt}
+                      onChange={(event) => handlePeopleWizardFieldChange('imagePrompt', event.target.value)}
+                      rows={4}
+                      className="mt-1 w-full resize-y rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                      placeholder="Describe the character portrait."
+                    />
+                  </div>
+                  <div className="flex flex-col gap-3 md:flex-row md:items-end">
+                    <div className="flex-1">
+                      <FieldLabel>Image Size</FieldLabel>
+                      <div className="mt-2 inline-flex rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-1">
+                        {PEOPLE_WIZARD_IMAGE_SIZE_OPTIONS.map((option) => (
+                          <button
+                            key={option.id}
+                            type="button"
+                            onClick={() => handlePeopleWizardFieldChange('imageSize', option.id)}
+                            title={`${option.label} image size`}
+                            aria-label={`${option.label} image size`}
+                            className={`inline-flex h-10 min-w-[3.25rem] items-center justify-center rounded-lg border px-3 text-xs font-semibold transition-colors ${buttonClass(peopleWizard.imageSize === option.id)}`}
+                          >
+                            <span>{option.label}</span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="flex-1">
+                      <FieldLabel>Orientation</FieldLabel>
+                      <div className="mt-2 inline-flex rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-1">
+                        {PEOPLE_WIZARD_IMAGE_ORIENTATION_OPTIONS.map((option) => (
+                          <button
+                            key={option.id}
+                            type="button"
+                            onClick={() => handlePeopleWizardFieldChange('imageOrientation', option.id)}
+                            title={`${option.label} orientation`}
+                            aria-label={`${option.label} orientation`}
+                            className={`inline-flex h-10 min-w-[5.75rem] items-center justify-center rounded-lg border px-3 text-xs font-semibold transition-colors ${buttonClass(peopleWizard.imageOrientation === option.id)}`}
+                          >
+                            <span>{option.label}</span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="rounded-lg border border-sf-dark-700 bg-sf-dark-950/60 p-3 text-[11px] text-sf-text-secondary">
+                    <span className="text-sf-text-muted">Canvas:</span> {formatResolutionLabel(resolvePeopleWizardImageResolution(peopleWizard.imageSize, peopleWizard.imageOrientation))}
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+                    <div>
+                      <FieldLabel>Seed</FieldLabel>
+                      <input
+                        type="number"
+                        value={peopleWizard.imageSeed}
+                        onChange={(event) => handlePeopleWizardFieldChange('imageSeed', Number(event.target.value))}
+                        className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                      />
+                    </div>
+                    <div className="flex items-end">
+                      <button
+                        type="button"
+                        onClick={() => handlePeopleWizardFieldChange('imageSeed', Math.floor(Math.random() * 1000000000))}
+                        className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                      >
+                        Randomize
+                      </button>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => updatePeopleWizard({ step: 'basic' })}
+                      className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                    >
+                      Back
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handlePeopleWizardCreateImage}
+                      disabled={!peopleWizardGenerationEnabled || Boolean(peopleWizardActiveJob)}
+                      className="rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {peopleWizardActiveJob ? 'Generating…' : 'Generate'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!peopleWizardGeneratedImageAsset) return
+                        updatePeopleWizard({ step: 'sheet' })
+                      }}
+                      disabled={!peopleWizardGeneratedImageAsset}
+                      className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Next
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {wizardStep === 'sheet' && (
+                <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-900/70 p-4 space-y-3">
+                  <div>
+                    <div className="text-sm font-semibold text-sf-text-primary">Character sheet</div>
+                    <p className="mt-1 text-xs text-sf-text-secondary">
+                      Use the previous image as the reference, then turn it into a multi-angle character sheet.
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-sf-dark-700 bg-sf-dark-950/60 p-3 text-xs text-sf-text-secondary">
+                    <div><span className="text-sf-text-muted">Reference:</span> {peopleWizardGeneratedImageAsset?.name || peopleWizardSelectedAsset?.name || 'No reference selected yet'}</div>
+                    <div><span className="text-sf-text-muted">Sheet workflow:</span> Multiple Angles (Characters)</div>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+                    <div>
+                      <FieldLabel>Seed</FieldLabel>
+                      <input
+                        type="number"
+                        value={peopleWizard.sheetSeed}
+                        onChange={(event) => handlePeopleWizardFieldChange('sheetSeed', Number(event.target.value))}
+                        className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                      />
+                    </div>
+                    <div className="flex items-end">
+                      <button
+                        type="button"
+                        onClick={() => handlePeopleWizardFieldChange('sheetSeed', Math.floor(Math.random() * 1000000000))}
+                        className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                      >
+                        Randomize
+                      </button>
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => updatePeopleWizard({ step: sheetBackStep })}
+                      className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                    >
+                      Back
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handlePeopleWizardCreateSheet}
+                      disabled={!peopleWizardGenerationEnabled || Boolean(peopleWizardActiveJob) || !(peopleWizardGeneratedImageAsset || peopleWizardSelectedAsset || peopleWizard.assetId)}
+                      className="rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {peopleWizardActiveJob ? 'Generating…' : 'Generate'}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="border-t border-sf-dark-700 bg-sf-dark-900/70 p-4 lg:border-l lg:border-t-0">
+              <div className="rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-[0.14em] text-sf-text-muted">Preview</div>
+                    <div className="text-sm font-semibold text-sf-text-primary">
+                      {previewTitle}
+                    </div>
+                  </div>
+                  {statusText && (
+                    <span className="rounded-full border border-sf-dark-600 bg-sf-dark-900 px-2 py-1 text-[10px] text-sf-text-muted">
+                      {statusText}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-3 aspect-[4/5] overflow-hidden rounded-lg border border-sf-dark-700 bg-sf-dark-950">
+                  {selectedPreviewAsset?.url ? (
+                    <img
+                      src={selectedPreviewAsset.url}
+                      alt={selectedPreviewAsset.name || 'People wizard preview'}
+                      className="h-full w-full object-contain"
+                    />
+                  ) : (
+                    <div className="flex h-full flex-col items-center justify-center gap-2 text-xs text-sf-text-muted">
+                      <ImageIcon className="h-8 w-8 opacity-60" />
+                      <span>{previewEmptyText}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-3 space-y-2 rounded-xl border border-sf-dark-700 bg-sf-dark-950/60 p-3 text-xs text-sf-text-secondary">
+                <div><span className="text-sf-text-muted">Mode:</span> {peopleWizard.mode === 'edit' ? 'Edit existing person' : 'Create person'}</div>
+                <div><span className="text-sf-text-muted">Name:</span> {peopleWizard.name || 'Untitled'}</div>
+                <div><span className="text-sf-text-muted">Slug:</span> {peopleWizard.slug || 'unset'}</div>
+                <div><span className="text-sf-text-muted">Role:</span> {peopleWizard.role || 'lead'}</div>
+                <div><span className="text-sf-text-muted">Path:</span> {wizardStep}</div>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-3 border-t border-sf-dark-700 bg-sf-dark-950 px-4 py-3">
+            <div className="text-[11px] text-sf-text-muted">
+              Save is available when name, slug, and a final image or sheet are ready.
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={closePeopleWizard}
+                className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handlePeopleWizardSave}
+                disabled={!canSavePeopleWizard}
+                className="rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   const renderPeopleStep = () => (
     <div className="space-y-4">
       {renderStepHeader(
@@ -1174,7 +1822,7 @@ export default function MusicVideoEasyMode({
           </div>
           <button
             type="button"
-            onClick={handleYoloMusicCastAdd}
+            onClick={() => handleOpenPeopleWizard(null)}
             className="inline-flex items-center justify-center gap-2 rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90"
           >
             <UserPlus className="h-4 w-4" />
@@ -1188,63 +1836,84 @@ export default function MusicVideoEasyMode({
               Add at least one person if the video has lip-sync performance shots.
             </div>
           )}
-          {(yoloMusicCast || []).map((entry, index) => (
-            <div key={entry.id || index} className="grid gap-2 rounded-lg border border-sf-dark-700 bg-sf-dark-950/50 p-3 lg:grid-cols-[1fr_1fr_1fr_auto]">
-              <div>
-                <FieldLabel>Name</FieldLabel>
-                <input
-                  type="text"
-                  value={entry?.label || ''}
-                  onChange={(event) => handleYoloMusicCastLabelChange(entry.id, event.target.value)}
-                  placeholder="Ava"
-                  className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                />
+          {(yoloMusicCast || []).map((entry, index) => {
+            const entryAsset = imageAssets.find((asset) => asset?.id === entry?.assetId) || null
+            const entryAssetUrl = getAssetUrl(entryAsset)
+            return (
+              <div key={entry.id || index} className="grid gap-2 rounded-lg border border-sf-dark-700 bg-sf-dark-950/50 p-3 lg:grid-cols-[1fr_1fr_1fr_auto_auto]">
+                <div>
+                  <FieldLabel>Name</FieldLabel>
+                  <input
+                    type="text"
+                    value={entry?.label || ''}
+                    onChange={(event) => handleYoloMusicCastLabelChange(entry.id, event.target.value)}
+                    placeholder="Ava"
+                    className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Script Slug</FieldLabel>
+                  <input
+                    type="text"
+                    value={entry?.slug || ''}
+                    onChange={(event) => handleYoloMusicCastSlugChange(entry.id, event.target.value)}
+                    placeholder="ava"
+                    className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 font-mono text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                  />
+                </div>
+                <div>
+                  <FieldLabel>Reference</FieldLabel>
+                  <div className="mt-1 flex min-h-[44px] items-center gap-3 rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md border border-sf-dark-600 bg-sf-dark-900">
+                      {entryAssetUrl ? (
+                        <img
+                          src={entryAssetUrl}
+                          alt={entryAsset?.name || entry?.label || 'Reference image'}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <ImageIcon className="h-4 w-4 text-sf-text-muted" />
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1 truncate">
+                      {entryAsset?.name || 'No reference image'}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-end gap-2">
+                  <select
+                    value={entry?.role || 'lead'}
+                    onChange={(event) => handleYoloMusicCastRoleChange(entry.id, event.target.value)}
+                    className="w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                  >
+                    {MUSIC_VIDEO_CAST_ROLE_OPTIONS.map((role) => (
+                      <option key={role.id} value={role.id}>{role.label}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex items-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleOpenPeopleWizard(entry)}
+                    className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-muted transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary"
+                    title="Edit person"
+                  >
+                    <Edit3 className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleYoloMusicCastRemove(entry.id)}
+                    className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-muted transition-colors hover:border-red-400/60 hover:text-red-200"
+                  >
+                    Remove
+                  </button>
+                </div>
               </div>
-              <div>
-                <FieldLabel>Script Slug</FieldLabel>
-                <input
-                  type="text"
-                  value={entry?.slug || ''}
-                  onChange={(event) => handleYoloMusicCastSlugChange(entry.id, event.target.value)}
-                  placeholder="ava"
-                  className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 font-mono text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                />
-              </div>
-              <div>
-                <FieldLabel>Reference</FieldLabel>
-                <select
-                  value={entry?.assetId || ''}
-                  onChange={(event) => handleYoloMusicCastAssetChange(entry.id, event.target.value || null)}
-                  className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                >
-                  <option value="">Select image asset</option>
-                  {imageAssets.map((asset) => (
-                    <option key={asset.id} value={asset.id}>{asset.name || asset.id}</option>
-                  ))}
-                </select>
-              </div>
-              <div className="flex items-end gap-2">
-                <select
-                  value={entry?.role || 'lead'}
-                  onChange={(event) => handleYoloMusicCastRoleChange(entry.id, event.target.value)}
-                  className="w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
-                >
-                  {MUSIC_VIDEO_CAST_ROLE_OPTIONS.map((role) => (
-                    <option key={role.id} value={role.id}>{role.label}</option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  onClick={() => handleYoloMusicCastRemove(entry.id)}
-                  className="rounded-lg border border-sf-dark-600 px-3 py-2 text-xs text-sf-text-muted transition-colors hover:border-red-400/60 hover:text-red-200"
-                >
-                  Remove
-                </button>
-              </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
       </div>
+      {renderPeopleWizardModal()}
     </div>
   )
 

--- a/src/components/panels/AssetsPanel.jsx
+++ b/src/components/panels/AssetsPanel.jsx
@@ -8,6 +8,7 @@ import { enqueuePlaybackTranscode } from '../../services/playbackCache'
 import { enqueueProxyTranscode, isProxyPlaybackEnabled } from '../../services/proxyCache'
 import { unstitchSequenceAsset } from '../../services/comfyAutoImport'
 import { deleteSpriteFromProject } from '../../services/thumbnailSprites'
+import { deleteVideoPosterFromProject } from '../../services/thumbnailPosters'
 import MaskGenerationDialog from '../MaskGenerationDialog'
 import OverlayGeneratorModal from '../OverlayGeneratorModal'
 import TopazVideoUpscaleDialog from '../TopazVideoUpscaleDialog'
@@ -51,22 +52,23 @@ const assetMatchesSearch = (asset, normalizedQuery) => {
     || normalizeSearchText(asset?.prompt).includes(normalizedQuery)
 }
 
-function LazyAssetThumbnail({
+function VideoAssetThumbnail({
   asset,
   Icon,
   isActive = true,
+  onVisible = null,
   iconClassName = 'w-3.5 h-3.5 text-sf-text-muted',
   imageAlt = '',
-  videoClassName = 'w-full h-full object-cover',
   imageClassName = 'w-full h-full object-cover',
-  videoProps = {},
 }) {
   const containerRef = useRef(null)
   const [shouldLoad, setShouldLoad] = useState(false)
+  const didNotifyVisibleRef = useRef(false)
 
   useEffect(() => {
     if (!isActive) {
       setShouldLoad(false)
+      didNotifyVisibleRef.current = false
       return undefined
     }
 
@@ -86,12 +88,43 @@ function LazyAssetThumbnail({
     return () => observer.disconnect()
   }, [isActive])
 
+  useEffect(() => {
+    if (!shouldLoad || didNotifyVisibleRef.current || typeof onVisible !== 'function' || !asset?.id) return
+    didNotifyVisibleRef.current = true
+    onVisible(asset)
+  }, [asset, onVisible, shouldLoad])
+
   const fallback = Icon ? <Icon className={iconClassName} /> : null
+  const poster = asset?.poster
+  const sprite = asset?.sprite
+  const posterReady = shouldLoad && asset?.type === 'video' && poster?.url
+  const spriteReady = shouldLoad && asset?.type === 'video' && !poster?.url && sprite?.url && Array.isArray(sprite?.frames) && sprite.frames.length > 0
+  const spriteFrame = spriteReady ? sprite.frames[0] : null
+  const spriteStyle = spriteReady ? {
+    width: `${spriteFrame.width}px`,
+    height: `${spriteFrame.height}px`,
+    backgroundImage: `url(${sprite.url})`,
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: `${sprite.width}px ${sprite.height}px`,
+    backgroundPosition: `${-spriteFrame.x}px ${-spriteFrame.y}px`,
+  } : null
 
   return (
     <div ref={containerRef} className="w-full h-full flex items-center justify-center">
-      {shouldLoad && asset?.type === 'video' && asset?.url ? (
-        <video src={asset.url} className={videoClassName} muted preload="none" {...videoProps} />
+      {posterReady ? (
+        <img
+          src={poster.url}
+          alt={imageAlt}
+          className={imageClassName}
+          loading="lazy"
+          decoding="async"
+        />
+      ) : spriteReady ? (
+        <div
+          className="flex-shrink-0 overflow-hidden bg-sf-dark-700"
+          style={spriteStyle}
+          aria-hidden="true"
+        />
       ) : shouldLoad && asset?.type === 'image' && asset?.url ? (
         <img src={asset.url} alt={imageAlt} className={imageClassName} loading="lazy" decoding="async" />
       ) : fallback}
@@ -297,7 +330,8 @@ function AssetsPanel({ isActive = true }) {
     moveAssetToFolder,
     moveAssetsToFolder,
     generateAssetSprite,
-    getAssetSprite,
+    generateAssetPoster,
+    hydrateAssetBrowserMedia,
     setAssetAudioEnabled,
   } = useAssetsStore()
   const { currentProject, currentProjectHandle, currentTimelineId, switchTimeline, renameTimeline, setTimelineColor, moveTimelineToFolder, duplicateTimeline, deleteTimeline, getCurrentTimelineSettings } = useProjectStore()
@@ -389,6 +423,9 @@ function AssetsPanel({ isActive = true }) {
           // Generate sprites asynchronously (don't await)
           generateAssetSprite(newAsset.id, projectPath).catch(err => {
             console.warn('Auto-sprite generation failed:', err)
+          })
+          generateAssetPoster(newAsset.id, projectPath).catch(err => {
+            console.warn('Auto-poster generation failed:', err)
           })
         }
       } catch (err) {
@@ -575,6 +612,7 @@ function AssetsPanel({ isActive = true }) {
       addPath(remainingRelativePaths, asset?.proxyPath)
       if (!asset?.path) addPath(remainingAbsolutePaths, asset?.absolutePath)
       addPath(remainingAbsolutePaths, asset?.sprite?.spritePath)
+      addPath(remainingAbsolutePaths, asset?.poster?.posterPath)
     }
 
     const deleteRelativePath = async (relativePath) => {
@@ -621,6 +659,16 @@ function AssetsPanel({ isActive = true }) {
         }
       } else if (asset?.sprite?.spritePath) {
         await deleteAbsolutePath(asset.sprite.spritePath)
+      }
+
+      if (isElectron() && typeof currentProjectHandle === 'string' && asset?.poster) {
+        try {
+          await deleteVideoPosterFromProject(currentProjectHandle, asset.id)
+        } catch (_) {
+          // Ignore poster cleanup failures.
+        }
+      } else if (asset?.poster?.posterPath) {
+        await deleteAbsolutePath(asset.poster.posterPath)
       }
     }
   }, [assets, currentProjectHandle])
@@ -694,6 +742,7 @@ function AssetsPanel({ isActive = true }) {
     
     try {
       await generateAssetSprite(assetId, projectPath)
+      await generateAssetPoster(assetId, projectPath)
     } catch (err) {
       console.error('Failed to generate thumbnails:', err)
     }
@@ -1278,7 +1327,7 @@ function AssetsPanel({ isActive = true }) {
   useEffect(() => {
     setSelectedSequenceId(currentTimelineId || null)
   }, [currentTimelineId])
-  
+
   // Get thumbnail size config
   const sizeConfig = THUMBNAIL_SIZES[thumbnailSize]
   const folderTileIconSize = FOLDER_TILE_ICON_SIZES[thumbnailSize] || FOLDER_TILE_ICON_SIZES.medium
@@ -1567,7 +1616,7 @@ function AssetsPanel({ isActive = true }) {
                 >
                   <div className="flex items-center gap-2 min-w-0">
                     <div className="w-6 h-6 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-                      <LazyAssetThumbnail
+                      <VideoAssetThumbnail
                         asset={asset}
                         Icon={Icon}
                         isActive={isActive}
@@ -1944,19 +1993,18 @@ function AssetsPanel({ isActive = true }) {
                 >
                   {/* Thumbnail */}
                   <div className="aspect-video bg-sf-dark-700 flex items-center justify-center relative overflow-hidden">
-                    <LazyAssetThumbnail
+                    <VideoAssetThumbnail
+                      key={asset.poster?.url || asset.sprite?.url || asset.id}
                       asset={asset}
                       Icon={Icon}
                       isActive={isActive}
+                      onVisible={(visibleAsset) => {
+                        hydrateAssetBrowserMedia(visibleAsset.id, currentProjectHandle).catch((err) => {
+                          console.warn('[AssetsPanel] visible asset hydration failed:', err)
+                        })
+                      }}
                       iconClassName={`${sizeConfig.iconSize} text-sf-text-muted`}
                       imageAlt={asset.name}
-                      videoProps={{
-                        onMouseEnter: (e) => e.target.play(),
-                        onMouseLeave: (e) => {
-                          e.target.pause()
-                          e.target.currentTime = 0
-                        },
-                      }}
                     />
                     
                     {/* Badge - AI, Imported, or Mask */}
@@ -1977,9 +2025,9 @@ function AssetsPanel({ isActive = true }) {
                     )}
 
                     {/* Sprite badge - shows if thumbnails are ready */}
-                    {asset.type === 'video' && asset.sprite?.url && (
-                      <div className={`absolute bottom-0.5 left-0.5 px-1 py-0.5 rounded ${sizeConfig.badgeSize} text-white font-medium bg-sf-blue/90`} title="Thumbnails ready for fast scrubbing">
-                        <Film className="w-2 h-2 inline-block" />
+                    {asset.type === 'video' && asset.poster?.url && (
+                      <div className={`absolute bottom-0.5 left-0.5 px-1 py-0.5 rounded ${sizeConfig.badgeSize} text-white font-medium bg-sf-blue/90`} title="Video poster ready">
+                        <Image className="w-2 h-2 inline-block" />
                       </div>
                     )}
                     
@@ -2131,10 +2179,16 @@ function AssetsPanel({ isActive = true }) {
                   {/* Name + thumbnail */}
                   <div className="flex items-center gap-2 min-w-0">
                     <div className="w-7 h-7 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-                      <LazyAssetThumbnail
+                      <VideoAssetThumbnail
+                        key={asset.poster?.url || asset.sprite?.url || asset.id}
                         asset={asset}
                         Icon={Icon}
                         isActive={isActive}
+                        onVisible={(visibleAsset) => {
+                          hydrateAssetBrowserMedia(visibleAsset.id, currentProjectHandle).catch((err) => {
+                            console.warn('[AssetsPanel] visible asset hydration failed:', err)
+                          })
+                        }}
                         iconClassName="w-3.5 h-3.5 text-sf-text-muted"
                         imageAlt=""
                       />
@@ -2187,10 +2241,16 @@ function AssetsPanel({ isActive = true }) {
           <div className="flex items-center gap-2 min-w-0">
             <div className="w-10 h-7 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
               {DragPreviewIcon && (
-                <LazyAssetThumbnail
+                <VideoAssetThumbnail
+                  key={dragPreviewAsset.poster?.url || dragPreviewAsset.sprite?.url || dragPreviewAsset.id}
                   asset={dragPreviewAsset}
                   Icon={DragPreviewIcon}
                   isActive={isActive}
+                  onVisible={(visibleAsset) => {
+                    hydrateAssetBrowserMedia(visibleAsset.id, currentProjectHandle).catch((err) => {
+                      console.warn('[AssetsPanel] visible asset hydration failed:', err)
+                    })
+                  }}
                   iconClassName="w-4 h-4 text-sf-text-muted"
                   imageAlt=""
                 />

--- a/src/components/panels/AssetsPanel.jsx
+++ b/src/components/panels/AssetsPanel.jsx
@@ -51,7 +51,55 @@ const assetMatchesSearch = (asset, normalizedQuery) => {
     || normalizeSearchText(asset?.prompt).includes(normalizedQuery)
 }
 
-function AssetsPanel() {
+function LazyAssetThumbnail({
+  asset,
+  Icon,
+  isActive = true,
+  iconClassName = 'w-3.5 h-3.5 text-sf-text-muted',
+  imageAlt = '',
+  videoClassName = 'w-full h-full object-cover',
+  imageClassName = 'w-full h-full object-cover',
+  videoProps = {},
+}) {
+  const containerRef = useRef(null)
+  const [shouldLoad, setShouldLoad] = useState(false)
+
+  useEffect(() => {
+    if (!isActive) {
+      setShouldLoad(false)
+      return undefined
+    }
+
+    const element = containerRef.current
+    if (!element) return undefined
+    if (typeof IntersectionObserver === 'undefined') {
+      setShouldLoad(true)
+      return undefined
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const visible = entries.some((entry) => entry.isIntersecting || entry.intersectionRatio > 0)
+      setShouldLoad(visible)
+    }, { root: null, rootMargin: '600px 0px', threshold: 0.01 })
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [isActive])
+
+  const fallback = Icon ? <Icon className={iconClassName} /> : null
+
+  return (
+    <div ref={containerRef} className="w-full h-full flex items-center justify-center">
+      {shouldLoad && asset?.type === 'video' && asset?.url ? (
+        <video src={asset.url} className={videoClassName} muted preload="none" {...videoProps} />
+      ) : shouldLoad && asset?.type === 'image' && asset?.url ? (
+        <img src={asset.url} alt={imageAlt} className={imageClassName} loading="lazy" decoding="async" />
+      ) : fallback}
+    </div>
+  )
+}
+
+function AssetsPanel({ isActive = true }) {
   const [viewMode, setViewMode] = useState('grid')
   const [thumbnailSize, setThumbnailSize] = useState('medium')
   const [assetDeleteMode, setAssetDeleteMode] = useState(() => {
@@ -1519,13 +1567,13 @@ function AssetsPanel() {
                 >
                   <div className="flex items-center gap-2 min-w-0">
                     <div className="w-6 h-6 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-                      {asset.type === 'video' && asset.url ? (
-                        <video src={asset.url} className="w-full h-full object-cover" muted preload="metadata" />
-                      ) : asset.type === 'image' && asset.url ? (
-                        <img src={asset.url} alt="" className="w-full h-full object-cover" />
-                      ) : (
-                        <Icon className="w-3.5 h-3.5 text-sf-text-muted" />
-                      )}
+                      <LazyAssetThumbnail
+                        asset={asset}
+                        Icon={Icon}
+                        isActive={isActive}
+                        iconClassName="w-3.5 h-3.5 text-sf-text-muted"
+                        imageAlt=""
+                      />
                     </div>
                     {isEditingAsset ? (
                       <form onSubmit={saveEdit} className="min-w-0 flex-1" onClick={(e) => e.stopPropagation()}>
@@ -1896,26 +1944,20 @@ function AssetsPanel() {
                 >
                   {/* Thumbnail */}
                   <div className="aspect-video bg-sf-dark-700 flex items-center justify-center relative overflow-hidden">
-                    {asset.type === 'video' && asset.url ? (
-                      <video
-                        src={asset.url}
-                        className="w-full h-full object-cover"
-                        muted
-                        onMouseEnter={(e) => e.target.play()}
-                        onMouseLeave={(e) => {
+                    <LazyAssetThumbnail
+                      asset={asset}
+                      Icon={Icon}
+                      isActive={isActive}
+                      iconClassName={`${sizeConfig.iconSize} text-sf-text-muted`}
+                      imageAlt={asset.name}
+                      videoProps={{
+                        onMouseEnter: (e) => e.target.play(),
+                        onMouseLeave: (e) => {
                           e.target.pause()
                           e.target.currentTime = 0
-                        }}
-                      />
-                    ) : asset.type === 'image' && asset.url ? (
-                      <img
-                        src={asset.url}
-                        alt={asset.name}
-                        className="w-full h-full object-cover"
-                      />
-                    ) : (
-                      <Icon className={`${sizeConfig.iconSize} text-sf-text-muted`} />
-                    )}
+                        },
+                      }}
+                    />
                     
                     {/* Badge - AI, Imported, or Mask */}
                     <div className={`absolute top-0.5 left-0.5 px-1 py-0.5 rounded ${sizeConfig.badgeSize} text-white font-medium ${
@@ -2089,13 +2131,13 @@ function AssetsPanel() {
                   {/* Name + thumbnail */}
                   <div className="flex items-center gap-2 min-w-0">
                     <div className="w-7 h-7 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-                      {asset.type === 'video' && asset.url ? (
-                        <video src={asset.url} className="w-full h-full object-cover" muted preload="metadata" />
-                      ) : asset.type === 'image' && asset.url ? (
-                        <img src={asset.url} alt="" className="w-full h-full object-cover" />
-                      ) : (
-                        <Icon className="w-3.5 h-3.5 text-sf-text-muted" />
-                      )}
+                      <LazyAssetThumbnail
+                        asset={asset}
+                        Icon={Icon}
+                        isActive={isActive}
+                        iconClassName="w-3.5 h-3.5 text-sf-text-muted"
+                        imageAlt=""
+                      />
                     </div>
                     {isEditingAsset ? (
                       <form onSubmit={saveEdit} className="min-w-0 flex-1" onClick={(e) => e.stopPropagation()}>
@@ -2144,12 +2186,14 @@ function AssetsPanel() {
         >
           <div className="flex items-center gap-2 min-w-0">
             <div className="w-10 h-7 rounded overflow-hidden bg-sf-dark-700 flex-shrink-0 flex items-center justify-center">
-              {dragPreviewAsset.type === 'video' && dragPreviewAsset.url ? (
-                <video src={dragPreviewAsset.url} className="w-full h-full object-cover" muted preload="metadata" />
-              ) : dragPreviewAsset.type === 'image' && dragPreviewAsset.url ? (
-                <img src={dragPreviewAsset.url} alt="" className="w-full h-full object-cover" />
-              ) : (
-                DragPreviewIcon && <DragPreviewIcon className="w-4 h-4 text-sf-text-muted" />
+              {DragPreviewIcon && (
+                <LazyAssetThumbnail
+                  asset={dragPreviewAsset}
+                  Icon={DragPreviewIcon}
+                  isActive={isActive}
+                  iconClassName="w-4 h-4 text-sf-text-muted"
+                  imageAlt=""
+                />
               )}
             </div>
             <div className="min-w-0">

--- a/src/services/thumbnailPosters.js
+++ b/src/services/thumbnailPosters.js
@@ -1,0 +1,111 @@
+import { isElectron } from './fileSystem'
+
+const POSTER_IMAGE_SUFFIX = '_poster.jpg'
+const POSTER_META_SUFFIX = '_poster.json'
+
+function normalizeSignature(signature = null) {
+  if (!signature || typeof signature !== 'object') return null
+  return {
+    sourcePath: String(signature.sourcePath || '').trim() || null,
+    sourceSize: Number(signature.sourceSize) || 0,
+    sourceModified: Number(signature.sourceModified) || 0,
+  }
+}
+
+function signaturesMatch(left, right) {
+  const a = normalizeSignature(left)
+  const b = normalizeSignature(right)
+  if (!a || !b) return false
+  return a.sourcePath === b.sourcePath
+    && a.sourceSize === b.sourceSize
+    && a.sourceModified === b.sourceModified
+}
+
+export function buildPosterSignature(fileInfo, sourcePath) {
+  return normalizeSignature({
+    sourcePath,
+    sourceSize: Number(fileInfo?.info?.size) || 0,
+    sourceModified: fileInfo?.info?.modified ? new Date(fileInfo.info.modified).getTime() : 0,
+  })
+}
+
+export async function loadVideoPosterFromProject(projectPath, assetId, expectedSignature = null) {
+  if (!isElectron() || !projectPath || !assetId) return null
+  const api = window.electronAPI
+  try {
+    const posterDir = await api.pathJoin(projectPath, 'thumbnails')
+    const posterPath = await api.pathJoin(posterDir, `${assetId}${POSTER_IMAGE_SUFFIX}`)
+    const metaPath = await api.pathJoin(posterDir, `${assetId}${POSTER_META_SUFFIX}`)
+    if (!await api.exists(posterPath)) return null
+
+    let posterMeta = null
+    if (await api.exists(metaPath)) {
+      const metaResult = await api.readFile(metaPath, { encoding: 'utf8' })
+      if (metaResult?.success && metaResult.data) {
+        try {
+          posterMeta = JSON.parse(metaResult.data)
+        } catch (_) {
+          posterMeta = null
+        }
+      }
+    }
+
+    if (expectedSignature && posterMeta?.sourceSignature && !signaturesMatch(posterMeta.sourceSignature, expectedSignature)) {
+      return null
+    }
+
+    const url = await api.getFileUrlDirect(posterPath)
+    return {
+      posterPath,
+      metaPath,
+      url,
+      posterData: {
+        url,
+        posterPath,
+        sourceSignature: posterMeta?.sourceSignature || null,
+        width: posterMeta?.width || null,
+        height: posterMeta?.height || null,
+        created: posterMeta?.created || null,
+      },
+    }
+  } catch (err) {
+    console.warn('Failed to load video poster:', err)
+    return null
+  }
+}
+
+export async function generateVideoPosterInProject(projectPath, assetId, sourcePath, sourceSignature, options = {}) {
+  if (!isElectron() || !projectPath || !assetId || !sourcePath) return null
+  const api = window.electronAPI
+  const posterDir = await api.pathJoin(projectPath, 'thumbnails')
+  await api.createDirectory(posterDir)
+  const posterPath = await api.pathJoin(posterDir, `${assetId}${POSTER_IMAGE_SUFFIX}`)
+  const metaPath = await api.pathJoin(posterDir, `${assetId}${POSTER_META_SUFFIX}`)
+
+  const result = await api.extractVideoPoster(sourcePath, posterPath, options)
+  if (!result?.success) {
+    throw new Error(result?.error || 'Failed to extract video poster')
+  }
+
+  const posterUrl = await api.getFileUrlDirect(posterPath)
+  const posterData = {
+    url: posterUrl,
+    posterPath,
+    sourceSignature: normalizeSignature(sourceSignature),
+    width: result.width || null,
+    height: result.height || null,
+    created: new Date().toISOString(),
+  }
+  await api.writeFile(metaPath, JSON.stringify(posterData, null, 2))
+  return { posterPath, metaPath, url: posterUrl, posterData }
+}
+
+export async function deleteVideoPosterFromProject(projectPath, assetId) {
+  if (!isElectron() || !projectPath || !assetId) return
+  const api = window.electronAPI
+  const posterDir = await api.pathJoin(projectPath, 'thumbnails')
+  const posterPath = await api.pathJoin(posterDir, `${assetId}${POSTER_IMAGE_SUFFIX}`)
+  const metaPath = await api.pathJoin(posterDir, `${assetId}${POSTER_META_SUFFIX}`)
+  try { await api.deleteFile(posterPath) } catch (_) {}
+  try { await api.deleteFile(metaPath) } catch (_) {}
+}

--- a/src/services/thumbnailSprites.js
+++ b/src/services/thumbnailSprites.js
@@ -260,25 +260,42 @@ export async function loadSpriteFromProject(projectPath, assetId, spriteIndex = 
   
   try {
     const thumbDir = await getThumbnailDirectory(projectPath)
-    const indexedSprite = spriteIndex?.[assetId] || (spriteIndex ? null : (await loadSpriteIndex(projectPath))[assetId])
-    const spritePath = indexedSprite?.spritePath || await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
-    const metaPath = indexedSprite?.metaPath || await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
-    
-    // Check if files exist
-    if (!await api.exists(spritePath)) {
-      return null
+    const loadedIndex = spriteIndex || await loadSpriteIndex(projectPath)
+    const indexedSprite = loadedIndex?.[assetId] || null
+    const legacySpritePath = await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
+    const legacyMetaPath = await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
+    const indexedSpritePath = indexedSprite?.spritePath || null
+    const indexedMetaPath = indexedSprite?.metaPath || null
+    const spriteCandidates = [indexedSpritePath, legacySpritePath].filter(Boolean)
+    let resolvedSpritePath = null
+    for (const candidate of spriteCandidates) {
+      if (await api.exists(candidate)) {
+        resolvedSpritePath = candidate
+        break
+      }
     }
+    if (!resolvedSpritePath) return null
 
-    let spriteData = indexedSprite || null
-    if (!spriteData) {
-      if (!await api.exists(metaPath)) return null
-      const metaResult = await api.readFile(metaPath, { encoding: 'utf8' })
-      if (!metaResult.success) return null
-      spriteData = JSON.parse(metaResult.data)
+    let spriteData = null
+    if (indexedSprite && indexedSpritePath === resolvedSpritePath) {
+      spriteData = indexedSprite
+    } else {
+      const metaCandidates = [
+        resolvedSpritePath === indexedSpritePath ? indexedMetaPath : null,
+        legacyMetaPath,
+      ].filter(Boolean)
+      for (const candidate of metaCandidates) {
+        if (!await api.exists(candidate)) continue
+        const metaResult = await api.readFile(candidate, { encoding: 'utf8' })
+        if (!metaResult.success) continue
+        spriteData = JSON.parse(metaResult.data)
+        break
+      }
     }
+    if (!spriteData) return null
     
     // Get URL for sprite image
-    const spriteUrl = await api.getFileUrlDirect(spritePath)
+    const spriteUrl = await api.getFileUrlDirect(resolvedSpritePath)
     
     return { spriteUrl, spriteData: { ...spriteData, url: spriteUrl } }
   } catch (err) {

--- a/src/services/thumbnailSprites.js
+++ b/src/services/thumbnailSprites.js
@@ -26,6 +26,38 @@ const SPRITE_CONFIG = {
   minDuration: 0.5,       // Don't generate sprites for clips shorter than this
 }
 
+const SPRITE_INDEX_FILE = 'sprite_index.json'
+
+async function getThumbnailDirectory(projectPath) {
+  const api = window.electronAPI
+  return await api.pathJoin(projectPath, 'thumbnails')
+}
+
+export async function loadSpriteIndex(projectPath) {
+  if (!isElectron()) return {}
+  const api = window.electronAPI
+  try {
+    const thumbDir = await getThumbnailDirectory(projectPath)
+    const indexPath = await api.pathJoin(thumbDir, SPRITE_INDEX_FILE)
+    if (!await api.exists(indexPath)) return {}
+    const result = await api.readFile(indexPath, { encoding: 'utf8' })
+    if (!result.success) return {}
+    const parsed = JSON.parse(result.data)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch (_) {
+    return {}
+  }
+}
+
+async function saveSpriteIndex(projectPath, index) {
+  if (!isElectron()) return
+  const api = window.electronAPI
+  const thumbDir = await getThumbnailDirectory(projectPath)
+  await api.createDirectory(thumbDir)
+  const indexPath = await api.pathJoin(thumbDir, SPRITE_INDEX_FILE)
+  await api.writeFile(indexPath, JSON.stringify(index || {}, null, 2))
+}
+
 /**
  * Generate a thumbnail sprite for a video file
  * Uses canvas-based frame extraction (works in both Electron and web)
@@ -178,7 +210,7 @@ export async function saveSpriteToProject(projectPath, assetId, spriteBlob, spri
   const api = window.electronAPI
   
   // Create thumbnails directory
-  const thumbDir = await api.pathJoin(projectPath, 'thumbnails')
+  const thumbDir = await getThumbnailDirectory(projectPath)
   await api.createDirectory(thumbDir)
   
   // Save sprite image
@@ -196,6 +228,18 @@ export async function saveSpriteToProject(projectPath, assetId, spriteBlob, spri
     createdAt: new Date().toISOString(),
   }
   await api.writeFile(metaPath, JSON.stringify(metaToSave, null, 2))
+
+  try {
+    const index = await loadSpriteIndex(projectPath)
+    index[assetId] = {
+      ...metaToSave,
+      spritePath,
+      metaPath,
+    }
+    await saveSpriteIndex(projectPath, index)
+  } catch (err) {
+    console.warn('Failed to update sprite index:', err)
+  }
   
   return { spritePath, metaPath, spriteData: metaToSave }
 }
@@ -207,7 +251,7 @@ export async function saveSpriteToProject(projectPath, assetId, spriteBlob, spri
  * @param {string} assetId - Asset ID
  * @returns {Promise<{spriteUrl: string, spriteData: object}|null>}
  */
-export async function loadSpriteFromProject(projectPath, assetId) {
+export async function loadSpriteFromProject(projectPath, assetId, spriteIndex = null) {
   if (!isElectron()) {
     return null
   }
@@ -215,19 +259,23 @@ export async function loadSpriteFromProject(projectPath, assetId) {
   const api = window.electronAPI
   
   try {
-    const thumbDir = await api.pathJoin(projectPath, 'thumbnails')
-    const spritePath = await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
-    const metaPath = await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
+    const thumbDir = await getThumbnailDirectory(projectPath)
+    const indexedSprite = spriteIndex?.[assetId] || (spriteIndex ? null : (await loadSpriteIndex(projectPath))[assetId])
+    const spritePath = indexedSprite?.spritePath || await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
+    const metaPath = indexedSprite?.metaPath || await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
     
     // Check if files exist
-    if (!await api.exists(spritePath) || !await api.exists(metaPath)) {
+    if (!await api.exists(spritePath)) {
       return null
     }
-    
-    // Load metadata
-    const metaResult = await api.readFile(metaPath, { encoding: 'utf8' })
-    if (!metaResult.success) return null
-    const spriteData = JSON.parse(metaResult.data)
+
+    let spriteData = indexedSprite || null
+    if (!spriteData) {
+      if (!await api.exists(metaPath)) return null
+      const metaResult = await api.readFile(metaPath, { encoding: 'utf8' })
+      if (!metaResult.success) return null
+      spriteData = JSON.parse(metaResult.data)
+    }
     
     // Get URL for sprite image
     const spriteUrl = await api.getFileUrlDirect(spritePath)
@@ -251,12 +299,22 @@ export async function deleteSpriteFromProject(projectPath, assetId) {
   const api = window.electronAPI
   
   try {
-    const thumbDir = await api.pathJoin(projectPath, 'thumbnails')
+    const thumbDir = await getThumbnailDirectory(projectPath)
     const spritePath = await api.pathJoin(thumbDir, `${assetId}_sprite.jpg`)
     const metaPath = await api.pathJoin(thumbDir, `${assetId}_sprite.json`)
     
     await api.deleteFile(spritePath)
     await api.deleteFile(metaPath)
+
+    try {
+      const index = await loadSpriteIndex(projectPath)
+      if (index && Object.prototype.hasOwnProperty.call(index, assetId)) {
+        delete index[assetId]
+        await saveSpriteIndex(projectPath, index)
+      }
+    } catch (_) {
+      // Ignore index cleanup failures.
+    }
   } catch (err) {
     // Ignore errors (files may not exist)
   }
@@ -320,6 +378,7 @@ export default {
   saveSpriteToProject,
   loadSpriteFromProject,
   deleteSpriteFromProject,
+  loadSpriteIndex,
   getSpriteFramePosition,
   getSpriteFrameStyle,
   SPRITE_CONFIG,

--- a/src/stores/assetsStore.js
+++ b/src/stores/assetsStore.js
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware'
 const SPRITE_GENERATION_CONCURRENCY = 2
 let activeSpriteGenerationCount = 0
 const pendingSpriteGenerationQueue = []
+let posterProjectSaveTimer = null
 
 const runWithSpriteGenerationSlot = async (task) => {
   if (activeSpriteGenerationCount >= SPRITE_GENERATION_CONCURRENCY) {
@@ -17,6 +18,25 @@ const runWithSpriteGenerationSlot = async (task) => {
     const next = pendingSpriteGenerationQueue.shift()
     if (next) next()
   }
+}
+
+const queueProjectPosterSave = (projectPath, delayMs = 1200) => {
+  if (!projectPath) return
+  if (posterProjectSaveTimer) {
+    clearTimeout(posterProjectSaveTimer)
+  }
+  posterProjectSaveTimer = setTimeout(async () => {
+    posterProjectSaveTimer = null
+    try {
+      const { useProjectStore } = await import('./projectStore')
+      const state = useProjectStore.getState()
+      if (state.currentProjectHandle === projectPath && typeof state.saveProject === 'function') {
+        await state.saveProject()
+      }
+    } catch (err) {
+      console.warn('Failed to persist poster metadata:', err)
+    }
+  }, delayMs)
 }
 
 /**
@@ -458,115 +478,49 @@ export const useAssetsStore = create(
       },
     })
 
+    const fileSystemHelpers = await import('../services/fileSystem')
+    const { getProjectFileUrl, getAbsoluteFileUrl, isElectron: isElectronMode } = fileSystemHelpers
+
     // Load assets - URLs need to be regenerated for imported assets
-    const assetsWithUrls = []
+    const assetsWithUrls = new Array(sourceAssets.length)
     let loadedAssetCount = 0
-    
-    for (const asset of sourceAssets) {
+
+    const hydrateAsset = async (asset, index) => {
       const needsUrlRefresh = asset?.url?.startsWith?.('blob:')
       const hasPath = !!asset?.path
       const hasAbsolutePath = !!asset?.absolutePath
 
-      if ((asset.isImported || needsUrlRefresh || hasPath || hasAbsolutePath) && projectHandle) {
-        // For imported assets (or stale blob URLs), regenerate URL from file
+      if ((asset?.isImported || needsUrlRefresh || hasPath || hasAbsolutePath) && projectHandle) {
         try {
-          const { getProjectFileUrl, getAbsoluteFileUrl, isElectron } = await import('../services/fileSystem')
           let url = null
-          if (isElectron() && hasAbsolutePath) {
+          if (isElectronMode() && hasAbsolutePath) {
             url = await getAbsoluteFileUrl(asset.absolutePath)
           } else if (hasPath) {
             url = await getProjectFileUrl(projectHandle, asset.path)
           }
-          // Regenerate playback cache URL if we have a cached transcode
-          let playbackCacheUrl = null
+
           let playbackCachePath = asset.playbackCachePath
           let playbackCacheStatus = asset.playbackCacheStatus
-          if (asset.playbackCachePath) {
-            try {
-              // Validate playback cache exists before generating a file:// URL.
-              // Missing cache files lead to networkState=3 and black flicker during playback.
-              let canUsePlaybackCache = true
-              if (
-                isElectron() &&
-                typeof projectHandle === 'string' &&
-                window.electronAPI?.pathJoin &&
-                window.electronAPI?.exists
-              ) {
-                const absolutePlaybackCachePath = await window.electronAPI.pathJoin(projectHandle, asset.playbackCachePath)
-                canUsePlaybackCache = await window.electronAPI.exists(absolutePlaybackCachePath)
-              }
 
-              if (canUsePlaybackCache) {
-                playbackCacheUrl = await getProjectFileUrl(projectHandle, asset.playbackCachePath)
-              } else {
-                playbackCachePath = null
-                playbackCacheStatus = 'failed'
-                console.warn(`[PlaybackCache] Missing cache file for ${asset.name}; falling back to source`, {
-                  assetId: asset.id,
-                  playbackCachePath: asset.playbackCachePath,
-                })
-              }
-            } catch (e) {
-              playbackCachePath = null
-              playbackCacheStatus = 'failed'
-              console.warn(`Could not load playback cache for ${asset.name}:`, e)
-            }
-          }
-          // Regenerate proxy URL (low-res NLE-style proxy) the same way.
-          // Kept separate from playbackCache so both tiers can coexist:
-          // proxy is strongly preferred for multi-layer preview, playback
-          // cache is used when proxy is missing/disabled.
-          let proxyUrl = null
-          let proxyPath = asset.proxyPath
-          let proxyStatus = asset.proxyStatus
-          if (asset.proxyPath) {
-            try {
-              let canUseProxy = true
-              if (
-                isElectron() &&
-                typeof projectHandle === 'string' &&
-                window.electronAPI?.pathJoin &&
-                window.electronAPI?.exists
-              ) {
-                const absoluteProxyPath = await window.electronAPI.pathJoin(projectHandle, asset.proxyPath)
-                canUseProxy = await window.electronAPI.exists(absoluteProxyPath)
-              }
-
-              if (canUseProxy) {
-                proxyUrl = await getProjectFileUrl(projectHandle, asset.proxyPath)
-              } else {
-                proxyPath = null
-                proxyStatus = 'failed'
-                console.warn(`[ProxyCache] Missing proxy file for ${asset.name}; falling back to source`, {
-                  assetId: asset.id,
-                  proxyPath: asset.proxyPath,
-                })
-              }
-            } catch (e) {
-              proxyPath = null
-              proxyStatus = 'failed'
-              console.warn(`Could not load proxy for ${asset.name}:`, e)
-            }
-          }
-          assetsWithUrls.push({
+          assetsWithUrls[index] = {
             ...asset,
             url,
             playbackCachePath: playbackCachePath ?? undefined,
             playbackCacheStatus,
-            playbackCacheUrl: playbackCacheUrl ?? undefined,
-            proxyPath: proxyPath ?? undefined,
-            proxyStatus,
-            proxyUrl: proxyUrl ?? undefined,
-          })
+            playbackCacheUrl: undefined,
+            proxyPath: asset.proxyPath ?? undefined,
+            proxyStatus: asset.proxyStatus,
+            proxyUrl: undefined,
+            poster: asset.poster || undefined,
+          }
         } catch (err) {
           console.warn(`Could not load asset ${asset.name}:`, err)
-          // Keep asset but mark URL as null
-          assetsWithUrls.push({ ...asset, url: null })
+          assetsWithUrls[index] = { ...asset, url: null }
         }
       } else {
-        // For AI/external assets, keep the URL as-is (may need ComfyUI to be running)
-        assetsWithUrls.push(asset)
+        assetsWithUrls[index] = asset
       }
+
       loadedAssetCount += 1
       set({
         mediaPreparation: {
@@ -579,6 +533,20 @@ export const useAssetsStore = create(
         },
       })
     }
+
+    const concurrency = Math.max(1, Math.min(8, Math.floor(Number(sourceAssets.length > 120 ? 8 : 4))))
+    let cursor = 0
+    const worker = async () => {
+      while (cursor < sourceAssets.length) {
+        const index = cursor
+        cursor += 1
+        const asset = sourceAssets[index]
+        await hydrateAsset(asset, index)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      }
+    }
+
+    await Promise.all(Array.from({ length: Math.min(concurrency, sourceAssets.length) }, () => worker()))
     
     const nextState = {
       assets: assetsWithUrls,
@@ -643,6 +611,22 @@ export const useAssetsStore = create(
       ),
       currentPreview: state.currentPreview?.id === assetId 
         ? { ...state.currentPreview, sprite: spriteData }
+        : state.currentPreview
+    }))
+  },
+
+  /**
+   * Update asset's poster data
+   * @param {string} assetId - The asset ID
+   * @param {object} posterData - Poster metadata { url, posterPath, sourceSignature, ... }
+   */
+  updateAssetPoster: (assetId, posterData) => {
+    set((state) => ({
+      assets: state.assets.map(a =>
+        a.id === assetId ? { ...a, poster: posterData } : a
+      ),
+      currentPreview: state.currentPreview?.id === assetId
+        ? { ...state.currentPreview, poster: posterData }
         : state.currentPreview
     }))
   },
@@ -725,6 +709,122 @@ export const useAssetsStore = create(
   },
 
   /**
+   * Generate a single-frame poster for a video asset.
+   * Posters are used by the Assets panel as the static preview image.
+   * @param {string} assetId - The asset ID
+   * @param {string} projectPath - Project directory path (for saving)
+   */
+  generateAssetPoster: async (assetId, projectPath) => {
+    const asset = get().assets.find(a => a.id === assetId)
+    if (!asset || asset.type !== 'video' || !asset.absolutePath || !projectPath) {
+      return null
+    }
+
+    try {
+      const { loadVideoPosterFromProject, generateVideoPosterInProject, buildPosterSignature } = await import('../services/thumbnailPosters')
+      const sourcePath = asset.absolutePath
+      const sourceInfo = await window.electronAPI?.getFileInfo?.(sourcePath)
+      const sourceSignature = buildPosterSignature(sourceInfo, sourcePath)
+      const existing = await loadVideoPosterFromProject(projectPath, assetId, sourceSignature)
+      if (existing?.posterData) {
+        get().updateAssetPoster(assetId, existing.posterData)
+        queueProjectPosterSave(projectPath)
+        return existing.posterData
+      }
+
+      const result = await generateVideoPosterInProject(projectPath, assetId, sourcePath, sourceSignature)
+      if (result?.posterData) {
+        get().updateAssetPoster(assetId, result.posterData)
+        queueProjectPosterSave(projectPath)
+        return result.posterData
+      }
+    } catch (err) {
+      console.warn('Failed to generate poster:', err)
+    }
+
+    return null
+  },
+
+  /**
+   * Hydrate the browser-facing media for a single video asset when it becomes visible.
+   * This is intentionally called lazily from the Assets panel so we only touch
+   * derived paths for tiles the user can actually see.
+   * @param {string} assetId - The asset ID
+   * @param {string} projectPath - Project directory path
+   */
+  hydrateAssetBrowserMedia: async (assetId, projectPath) => {
+    if (!assetId || !projectPath || typeof window === 'undefined' || !window.electronAPI?.isElectron) return null
+    const asset = get().assets.find(a => a.id === assetId)
+    if (!asset || asset.type !== 'video') return null
+
+    const { getProjectFileUrl, getAbsoluteFileUrl } = await import('../services/fileSystem')
+    const { loadVideoPosterFromProject, generateVideoPosterInProject, buildPosterSignature } = await import('../services/thumbnailPosters')
+
+    let poster = asset.poster || null
+    let posterChanged = false
+    let playbackCacheUrl = asset.playbackCacheUrl || undefined
+    let proxyUrl = asset.proxyUrl || undefined
+
+    if (!poster && asset.absolutePath) {
+      try {
+        const sourceInfo = await window.electronAPI.getFileInfo(asset.absolutePath)
+        const sourceSignature = buildPosterSignature(sourceInfo, asset.absolutePath)
+        const existing = await loadVideoPosterFromProject(projectPath, assetId, sourceSignature)
+        if (existing?.posterData) {
+          poster = existing.posterData
+          posterChanged = true
+        } else {
+          const generated = await generateVideoPosterInProject(projectPath, assetId, asset.absolutePath, sourceSignature)
+          if (generated?.posterData) {
+            poster = generated.posterData
+            posterChanged = true
+            queueProjectPosterSave(projectPath)
+          }
+        }
+      } catch (err) {
+        console.warn('Failed to hydrate poster for visible asset:', err)
+      }
+    }
+
+    if (!playbackCacheUrl && asset.playbackCachePath) {
+      try {
+        const absolutePlaybackCachePath = await window.electronAPI.pathJoin(projectPath, asset.playbackCachePath)
+        const exists = await window.electronAPI.exists(absolutePlaybackCachePath)
+        if (exists) {
+          playbackCacheUrl = await getProjectFileUrl(projectPath, asset.playbackCachePath)
+        }
+      } catch (err) {
+        console.warn('Failed to hydrate playback cache URL for visible asset:', err)
+      }
+    }
+
+    if (!proxyUrl && asset.proxyPath) {
+      try {
+        const absoluteProxyPath = await window.electronAPI.pathJoin(projectPath, asset.proxyPath)
+        const exists = await window.electronAPI.exists(absoluteProxyPath)
+        if (exists) {
+          proxyUrl = await getProjectFileUrl(projectPath, asset.proxyPath)
+        }
+      } catch (err) {
+        console.warn('Failed to hydrate proxy URL for visible asset:', err)
+      }
+    }
+
+    if (!posterChanged && !playbackCacheUrl && !proxyUrl) return null
+
+    const updates = {}
+    if (posterChanged) updates.poster = poster || undefined
+    if (typeof playbackCacheUrl !== 'undefined') updates.playbackCacheUrl = playbackCacheUrl
+    if (typeof proxyUrl !== 'undefined') updates.proxyUrl = proxyUrl
+
+    if (Object.keys(updates).length > 0) {
+      get().updateAsset(assetId, updates)
+    }
+
+    return updates
+  },
+
+  /**
    * Load saved thumbnail sprites for video assets without flooding the renderer.
    * Startup intentionally does not call this; use it for explicit/on-demand
    * warming where bounded background work is acceptable.
@@ -797,6 +897,97 @@ export const useAssetsStore = create(
     try {
       await Promise.all(Array.from({ length: Math.min(concurrency, videoAssets.length) }, () => worker()))
     } finally {
+      get().clearMediaPreparation()
+    }
+  },
+
+  /**
+   * Load or generate posters for video assets without flooding the renderer.
+   * Used by the Assets panel so video tiles show a static thumbnail even
+   * without a timeline preview.
+   * @param {string} projectPath - Project directory path
+   * @param {object} options - { concurrency?: number, limit?: number, assetIds?: string[] }
+   */
+  loadPostersFromProject: async (projectPath, options = {}) => {
+    if (!projectPath) return
+
+    const { loadVideoPosterFromProject, generateVideoPosterInProject, buildPosterSignature } = await import('../services/thumbnailPosters')
+    const state = get()
+    const targetIds = Array.isArray(options.assetIds) && options.assetIds.length > 0
+      ? new Set(options.assetIds)
+      : null
+    const limit = Number.isFinite(Number(options.limit)) && Number(options.limit) > 0
+      ? Math.floor(Number(options.limit))
+      : null
+    const concurrency = Math.max(1, Math.min(4, Math.floor(Number(options.concurrency) || 2)))
+    const videoAssets = state.assets
+      .filter((asset) => asset?.type === 'video' && (!targetIds || targetIds.has(asset.id)))
+      .slice(0, limit || undefined)
+
+    if (videoAssets.length === 0) {
+      return
+    }
+
+    let completed = 0
+    const updateProgress = () => {
+      set({
+        mediaPreparation: {
+          active: true,
+          phase: 'posters',
+          label: `Loading video thumbnails (${concurrency} at a time)...`,
+          completed,
+          total: videoAssets.length,
+          critical: false,
+        },
+      })
+    }
+    updateProgress()
+
+    let cursor = 0
+    let updatedAnyPoster = false
+    const loadOne = async (asset) => {
+      try {
+        if (asset?.poster?.url) {
+          return
+        }
+        const sourcePath = asset?.absolutePath || null
+        if (!sourcePath) return
+        const sourceInfo = await window.electronAPI?.getFileInfo?.(sourcePath)
+        const sourceSignature = buildPosterSignature(sourceInfo, sourcePath)
+        const loaded = await loadVideoPosterFromProject(projectPath, asset.id, sourceSignature)
+        if (loaded?.posterData) {
+          get().updateAssetPoster(asset.id, loaded.posterData)
+          updatedAnyPoster = true
+          return
+        }
+        const generated = await generateVideoPosterInProject(projectPath, asset.id, sourcePath, sourceSignature)
+        if (generated?.posterData) {
+          get().updateAssetPoster(asset.id, generated.posterData)
+          updatedAnyPoster = true
+        }
+      } catch (err) {
+        console.warn('[AssetsStore] poster load failed:', err)
+      } finally {
+        completed += 1
+        updateProgress()
+      }
+    }
+
+    const worker = async () => {
+      while (cursor < videoAssets.length) {
+        const asset = videoAssets[cursor]
+        cursor += 1
+        await loadOne(asset)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      }
+    }
+
+    try {
+      await Promise.all(Array.from({ length: Math.min(concurrency, videoAssets.length) }, () => worker()))
+    } finally {
+      if (updatedAnyPoster) {
+        queueProjectPosterSave(projectPath)
+      }
       get().clearMediaPreparation()
     }
   },

--- a/src/stores/assetsStore.js
+++ b/src/stores/assetsStore.js
@@ -562,28 +562,17 @@ export const useAssetsStore = create(
       })
     }
     
-    const videoAssetCount = assetsWithUrls.filter((asset) => asset?.type === 'video').length
-    const willLoadSprites = typeof projectHandle === 'string' && videoAssetCount > 0
     const nextState = {
       assets: assetsWithUrls,
       assetCounter: (projectAssets?.length || 0) + 1,
-      mediaPreparation: willLoadSprites
-        ? {
-            active: true,
-            phase: 'sprites',
-            label: 'Loading video thumbnails...',
-            completed: 0,
-            total: videoAssetCount,
-            critical: false,
-          }
-        : {
-            active: false,
-            phase: 'idle',
-            label: '',
-            completed: 0,
-            total: 0,
-            critical: false,
-          },
+      mediaPreparation: {
+        active: false,
+        phase: 'idle',
+        label: '',
+        completed: 0,
+        total: 0,
+        critical: false,
+      },
     }
     // Restore folder structure from project file so folders persist across sessions
     if (Array.isArray(projectFolders)) {

--- a/src/stores/assetsStore.js
+++ b/src/stores/assetsStore.js
@@ -1,6 +1,24 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
+const SPRITE_GENERATION_CONCURRENCY = 2
+let activeSpriteGenerationCount = 0
+const pendingSpriteGenerationQueue = []
+
+const runWithSpriteGenerationSlot = async (task) => {
+  if (activeSpriteGenerationCount >= SPRITE_GENERATION_CONCURRENCY) {
+    await new Promise((resolve) => pendingSpriteGenerationQueue.push(resolve))
+  }
+  activeSpriteGenerationCount += 1
+  try {
+    return await task()
+  } finally {
+    activeSpriteGenerationCount = Math.max(0, activeSpriteGenerationCount - 1)
+    const next = pendingSpriteGenerationQueue.shift()
+    if (next) next()
+  }
+}
+
 /**
  * Store for managing generated and imported assets
  * Persisted to localStorage for data survival across refreshes
@@ -661,8 +679,9 @@ export const useAssetsStore = create(
     try {
       const { generateThumbnailSprite, saveSpriteToProject } = await import('../services/thumbnailSprites')
       
-      // Generate sprite
-      const result = await generateThumbnailSprite(asset.url, asset.duration || 5)
+      // Generate sprite. This uses a hidden video element and canvas seeks,
+      // so keep generation bounded across imports/manual actions.
+      const result = await runWithSpriteGenerationSlot(() => generateThumbnailSprite(asset.url, asset.duration || 5))
       if (!result) {
         throw new Error('Failed to generate sprite')
       }
@@ -706,55 +725,80 @@ export const useAssetsStore = create(
   },
 
   /**
-   * Load sprites for all video assets from project
+   * Load saved thumbnail sprites for video assets without flooding the renderer.
+   * Startup intentionally does not call this; use it for explicit/on-demand
+   * warming where bounded background work is acceptable.
    * @param {string} projectPath - Project directory path
+   * @param {object} options - { concurrency?: number, limit?: number, assetIds?: string[] }
    */
-  loadSpritesFromProject: async (projectPath) => {
+  loadSpritesFromProject: async (projectPath, options = {}) => {
     if (!projectPath) return
 
-    const { loadSpriteFromProject } = await import('../services/thumbnailSprites')
+    const { loadSpriteFromProject, loadSpriteIndex } = await import('../services/thumbnailSprites')
+    const spriteIndex = await loadSpriteIndex(projectPath)
     const state = get()
-    
-    const videoAssets = state.assets.filter(a => a.type === 'video')
+    const targetIds = Array.isArray(options.assetIds) && options.assetIds.length > 0
+      ? new Set(options.assetIds)
+      : null
+    const limit = Number.isFinite(Number(options.limit)) && Number(options.limit) > 0
+      ? Math.floor(Number(options.limit))
+      : null
+    const concurrency = Math.max(1, Math.min(4, Math.floor(Number(options.concurrency) || 2)))
+    const videoAssets = state.assets
+      .filter((asset) => asset?.type === 'video' && (!targetIds || targetIds.has(asset.id)))
+      .slice(0, limit || undefined)
+
     if (videoAssets.length === 0) {
       get().clearMediaPreparation()
       return
     }
 
-    set({
-      mediaPreparation: {
-        active: true,
-        phase: 'sprites',
-        label: 'Loading video thumbnails...',
-        completed: 0,
-        total: videoAssets.length,
-        critical: false,
-      },
-    })
-    
-    for (const [index, asset] of videoAssets.entries()) {
+    let completed = 0
+    const updateProgress = () => {
+      set({
+        mediaPreparation: {
+          active: true,
+          phase: 'sprites',
+          label: `Loading video thumbnails (${concurrency} at a time)...`,
+          completed,
+          total: videoAssets.length,
+          critical: false,
+        },
+      })
+    }
+    updateProgress()
+
+    let cursor = 0
+    const loadOne = async (asset) => {
       try {
-        const sprite = await loadSpriteFromProject(projectPath, asset.id)
+        const sprite = await loadSpriteFromProject(projectPath, asset.id, spriteIndex)
         if (sprite) {
           get().updateAssetSprite(asset.id, sprite.spriteData)
           console.log(`Loaded sprite for ${asset.name}`)
         }
       } catch (err) {
-        // Sprite might not exist yet, that's OK
+        // Sprite might not exist yet, that's OK.
       } finally {
-        set({
-          mediaPreparation: {
-            active: true,
-            phase: 'sprites',
-            label: 'Loading video thumbnails...',
-            completed: index + 1,
-            total: videoAssets.length,
-            critical: false,
-          },
-        })
+        completed += 1
+        updateProgress()
       }
     }
-    get().clearMediaPreparation()
+
+    const worker = async () => {
+      while (cursor < videoAssets.length) {
+        const asset = videoAssets[cursor]
+        cursor += 1
+        await loadOne(asset)
+        // Yield between items so tab switches and paint are not starved.
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      }
+    }
+
+    try {
+      await Promise.all(Array.from({ length: Math.min(concurrency, videoAssets.length) }, () => worker()))
+    } finally {
+      get().clearMediaPreparation()
+    }
   },
 
   /**

--- a/src/stores/assetsStore.js
+++ b/src/stores/assetsStore.js
@@ -190,8 +190,16 @@ export const useAssetsStore = create(
    * Add a new generated asset
    */
   addAsset: (asset) => {
+    const buildUniqueAssetId = () => {
+      const prefix = `asset_${Date.now()}`
+      let candidate = `${prefix}_${Math.random().toString(36).slice(2, 8)}`
+      while (get().assets.some((entry) => entry?.id === candidate)) {
+        candidate = `${prefix}_${Math.random().toString(36).slice(2, 8)}`
+      }
+      return candidate
+    }
     const newAsset = {
-      id: Date.now().toString(),
+      id: buildUniqueAssetId(),
       createdAt: new Date().toISOString(),
       ...asset
     }

--- a/src/stores/projectStore.js
+++ b/src/stores/projectStore.js
@@ -300,41 +300,9 @@ export const useProjectStore = create(
           if (storedProject) {
             const isValid = await verifyPermission(storedProject)
             if (isValid) {
-              // Load project data
               const projectData = await loadProjectFromFile(storedProject)
               if (projectData) {
-                // Get the current/first timeline
-                const currentTimelineId = projectData.currentTimelineId || projectData.timelines?.[0]?.id
-                const currentTimeline = projectData.timelines?.find(t => t.id === currentTimelineId) || projectData.timelines?.[0]
-                
-                // Load timeline data (normalize clip timebases with asset fps)
-                if (currentTimeline) {
-                  const timelineFps = currentTimeline?.fps || projectData?.settings?.fps || 24
-                  useTimelineStore.getState().loadFromProject(currentTimeline, projectData.assets || [], timelineFps)
-                }
-                
-                // Regenerate asset URLs from project files; restore folder structure
-                if (projectData.assets) {
-                  await useAssetsStore.getState().loadFromProject(
-                    projectData.assets,
-                    storedProject,
-                    projectData.folders,
-                    projectData.folderCounter
-                  )
-                }
-                
-                // Load thumbnail sprites in background (Electron only)
-                if (typeof storedProject === 'string') {
-                  useAssetsStore.getState().loadSpritesFromProject(storedProject).catch(err => {
-                    console.warn('Failed to load sprites:', err)
-                  })
-                }
-                
-                set({
-                  currentProject: projectData,
-                  currentProjectHandle: storedProject,
-                  currentTimelineId: currentTimelineId,
-                })
+                await hydrateOpenedProjectSession(storedProject, projectData, set)
               }
             }
           }

--- a/src/stores/projectStore.js
+++ b/src/stores/projectStore.js
@@ -163,11 +163,11 @@ const hydrateOpenedProjectSession = async (projectHandleOrPath, rawProjectData, 
     projectData.folderCounter
   )
 
-  if (typeof projectHandleOrPath === 'string') {
-    useAssetsStore.getState().loadSpritesFromProject(projectHandleOrPath).catch((err) => {
-      console.warn('Failed to load sprites:', err)
-    })
-  }
+  // Do not eagerly load every saved video thumbnail sprite on project open.
+  // Large projects can contain hundreds of videos; walking all thumbnail
+  // metadata here blocks startup and can make Electron appear as a black
+  // screen. Thumbnails are loaded/generated on demand from the asset browser
+  // and timeline paths instead.
 
   const recentProject = {
     name: projectData.name,


### PR DESCRIPTION
This branch replaces the old row-first cast entry flow in Music Video Easy Mode with a guided People wizard for creating and editing cast references.

**What changed**

- Replaced Add Person row insertion with a modal wizard in the Music Video People step.
- Added support for:entering name, slug, and role
- picking an existing image as the person reference
- generating a new portrait image
- generating a character sheet from the selected/generated image
- editing existing people through the same wizard flow
- Added workflow-aware gating so portrait and character-sheet generation are only available when the required workflows exist.
- Added People-wizard job metadata handling in generation flow so generated portrait/sheet assets can be tracked back to the wizard session.
- Added automatic post-processing for multi-angle character-sheet generation so the final combined sheet is created and used as the person reference.
- Added safer generated asset IDs to avoid collisions during burst asset creation, especially in the character-sheet flow.

**Behavior changes**

The People step is now wizard-driven instead of manual row creation first.
Saving from the wizard can now use:

- an existing project image
- a newly generated portrait
- a generated character sheet

Character-sheet generation is now integrated into the queue flow instead of depending on a separate manual follow-up action.

**Files changed**

`src/components/generate/MusicVideoEasyMode.jsx`
`src/components/GenerateWorkspace.jsx`
`src/stores/assetsStore.js`
