### PR TITLE
Fill Gap (FLF2V) - generate video between two clips using Wan 2.2 14B

### DIFF
--- a/docs/FLF2V_HANDOFF.md
+++ b/docs/FLF2V_HANDOFF.md
@@ -1,0 +1,606 @@
+
+# Feature: Right-Click "Fill Gap (FLF2V)" on Timeline
+
+## Goal
+
+In ComfyStudio's timeline, when there is a gap between two clips on the same
+video track, right-clicking that gap should show a context menu item
+"Fill Gap (FLF2V)". Selecting it must:
+
+1. Capture the **last frame** of the clip immediately before the gap.
+2. Capture the **first frame** of the clip immediately after the gap.
+3. Send both frames to the Generate workspace, pre-selecting a local Wan 2.2
+   14B First-Last-Frame-to-Video (FLF2V) workflow, with the generation
+   length pre-filled to match the gap duration.
+4. After generation completes, insert the resulting video clip directly into
+   the gap on the same track, replacing the gap.
+
+This must reuse existing app architecture, not invent a new one. The codebase
+already has every primitive needed except the FLF2V workflow itself and the
+gap-specific UI wiring. Do not build a parallel system.
+
+## Repo
+
+Clone fresh into the current folder (where this file lives):
+
+```bash
+git clone https://github.com/JaimeIsMe/comfystudio.git
+cd comfystudio
+npm install
+```
+
+Work on a branch:
+
+```bash
+git checkout -b feature/fill-gap-flf2v
+```
+
+## Relevant existing architecture (read these files first, in this order)
+
+1. `src/stores/timelineStore.js` — clip/gap/track state. Search for
+   `getTrackGapAtTime`-style logic (it actually lives in `Timeline.jsx`, see
+   below) and `addClip`, `removeClip`/gap-closing helpers.
+2. `src/components/Timeline.jsx` — this is the largest file and owns:
+   - `getTrackGapAtTime(trackId, time)` (~line 796): returns
+     `{ trackId, startTime, endTime }` for the gap at a given time on a
+     track, or `null`. This is the function to call to find the gap's clip
+     neighbors.
+   - `selectedGap`, `selectGap`, `rippleDeleteSelectedGap` — gaps are already
+     first-class selectable timeline objects.
+   - `handleTrackLaneContextMenu` (~line 871) — right-click handler for
+     empty/lane space, already calls `getTrackGapAtTime` to detect if the
+     click landed on a gap. Currently it does NOT open a context menu for
+     gaps (only sets up lane pointer/selection state) — this needs to be
+     extended to show a menu with a "Fill Gap (FLF2V)" action when a gap is
+     right-clicked.
+   - `handleClipContextMenu` / `clipContextMenu` state / `handleContextMenuAction`
+     (~lines 3200-3360) — this is the existing pattern for a right-click
+     context menu with actions on a clip. Model the new gap context menu on
+     this exact pattern (local `gapContextMenu` state: `{ x, y, gap }`,
+     a ref, `useViewportClampedPosition`, click-outside-to-close effect, and
+     a render block near where `clipContextMenu` is rendered, ~line 6414).
+3. `src/utils/captureTimelineFrame.js` — already has
+   `getTopmostVideoOrImageClipAtTime(time)` and `getSourceTimeForClip(clip, timelineTime)`
+   plus a `renderTimelineCompositeStill(time, canvas, width, height)` function
+   that rasterizes the frame at a given timeline time to a canvas. This is
+   the exact utility to call twice: once at `gap.startTime - epsilon`
+   (last frame of the clip before) and once at `gap.endTime + epsilon`
+   (first frame of the clip after). Read the full file before using it,
+   it has more helpers below the part already shown.
+4. `src/stores/frameForAIStore.js` — a zustand store holding a single
+   `{ blobUrl, file, mode }` frame object consumed by Generate workspace.
+   Currently only supports one frame (`mode: 'extend' | 'keyframe'`). This
+   store needs a new shape to carry TWO frames for FLF2V — do not break the
+   existing single-frame consumers (`PreviewPanel.jsx`,
+   `GenerateWorkspace.jsx`). Recommended: add a new mode `'flf2v'` and allow
+   the stored object to optionally include `startFrame` and `endFrame`
+   (each `{ blobUrl, file }`), and a `targetDurationSeconds` field for the
+   gap length. Keep backward compatibility with the existing single-frame
+   shape used by `extend`/`keyframe` modes.
+5. `src/components/PreviewPanel.jsx` (~line 261) — existing example of
+   capturing a still frame and calling `setFrameForAI` from the preview
+   panel's own context menu. Read this end to end as the reference
+   implementation for "capture frame, push to store, switch tabs."
+6. `src/components/GenerateWorkspace.jsx` (~line 3479-3510) — consumes
+   `frameForAI` via a `useEffect` that does:
+   ```js
+   useEffect(() => {
+     if (frameForAI) {
+       setCategory('video')
+       setWorkflowId('wan22-i2v')
+       setFormError(null)
+     }
+   }, [frameForAI?.blobUrl])
+   ```
+   This needs a new branch: if `frameForAI.mode === 'flf2v'`, set
+   `setWorkflowId('wan22-flf2v')` (the new workflow id you are registering,
+   see below) instead of `'wan22-i2v'`, and pre-populate the
+   `firstFrameAsset` / `lastFrameAsset` / `duration` form fields from
+   `frameForAI.startFrame`, `frameForAI.endFrame`, and
+   `frameForAI.targetDurationSeconds`. Find how `wan22-i2v`'s single frame
+   currently gets attached to its `image`-type field for the same effect, and
+   mirror that for two fields instead of one.
+   Also find (search this file for `frameForAI` near line 11430) the second
+   usage of `useFrameForAIStore.getState().frame` — that is likely where the
+   captured frame is actually converted into a usable asset/file for the
+   workflow's input field. Trace this carefully; the new FLF2V path must do
+   the same asset-registration step for both frames.
+7. `src/config/workflowRegistry.js` — `BUILTIN_WORKFLOWS` array. Already
+   contains a cloud FLF2V entry for reference:
+   ```js
+   { id: 'seedance2-flf2v', label: 'First/Last Frame to Video (Seedance 2.0)', category: 'video', needsImage: false, description: 'Cloud first-frame/last-frame video with ByteDance Seedance 2.0', file: 'api_seedance2_0_flf2v.json' },
+   ```
+   and the existing local Wan 2.2 i2v entry:
+   ```js
+   { id: 'wan22-i2v', label: 'Image to Video (WAN 2.2)', category: 'video', needsImage: true, description: 'Animate an image into video', file: 'video_wan2_2_14B_i2v.json' },
+   ```
+   Add a new entry, `wan22-flf2v`, modeled on these two, pointing at a new
+   bundled workflow JSON file `video_wan2_2_14B_flf2v.json` (see "Workflow
+   JSON" section below). `needsImage` should be `false` (it needs two
+   images, not the single generic "image" the form system expects for
+   `needsImage: true` workflows — follow the same pattern Seedance's FLF2V
+   entry uses).
+8. `src/config/generateWorkflowCatalog.js` — has an existing
+   `firstLastFrameVideoFields` schema (~line 96) already built for Seedance's
+   cloud FLF2V workflow:
+   ```js
+   const firstLastFrameVideoFields = Object.freeze([
+     field('firstFrameAsset', { label: 'First frame', type: 'assetSelect', assetType: 'image', required: true, helper: '...' }),
+     field('lastFrameAsset', { label: 'Last frame', type: 'assetSelect', assetType: 'image', required: true, helper: '...' }),
+     field('prompt', { label: 'Prompt', type: 'textarea' }),
+     field('duration', { label: 'Duration', type: 'duration' }),
+     field('resolution', { label: 'Resolution', type: 'resolution' }),
+     field('seed', { label: 'Seed', type: 'seed' }),
+   ])
+   ```
+   Reuse this exact `firstLastFrameVideoFields` array for the new catalog
+   entry (do not duplicate it into a near-identical local-only variant
+   unless the local Wan workflow truly needs different fields — check
+   whether Wan 2.2 FLF2V needs a `clip_vision` toggle field; if so, extend
+   `firstLastFrameVideoFields` with an optional field rather than forking
+   it). Add a new catalog object modeled exactly on the existing
+   `wan22-i2v` entry (local, route: 'local', provider: 'Local',
+   runtimeLabel: '24GB+ recommended') but with `id`/`workflowId`:
+   `'wan22-flf2v'`, `fields: firstLastFrameVideoFields`, and an appropriate
+   `title`/`description`/`tags` (include `'flf2v'`, `'first frame'`,
+   `'last frame'`, `'wan'`, `'local'`).
+
+## Workflow JSON to add
+
+`public/workflows/video_wan2_2_14B_flf2v.json`
+
+This repo already ships `public/workflows/video_wan2_2_14B_i2v.json` and
+`video_wan2_2_14B_t2v.json` as references for the ComfyUI API-format JSON
+structure this app expects (graph of nodes with class_type, inputs, widget
+values — NOT the UI-format workflow export). Open
+`video_wan2_2_14B_i2v.json` first to learn the exact node graph shape ComfyUI
+desktop already had loaded.
+
+The new FLF2V json must use the `WanFirstLastFrameToVideo` node
+(`comfy_extras/nodes_wan.py` in a standard ComfyUI install — already
+confirmed present, no custom node required) in place of whatever node
+`video_wan2_2_14B_i2v.json` uses for single-image conditioning. Inputs to
+wire: `positive`, `negative`, `vae`, `width`, `height`, `length`,
+`batch_size`, optional `start_image`/`end_image` (wire these from two
+`LoadImage`-equivalent input nodes), optional `clip_vision_start_image`/
+`clip_vision_end_image`.
+
+The exact safest approach: take the already-confirmed-working FLF2V workflow
+the user built themselves locally in ComfyUI (exported via
+"Save (API Format)" from the ComfyUI canvas) and use that JSON verbatim
+as `video_wan2_2_14B_flf2v.json`, only renaming/aliasing input node titles if
+needed so this app's existing input-mapping logic (used for `wan22-i2v`,
+look at how that workflow's JSON marks its image input node so the app knows
+where to inject the uploaded image — likely a `"title"` or `"_meta"` field
+on the relevant node) can find and set `start_image` / `end_image` /
+`length` programmatically. Locate this convention by diffing
+`video_wan2_2_14B_i2v.json` against how `wan22-i2v`'s `needsImage: true`
+field gets consumed in `comfyWorkflowGraph.js` or `comfyui.js`
+(`grep -n "needsImage\|injectImage\|setNodeInput" src/services/comfyWorkflowGraph.js src/services/comfyui.js`)
+before writing the new JSON, so the node titling matches what the input-
+injection code expects.
+
+## Gap fill flow — new code
+
+### 1. Gap context menu (`Timeline.jsx`)
+
+- Add `const [gapContextMenu, setGapContextMenu] = useState(null) // { x, y, gap }`
+  alongside the existing `clipContextMenu` state.
+- In `handleTrackLaneContextMenu`, when `getTrackGapAtTime` returns a real
+  gap (duration > 0.001s) on right-click, call `e.preventDefault()` and
+  `setGapContextMenu({ x: e.clientX, y: e.clientY, gap })` instead of (or in
+  addition to) the current lane-pointer-state logic. Follow the exact
+  click-outside-closes and viewport-clamped-position pattern already used
+  for `clipContextMenu`.
+- Render a small menu with one action: "Fill Gap (FLF2V)". Disable/hide it
+  if either neighboring clip is not a video/image clip (audio-only gaps
+  should not show this action).
+
+### 2. Frame capture on action click
+
+When "Fill Gap (FLF2V)" is clicked, with `gap = { trackId, startTime, endTime }`:
+
+```js
+const EPS = 1 / timelineFps // one frame, avoid landing exactly on the boundary clip's edge case
+const lastFrameTime = gap.startTime - EPS
+const firstFrameTime = gap.endTime + EPS
+```
+
+Use `renderTimelineCompositeStill` (or the single-clip variant if a
+non-composited single-clip capture is more correct here — check whether
+`captureTimelineFrame.js` exports a clip-only capture helper as well as the
+composite one) at both times to get two canvases/blobs. Convert each to a
+`File`/`blobUrl` the same way `PreviewPanel.jsx`'s existing
+"capture frame for AI" action does it (read that code path fully — it
+already solves canvas-to-blob-to-File).
+
+### 3. Extend `frameForAIStore.js`
+
+Add support for a two-frame payload without breaking existing single-frame
+consumers:
+
+```js
+setFrame: (frame) => set({ frame }),
+```
+
+Frame shape for the new mode:
+
+```js
+{
+  mode: 'flf2v',
+  startFrame: { blobUrl, file },
+  endFrame: { blobUrl, file },
+  targetDurationSeconds: gap.endTime - gap.startTime,
+  targetTrackId: gap.trackId,
+  targetGapStartTime: gap.startTime, // needed later to know where to insert the result
+}
+```
+
+Call `useFrameForAIStore.getState().setFrame(...)` with this shape from the
+new gap-fill handler in `Timeline.jsx`, then switch the active right panel /
+tab to Generate (find how `PreviewPanel.jsx` switches tabs after capturing a
+frame for AI — likely a prop callback or a UI store action — and reuse it).
+
+### 4. Consume the two-frame mode in `GenerateWorkspace.jsx`
+
+In the existing effect at ~line 3479:
+
+```js
+useEffect(() => {
+  if (!frameForAI) return
+  if (frameForAI.mode === 'flf2v') {
+    setCategory('video')
+    setWorkflowId('wan22-flf2v')
+    // populate firstFrameAsset / lastFrameAsset / duration form fields here,
+    // following whatever pattern the existing single-image branch below uses
+    // to turn frameForAI.file into a usable assetSelect value.
+    setFormError(null)
+    return
+  }
+  setCategory('video')
+  setWorkflowId('wan22-i2v')
+  setFormError(null)
+}, [frameForAI?.blobUrl, frameForAI?.mode])
+```
+
+Trace exactly how the existing single-frame branch sets the `image` field's
+form value from `frameForAI.file` (it likely registers the file as a
+temporary asset via `addAsset` from `assetsStore.js`, then sets the field
+value to that new asset's id). Do this twice — once for `startFrame` into
+`firstFrameAsset`, once for `endFrame` into `lastFrameAsset` — and set the
+`duration` field from `frameForAI.targetDurationSeconds`.
+
+### 5. Insert the result back into the gap
+
+After the FLF2V generation completes and the user accepts/queues the output
+(follow whatever existing "send generated video to timeline" action already
+exists for other local video workflows — search `GenerateWorkspace.jsx` for
+`timelineAddClip` usage), the resulting clip should NOT just be appended to
+the timeline like a normal generation. It must be inserted with
+`startTime: frameForAI.targetGapStartTime` on `frameForAI.targetTrackId`,
+replacing the gap exactly. Check `timelineAddClip`'s signature in
+`timelineStore.js` for how to specify an explicit `trackId` and `startTime`
+rather than appending at the playhead. If the generated clip's duration
+doesn't exactly match `targetDurationSeconds` (likely, since Wan generates in
+fixed frame-count chunks), trim it to fit or leave a residual gap/overlap and
+warn the user in a toast/notification rather than silently breaking the
+timeline.
+
+After successful insertion, call `useFrameForAIStore.getState().clearFrame()`
+to release the blob URLs (existing store already does `URL.revokeObjectURL`
+in `clearFrame`).
+
+## Build
+
+After implementation, build the Electron app for Linux:
+
+```bash
+npm run build
+npm run electron:build:linux
+```
+
+Artifacts land in `release/`. If Docker is preferred (per the repo's own
+docs) for a clean native Linux build instead of the host toolchain:
+
+```bash
+./scripts/docker-build-linux.sh
+```
+
+## Acceptance criteria
+
+- Right-clicking a gap between two video clips on the same track shows a
+  context menu with "Fill Gap (FLF2V)" (and only that gap-fill action — do
+  not add unrelated menu items).
+- Clicking it captures correct last/first frames from the two neighboring
+  clips (verify visually against the actual frames, not black/blank
+  captures).
+- Generate workspace opens already configured: video category, the new
+  `wan22-flf2v` workflow selected, both frame fields populated, duration
+  field matching the gap length.
+- Running generation produces a video and, once accepted, that video is
+  inserted exactly into the original gap's position and track — no
+  duplicate clips, no leftover gap markers, no shifted neighboring clips.
+- Existing single-frame "extend"/"keyframe" flows (`PreviewPanel.jsx` →
+  `wan22-i2v`) still work unmodified.
+- `npm run electron:build:linux` succeeds and produces a runnable AppImage
+  or `.deb` in `release/`.
+---
+
+## Current State (Handoff Notes — 2026-06-19)
+
+Branch: `feature/fill-gap-flf2v` in `/home/y/.App/ComfyStudio/comfystudio/`
+Latest commit: `c14154b fix(flf2v): fall back to ffmpeg-static via IPC for HEVC/unsupported codecs`
+
+### What works (verified end-to-end)
+
+Right-click on a gap between two video clips on the timeline → "Fill Gap (FLF2V)" →
+- captures the last frame of the clip before the gap (single-clip capture, robust against HEVC/AV1/etc. via ffmpeg fallback)
+- captures the first frame of the clip after the gap
+- dispatches a frame payload to the Generate workspace where the bundled Wan 2.2 14B FLF2V workflow is pre-selected and a self-contained "Flf2vDraftCard" shows the previews + form
+- user clicks "Queue Video" → frames upload to ComfyUI, prompt is queued with the form's width/height/fps/duration + prompt + negative prompt, polled to completion, downloaded
+- result is saved into the project's `assets/video/` via `importAsset`, gets `absolutePath` + `url` + duration/fps/width/height set, `generateAssetPoster` + `generateAssetSprite` fire for thumbnail/scrubber, then inserted into the timeline gap with `timelineStore.addClip` at `targetGapStartTime` on `targetTrackId`
+- after success the card switches the tab back to editor so the user lands on the timeline and sees the freshly-inserted clip
+- the card stays open (no auto-clear) so the user can re-queue with different params if the output is wrong
+
+The "Change workflow" button on the card opens an inline popover with the bundled profile + an "Import JSON file..." option (auto-detects the FLF2V schema from the imported JSON's node types). Selection persists to localStorage so reopening the app keeps the same workflow.
+
+### Bug fixes applied along the way (final commit history)
+
+| commit | what it fixed |
+| --- | --- |
+| `a4b78b2` | initial FLF2V feature (right-click → fill → splice) |
+| `ee9ebed` | reset per-job state on new frameForAI so 2nd fill wasn't stuck in previous run's "Done" |
+| `72b3005` | state-ref for gapContextMenu inside handler + diagnostic logging |
+| `489a1e9` | capture each neighbor clip directly instead of compositing the full timeline (the composite renderer returns false when the requested time lands past a clip edge) |
+| `df660bc` | URL-encode file:// paths before setting as video/image src |
+| `fa9a9f2` | load clip media via fetch + Blob URL (bypasses Chromium file:// encoding quirks) |
+| `c14154b` | fall back to ffmpeg-static via IPC for HEVC/unsupported codecs |
+
+### Root causes (in order they were diagnosed)
+
+1. **prompt_id extraction always falsy** — `comfyui.queuePrompt()` returns the prompt_id string directly, not `{ prompt_id }`. Fixed: `const promptId = await comfyui.queuePrompt(workflow)`.
+2. **Swapped start/end frame wiring** — WanFirstLastFrameToVideo's `start_image` / `end_image` inputs pointed at the wrong LoadImage nodes. Fixed in `wan22Flf2v.js`.
+3. **"No videos" after success** — ComfyUI's `SaveVideo` node reports output under `images` with `animated: [true]`, not `videos`. Fixed: `collectVideoOutputs` checks the `images + animated` path.
+4. **Inserted clip blank in timeline** — `importAsset()` returns an asset with `absolutePath` but no `url` field; `timelineStore.addClip` reads `asset.url` for both source and thumbnail. Fixed: resolved the URL via `getAbsoluteFileUrl(asset.absolutePath)` before calling addClip.
+5. **Inserted clip 5s blank for a 2.5s gap** — same root cause as #4; with proper URL + duration + fps set on the asset, addClip used the real duration.
+6. **No thumbnail generated** — `AssetsPanel`'s import path auto-fires `generateAssetPoster` + `generateAssetSprite` after `importAsset`; Flf2vDraftCard was bypassing that. Fixed by calling both explicitly.
+7. **Tab return to editor on completion** — added a `comfystudio-switch-tab` custom event + a generic handler in `App.jsx`.
+8. **Second gap fill did nothing** — multiple distinct causes, fixed in sequence (see commits ee9ebed, 72b3005, 489a1e9).
+9. **HEVC clip capture failure** — Chromium on Linux has no H.265 decoder; `<video>` element fires `onerror` with `DEMUXER_ERROR_NO_SUPPORTED_STREAMS`. Fixed by adding `media:extractFrame` IPC handler in `electron/main.js` that uses ffmpeg-static to extract a single PNG frame as fallback.
+
+### Key files for the next agent
+
+1. `/home/y/.App/ComfyStudio/comfystudio/src/components/Flf2vDraftCard.jsx` — the submit card (no catalog dependency, reads a profile)
+2. `/home/y/.App/ComfyStudio/comfystudio/src/components/Flf2vWorkflowPicker.jsx` — bundled + import picker
+3. `/home/y/.App/ComfyStudio/comfystudio/src/services/builtinWorkflows/wan22Flf2v.js` — bundled workflow JSON + node ID map (swap start/end fix is in here)
+4. `/home/y/.App/ComfyStudio/comfystudio/src/services/builtinWorkflows/flf2vProfiles.js` — registry + auto-detect for imported JSON
+5. `/home/y/.App/ComfyStudio/comfystudio/src/utils/captureTimelineFrame.js` — `captureGapBoundaryFrames`, `captureSingleClipFrame`, `loadClipSourceAtTime` (with blob URL + ffmpeg fallback), `encodeFileUrl`, `filePathFromFileUrl`
+6. `/home/y/.App/ComfyStudio/comfystudio/src/components/Timeline.jsx` — `handleFillGapFlf2v` (the right-click action), uses state-ref for gapContextMenu
+7. `/home/y/.App/ComfyStudio/comfystudio/electron/main.js` — `media:extractFrame` IPC handler (ffmpeg fallback)
+8. `/home/y/.App/ComfyStudio/comfystudio/electron/preload.js` — exposes `window.electronAPI.extractVideoFrame`
+9. `/home/y/.App/ComfyStudio/comfystudio/src/App.jsx` — `comfystudio-switch-tab` listener (switches the main tab to whatever name is in `event.detail.tab`)
+10. `/home/y/.App/ComfyStudio/comfystudio/src/stores/frameForAIStore.js` — extended with `mode: 'flf2v'` payload shape (startFrame, endFrame, targetDurationSeconds, targetTrackId, targetGapStartTime)
+
+### Fork & PR
+
+- Working repo (fork): https://github.com/asgitcode-tech/comfystudio
+- Original: https://github.com/JaimeIsMe/comfystudio
+- Open a PR back to the original at: https://github.com/JaimeIsMe/comfystudio/compare/main...asgitcode-tech:feature/fill-gap-flf2v?expand=1
+- PR title: `Fill Gap (FLF2V) — generate video between two clips using Wan 2.2 14B`
+- PR body (verbatim):
+
+  ```
+  I pushed my fork with this change, please review:
+  https://github.com/JaimeIsMe/comfystudio/compare/main...asgitcode-tech:feature/fill-gap-flf2v?expand=1
+
+  Adds a right-click "Fill Gap (FLF2V)" action on the timeline. When you
+  right-click the gap between two video clips, it captures the last frame
+  of the clip before and the first frame of the clip after, opens the
+  Generate workspace with the bundled Wan 2.2 14B first/last-frame
+  workflow pre-selected, and splices the resulting video back into the
+  original gap on completion.
+
+  Also removes the quit-time prompt asking whether to stop or leave ComfyUI
+  running — ComfyUI now stays running across ComfyStudio restarts by
+  default.
+
+  Includes a workflow picker so users can switch between bundled and
+  imported FLF2V workflow JSONs (selection persists across restarts).
+
+  14 files changed: 2013+ insertions, 59 deletions.
+  Branch: feature/fill-gap-flf2v
+  ```
+
+### Sanity-check after rebuild
+
+```bash
+# Extract app.asar and verify the ffmpeg fallback + blob URL code is in
+npx --yes @electron/asar extract /opt/ComfyStudio/resources/app.asar /tmp/asar_check
+python3 -c "
+import glob
+txt = open(glob.glob('/tmp/asar_check/dist/assets/index-*.js')[0]).read()
+print('extractVideoFrame:', 'extractVideoFrame' in txt)
+print('DEMUXER_ERROR handled:', 'DEMUXER_ERROR' in txt or 'no supported streams' in txt)
+print('encodeFileUrl present:', 'encodeURIComponent' in txt)
+"
+grep -c 'media:extractFrame' /tmp/asar_check/electron/main.js   # expect 1
+grep -c 'extractVideoFrame' /tmp/asar_check/electron/preload.js   # expect 1
+```
+
+### Build commands (host, no Docker)
+
+```bash
+cd /home/y/.App/ComfyStudio/comfystudio
+npm run build                                    # vite build only
+
+# Electron mirror (if not already running):
+mkdir -p /tmp/electron-mirror/28.3.3
+ln -sf /home/y/Downloads/electron-v28.3.3-linux-x64.zip /tmp/electron-mirror/28.3.3/electron-v28.3.3-linux-x64.zip
+nohup python3 -m http.server 8765 --directory /tmp/electron-mirror &
+# Build:
+ELECTRON_MIRROR="http://127.0.0.1:8765/" npm run electron:build:linux
+
+# Install:
+sudo dpkg -i release/ComfyStudio-0.1.20-linux-amd64.deb
+```
+
+---
+
+## Current State (Handoff Notes — 2026-06-18, superseded by the section above)
+
+Branch: `feature/fill-gap-flf2v` in `/home/y/.App/ComfyStudio/comfystudio/`
+
+### Build artifacts (current)
+
+- `/home/y/.App/ComfyStudio/comfystudio/release/ComfyStudio-0.1.20-linux-amd64.deb`
+- `/home/y/.App/ComfyStudio/comfystudio/release/ComfyStudio-0.1.20-linux-x86_64.AppImage`
+- Install with: `sudo dpkg -i /home/y/.App/ComfyStudio/comfystudio/release/ComfyStudio-0.1.20-linux-amd64.deb`
+- Latest `app.asar` md5: must be re-verified after every build.
+
+### What works
+
+1. **Timeline right-click → "Fill Gap (FLF2V)" context menu** — implemented in `src/components/Timeline.jsx`:
+   - `gapContextMenu` state (x, y, gap), viewport-clamped position
+   - `isGapFillable(gap)` — checks both neighbours are video/image clips
+   - `handleFillGapFlf2v()` — captures `gap.startTime - 1/fps` and `gap.endTime + 1/fps` via `captureTimelineFrameAt`, sets `frameForAI` to mode `'flf2v'`
+   - Dispatches `comfystudio-open-generate-with-frame` (handled in `src/App.jsx` to switch main tab to Generate)
+
+2. **Frame-capture store** — `src/stores/frameForAIStore.js` extended with `mode: 'flf2v'` payload shape:
+   ```js
+   { mode: 'flf2v',
+     startFrame: { blobUrl, file },
+     endFrame:   { blobUrl, file },
+     targetDurationSeconds,
+     targetTrackId,
+     targetGapStartTime }
+   ```
+   `clearFrame()` revokes all blob URLs.
+
+3. **Generate workspace card** — `src/components/Flf2vDraftCard.jsx` (new file, ~430 lines):
+   - Self-contained — does NOT go through the catalog.
+   - Renders two captured-frame previews, gap duration badge, prompt textarea, width/height/seed inputs, **Queue Video** button.
+   - Bundled workflow JSON inline at `src/services/builtinWorkflows/wan22Flf2v.js` (built from the user's tested `▶️ Video FLF.json`).
+
+4. **Submit flow** — at Queue:
+   1. Uploads both frames to ComfyUI via `comfyui.uploadFile()`
+   2. Deep-clones bundled workflow JSON
+   3. Mutates inputs in memory: image filenames, prompt text, negative text, length, fps, seed, filename_prefix
+   4. `comfyui.queuePrompt(workflow)` → `promptId`
+   5. Polls `/history/<promptId>` every 2s
+   6. On done: downloads the output video, registers it as an asset, splices it into the original gap via `timelineStore.addClip(targetTrack.id, newAsset, gap.startTime, fps, {...})`, calls `clearFrameForAI()`.
+
+5. **Quit prompt suppressed** — `electron/main.js` — both `mainWindow.on('close')` and `app.on('before-quit')` now unconditionally `comfyLauncher.detach()` instead of showing the "Stop ComfyUI / Leave ComfyUI / Cancel" dialog. ComfyUI stays running across ComfyStudio restarts.
+
+6. **Models bundled by user** at `/home/y/ComfyUI/models/` — same files the workflow references:
+   - `clip/umt5_xxl_fp8_e4m3fn_scaled.safetensors`
+   - `vae/wan_2.1_vae.safetensors`
+   - `unet/wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors` + `_low_noise_`
+   - `loras/wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors` + `_low_noise_`
+
+### What still does NOT work — current blocker
+
+After clicking **Queue Video**, the new error is:
+
+> `Prompt outputs failed validation Node 94 (CreateVideo) [exception_during_inner_validation] Exception when validating inner node — '-8'`
+
+### Why it fails — root cause history
+
+The bundled workflow at `src/services/builtinWorkflows/wan22Flf2v.js` is **derived from the user's UI workflow `▶️ Video FLF.json`** at `/home/y/ComfyUI/user/default/workflows/▶️ Video FLF.json`. That UI workflow has TWO WanFirstLastFrameToVideo pipelines (A=4-step lightx2v, B=20-step lightx2v) sharing most helper nodes. **Pipeline A is the active one.**
+
+Earlier iterations of the conversion picked the wrong half:
+
+- **First try (broken)**: Picked node 81 (which is WanFLF2V for pipeline B). Node 81 lacked the `width/height/length/batch_size` widget values in the API format, so WanFirstLastFrameToVideo had nothing to render against. **Error**: `KSamplerAdvanced (node 85) — tuple index out of range`.
+
+- **Second try (still broken)**: Switched to node 67 (WanFLF2V for pipeline A, correct choice), but **failed to remap the VAEDecode node**. The user's pipeline A actually uses VAEDecode `node 8` (canonical 87) — not node 85 (which is the pipeline B VAEDecode). The CreateVideo `node 60` (canonical 94) was wired to receive images from `node 8`, but the conversion kept `images: ["8", 0]` (literal original ID) instead of remapping to `"87", 0`. So at submit time, ComfyUI received `images: ["8", 0]` referring to a node that doesn't exist in the bundled graph. **Current error**: `CreateVideo (node 94) — '-8'`.
+
+### The fix that needs to land
+
+The bundled workflow at `src/services/builtinWorkflows/wan22Flf2v.js` must have CreateVideo's `images` input remapped from `["8", 0]` to `["87", 0]`, AND the bundled JSON must include node 87 (VAEDecode) wired from KSampler 85's `samples` output and VAELoader 90's `vae` output.
+
+The current bundled JSON file (`src/services/builtinWorkflows/wan22Flf2v.js`) is regenerated by the Python conversion script at `/tmp/convert.py` (the canonical-remap version that produces the correct graph). After regenerating, the inline export in the JS module is `export const WAN22_FLF2V_WORKFLOW_JSON = { ... }` followed by `export const WAN22_FLF2V_NODES = { ... VAE_DECODE: '87', ... }`.
+
+**Verify after build** that node 87 in the bundled JSON has `inputs.samples: ["85", 0]` and `inputs.vae: ["90", 0]`, and node 94 has `inputs.images: ["87", 0]` (NOT `["8", 0]`).
+
+### Files touched by this feature
+
+```
+M src/components/GenerateWorkspace.jsx       # removed catalog wiring, added Flf2vDraftCard import
+M src/components/Timeline.jsx                # added gap context menu + fill handler
+M src/config/generateWorkflowCatalog.js     # removed wan22-flf2v entry
+M src/config/workflowRegistry.js            # removed wan22-flf2v entry
+M src/services/comfyui.js                    # removed modifyWan22FLF2VWorkflow dispatch
+M src/stores/frameForAIStore.js             # extended with flf2v mode
+A src/components/Flf2vDraftCard.jsx         # NEW — self-contained submit card
+A src/services/builtinWorkflows/wan22Flf2v.js  # NEW — bundled workflow JSON
+M electron/main.js                           # removed quit prompt
+M public/workflows/video_wan2_2_14B_flf2v.json  # still exists, unused
+```
+
+### Build commands (host, no Docker)
+
+```bash
+cd /home/y/.App/ComfyStudio/comfystudio
+npm run build                                    # vite build only
+
+# Full electron build (needs local mirror at 8765 serving electron-v28.3.3-linux-x64.zip)
+# Mirror:
+mkdir -p /tmp/electron-mirror/28.3.3
+ln -sf /home/y/Downloads/electron-v28.3.3-linux-x64.zip \
+       /tmp/electron-mirror/28.3.3/electron-v28.3.3-linux-x64.zip
+nohup python3 -m http.server 8765 --directory /tmp/electron-mirror &
+# Build:
+ELECTRON_MIRROR="http://127.0.0.1:8765/" npm run electron:build:linux
+
+# Install:
+sudo dpkg -i release/ComfyStudio-0.1.20-linux-amd64.deb
+# Then quit ComfyStudio if open and relaunch.
+```
+
+### Key files for next agent to read
+
+1. `/home/y/.App/ComfyStudio/comfystudio/src/components/Flf2vDraftCard.jsx` — the submit card (no catalog dependency)
+2. `/home/y/.App/ComfyStudio/comfystudio/src/services/builtinWorkflows/wan22Flf2v.js` — bundled workflow JSON
+3. `/home/y/.App/ComfyStudio/comfystudio/src/components/Timeline.jsx` (gap context menu + `handleFillGapFlf2v` ~line 945)
+4. `/home/y/.App/ComfyStudio/comfystudio/src/stores/frameForAIStore.js` (flf2v payload)
+5. `/home/y/ComfyUI/user/default/workflows/▶️ Video FLF.json` — source UI workflow (DO NOT modify)
+
+### Sanity-check command after fix
+
+```bash
+# Extract app.asar and verify node 87 has the right chain
+python3 -c "
+import re, json
+with open('/tmp/asar5/asar/dist/assets/index-*.js'.replace('*','XX')) as f: pass
+"
+# (extract first, then grep)
+npx --yes @electron/asar extract /opt/ComfyStudio/resources/app.asar /tmp/asar5
+python3 <<'PY'
+import re, json, glob
+for f in glob.glob('/tmp/asar5/asar/dist/assets/index-*.js'):
+    txt = open(f).read()
+    def extract(nid):
+        i = txt.find(f'"{nid}":')
+        if i < 0: return None
+        j = txt.find('{', i)
+        depth = 0
+        while j < len(txt):
+            if txt[j] == '{': depth += 1
+            elif txt[j] == '}':
+                depth -= 1
+                if depth == 0: return txt[i:j+1]
+            j += 1
+    for nid in ('85', '87', '94', '98'):
+        b = extract(nid)
+        if b: print(f'== {nid} =='); print(b[:200])
+PY
+# Expect: 87 has samples:["85",0], vae:["90",0]
+# Expect: 94 has images:["87",0]
+# Expect: 85 latent_image:["86",0]
+```
+
+### What the next agent should do
+
+1. Re-run the conversion with the correct VAEDecode mapping (`8: 87` not `8: 85`).
+2. Verify CreateVideo 94's `images` field is `["87", 0]` after remap.
+3. If still broken, dump the full submitted workflow JSON from the dev console and compare it byte-for-byte against the user's working ComfyUI workflow (exported via ComfyUI's "Save (API Format)" → compare with `/home/y/ComfyUI/user/default/workflows/▶️ Video FLF.json`).
+4. The user's UI workflow **works** when loaded directly into ComfyUI. Anything different in the bundled JSON is the bug.

--- a/electron/main.js
+++ b/electron/main.js
@@ -2291,35 +2291,20 @@ async function createWindow() {
     const ownsRunning = state.ownership === 'ours' && (state.state === 'running' || state.state === 'starting')
     if (!ownsRunning) return
 
+    // User preference: always leave ComfyUI running on quit. No prompt,
+    // no shutdown — just detach ownership so the next ComfyStudio launch
+    // can re-attach to it without a cold boot.
     event.preventDefault()
+    launcherQuitConfirmed = true
     try {
-      const choice = await dialog.showMessageBox(mainWindow, {
-        type: 'question',
-        buttons: ['Stop ComfyUI & quit', 'Leave ComfyUI running', 'Cancel'],
-        defaultId: 0,
-        cancelId: 2,
-        title: 'Quit ComfyStudio?',
-        message: 'ComfyUI is still running.',
-        detail: 'ComfyStudio started ComfyUI. Choose what happens to it when you quit.\n\n• Stop ComfyUI & quit — shuts down ComfyUI and cancels any in-flight generation jobs.\n• Leave ComfyUI running — ComfyStudio will quit but ComfyUI stays up. Handy when you\'re just relaunching ComfyStudio and don\'t want to wait for ComfyUI to boot again.',
-      })
-      if (choice.response === 2) return
-      launcherQuitConfirmed = true
-      try {
-        if (choice.response === 1) {
-          await comfyLauncher.detach()
-        } else {
-          await comfyLauncher.shutdown({ confirmStop: true })
-        }
-      } catch (error) {
-        console.warn('[comfyLauncher] shutdown/detach during close failed:', error?.message || error)
-      }
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.close()
-      } else {
-        app.quit()
-      }
+      await comfyLauncher.detach()
     } catch (error) {
-      console.warn('[comfyLauncher] close handler error:', error?.message || error)
+      console.warn('[comfyLauncher] detach during close failed:', error?.message || error)
+    }
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.close()
+    } else {
+      app.quit()
     }
   })
 
@@ -4700,29 +4685,16 @@ app.on('before-quit', async (event) => {
   const ownsRunning = state.ownership === 'ours' && (state.state === 'running' || state.state === 'starting')
   if (!ownsRunning) return
 
+  // User preference: always leave ComfyUI running on quit. No prompt,
+  // no shutdown — just detach ownership so the next ComfyStudio launch
+  // can re-attach to it without a cold boot.
   event.preventDefault()
-  try {
-    const choice = await dialog.showMessageBox(mainWindow && !mainWindow.isDestroyed() ? mainWindow : null, {
-      type: 'question',
-      buttons: ['Stop ComfyUI & quit', 'Leave ComfyUI running', 'Cancel'],
-      defaultId: 0,
-      cancelId: 2,
-      title: 'Quit ComfyStudio?',
-      message: 'ComfyUI is still running.',
-      detail: 'ComfyStudio started ComfyUI. Choose what happens to it when you quit.\n\n• Stop ComfyUI & quit — shuts down ComfyUI and cancels any in-flight generation jobs.\n• Leave ComfyUI running — ComfyStudio will quit but ComfyUI stays up. Handy when you\'re just relaunching ComfyStudio and don\'t want to wait for ComfyUI to boot again.',
-    })
-    if (choice.response === 2) {
-      return
-    }
-    if (choice.response === 1) {
-      await comfyLauncher.detach()
-    } else {
-      await comfyLauncher.shutdown({ confirmStop: true })
-    }
-  } catch (error) {
-    console.warn('[comfyLauncher] before-quit shutdown error:', error?.message || error)
-  }
   launcherQuitConfirmed = true
+  try {
+    await comfyLauncher.detach()
+  } catch (error) {
+    console.warn('[comfyLauncher] detach during before-quit failed:', error?.message || error)
+  }
   app.quit()
 })
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -2291,20 +2291,35 @@ async function createWindow() {
     const ownsRunning = state.ownership === 'ours' && (state.state === 'running' || state.state === 'starting')
     if (!ownsRunning) return
 
-    // User preference: always leave ComfyUI running on quit. No prompt,
-    // no shutdown — just detach ownership so the next ComfyStudio launch
-    // can re-attach to it without a cold boot.
     event.preventDefault()
-    launcherQuitConfirmed = true
     try {
-      await comfyLauncher.detach()
+      const choice = await dialog.showMessageBox(mainWindow, {
+        type: 'question',
+        buttons: ['Stop ComfyUI & quit', 'Leave ComfyUI running', 'Cancel'],
+        defaultId: 0,
+        cancelId: 2,
+        title: 'Quit ComfyStudio?',
+        message: 'ComfyUI is still running.',
+        detail: 'ComfyStudio started ComfyUI. Choose what happens to it when you quit.\n\n• Stop ComfyUI & quit — shuts down ComfyUI and cancels any in-flight generation jobs.\n• Leave ComfyUI running — ComfyStudio will quit but ComfyUI stays up. Handy when you\'re just relaunching ComfyStudio and don\'t want to wait for ComfyUI to boot again.',
+      })
+      if (choice.response === 2) return
+      launcherQuitConfirmed = true
+      try {
+        if (choice.response === 1) {
+          await comfyLauncher.detach()
+        } else {
+          await comfyLauncher.shutdown({ confirmStop: true })
+        }
+      } catch (error) {
+        console.warn('[comfyLauncher] shutdown/detach during close failed:', error?.message || error)
+      }
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.close()
+      } else {
+        app.quit()
+      }
     } catch (error) {
-      console.warn('[comfyLauncher] detach during close failed:', error?.message || error)
-    }
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.close()
-    } else {
-      app.quit()
+      console.warn('[comfyLauncher] close handler error:', error?.message || error)
     }
   })
 
@@ -4726,16 +4741,29 @@ app.on('before-quit', async (event) => {
   const ownsRunning = state.ownership === 'ours' && (state.state === 'running' || state.state === 'starting')
   if (!ownsRunning) return
 
-  // User preference: always leave ComfyUI running on quit. No prompt,
-  // no shutdown — just detach ownership so the next ComfyStudio launch
-  // can re-attach to it without a cold boot.
   event.preventDefault()
-  launcherQuitConfirmed = true
   try {
-    await comfyLauncher.detach()
+    const choice = await dialog.showMessageBox(mainWindow && !mainWindow.isDestroyed() ? mainWindow : null, {
+      type: 'question',
+      buttons: ['Stop ComfyUI & quit', 'Leave ComfyUI running', 'Cancel'],
+      defaultId: 0,
+      cancelId: 2,
+      title: 'Quit ComfyStudio?',
+      message: 'ComfyUI is still running.',
+      detail: 'ComfyStudio started ComfyUI. Choose what happens to it when you quit.\n\n• Stop ComfyUI & quit — shuts down ComfyUI and cancels any in-flight generation jobs.\n• Leave ComfyUI running — ComfyStudio will quit but ComfyUI stays up. Handy when you\'re just relaunching ComfyStudio and don\'t want to wait for ComfyUI to boot again.',
+    })
+    if (choice.response === 2) {
+      return
+    }
+    if (choice.response === 1) {
+      await comfyLauncher.detach()
+    } else {
+      await comfyLauncher.shutdown({ confirmStop: true })
+    }
   } catch (error) {
-    console.warn('[comfyLauncher] detach during before-quit failed:', error?.message || error)
+    console.warn('[comfyLauncher] before-quit shutdown error:', error?.message || error)
   }
+  launcherQuitConfirmed = true
   app.quit()
 })
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -2464,6 +2464,47 @@ ipcMain.handle('fs:readFileAsBuffer', async (event, filePath) => {
   }
 })
 
+// Extract a single frame from a video file as PNG bytes. Used as a
+// fallback when the renderer's <video> element can't decode the
+// file (e.g. HEVC/H.265 on Linux Chromium which has no H.265
+// decoder bundled). Spawns ffmpeg-static so it works for any
+// codec ffmpeg supports without needing per-codec fallback in
+// the renderer.
+ipcMain.handle('media:extractFrame', async (event, { filePath, timeSeconds = 0, width = null, height = null } = {}) => {
+  if (!filePath || typeof filePath !== 'string') {
+    return { success: false, error: 'filePath required' }
+  }
+  if (!ffmpegPath) {
+    return { success: false, error: 'ffmpeg binary not available' }
+  }
+  try {
+    const safeTime = Math.max(0, Number(timeSeconds) || 0)
+    const args = ['-y', '-ss', String(safeTime), '-i', filePath, '-frames:v', '1', '-f', 'image2pipe', '-c:v', 'png']
+    if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+      args.push('-vf', `scale=${Math.round(width)}:${Math.round(height)}`)
+    }
+    args.push('-')
+    const result = await new Promise((resolve) => {
+      const proc = spawn(ffmpegPath, args, { windowsHide: true })
+      const chunks = []
+      let stderr = ''
+      proc.stdout.on('data', (c) => chunks.push(c))
+      proc.stderr.on('data', (c) => { stderr += c.toString() })
+      proc.on('error', (err) => resolve({ success: false, error: err.message }))
+      proc.on('close', (code) => {
+        if (code !== 0) {
+          resolve({ success: false, error: `ffmpeg exited with code ${code}: ${stderr.slice(-400)}` })
+          return
+        }
+        resolve({ success: true, data: Buffer.concat(chunks) })
+      })
+    })
+    return result
+  } catch (err) {
+    return { success: false, error: err.message }
+  }
+})
+
 ipcMain.handle('fs:writeFile', async (event, filePath, data, options = {}) => {
   try {
     // Handle different data types

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -71,6 +71,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
    * @returns {Promise<{success: boolean, data?: ArrayBuffer, error?: string}>}
    */
   readFileAsBuffer: (filePath) => ipcRenderer.invoke('fs:readFileAsBuffer', filePath),
+
+  /**
+   * Extract a single frame from a video file via ffmpeg-static. Returns
+   * PNG bytes as an ArrayBuffer in { success, data } or { success: false, error }.
+   * Used as a fallback when the renderer's <video> element can't decode
+   * the file (e.g. HEVC on Linux Chromium).
+   * @param {{filePath: string, timeSeconds?: number, width?: number, height?: number}} opts
+   * @returns {Promise<{success: boolean, data?: ArrayBuffer, error?: string}>}
+   */
+  extractVideoFrame: (opts) => ipcRenderer.invoke('media:extractFrame', opts),
   
   /**
    * Write a file

--- a/public/workflows/video_wan2_2_14B_flf2v.json
+++ b/public/workflows/video_wan2_2_14B_flf2v.json
@@ -1,0 +1,283 @@
+{
+  "84": {
+    "inputs": {
+      "clip_name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+      "type": "wan",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "85": {
+    "inputs": {
+      "add_noise": "disable",
+      "noise_seed": 0,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 2,
+      "end_at_step": 10000,
+      "return_with_leftover_noise": "disable",
+      "model": [
+        "104",
+        0
+      ],
+      "positive": [
+        "86",
+        0
+      ],
+      "negative": [
+        "86",
+        1
+      ],
+      "latent_image": [
+        "86",
+        2
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": "KSampler (Advanced) 2nd pass"
+    }
+  },
+  "86": {
+    "inputs": {
+      "add_noise": "enable",
+      "noise_seed": 0,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 0,
+      "end_at_step": 2,
+      "return_with_leftover_noise": "enable",
+      "model": [
+        "103",
+        0
+      ],
+      "positive": [
+        "98",
+        0
+      ],
+      "negative": [
+        "98",
+        1
+      ],
+      "latent_image": [
+        "98",
+        2
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": "KSampler (Advanced) 1st pass"
+    }
+  },
+  "87": {
+    "inputs": {
+      "samples": [
+        "85",
+        0
+      ],
+      "vae": [
+        "90",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "89": {
+    "inputs": {
+      "text": "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走",
+      "clip": [
+        "84",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "90": {
+    "inputs": {
+      "vae_name": "wan_2.1_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "93": {
+    "inputs": {
+      "text": "冰晶组成的小猫突然被惊醒，愤怒的它抬头，渐渐长出色彩毛发变成为一个巨兽，像发现危险一样呲牙，瞪大眼睛",
+      "clip": [
+        "84",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "94": {
+    "inputs": {
+      "fps": 16,
+      "images": [
+        "87",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": "Create Video"
+    }
+  },
+  "95": {
+    "inputs": {
+      "unet_name": "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model (High Noise)"
+    }
+  },
+  "96": {
+    "inputs": {
+      "unet_name": "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model (Low Noise)"
+    }
+  },
+  "97": {
+    "inputs": {
+      "image": "video_wan2_2_14B_flf2v_start_image.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Start Frame"
+    }
+  },
+  "971": {
+    "inputs": {
+      "image": "video_wan2_2_14B_flf2v_end_image.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load End Frame"
+    }
+  },
+  "98": {
+    "inputs": {
+      "width": 640,
+      "height": 640,
+      "length": 81,
+      "batch_size": 1,
+      "positive": [
+        "93",
+        0
+      ],
+      "negative": [
+        "89",
+        0
+      ],
+      "vae": [
+        "90",
+        0
+      ],
+      "start_image": [
+        "97",
+        0
+      ],
+      "end_image": [
+        "971",
+        0
+      ]
+    },
+    "class_type": "WanFirstLastFrameToVideo",
+    "_meta": {
+      "title": "WanFirstLastFrameToVideo"
+    }
+  },
+  "101": {
+    "inputs": {
+      "lora_name": "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors",
+      "strength_model": 1,
+      "model": [
+        "95",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly (High)"
+    }
+  },
+  "102": {
+    "inputs": {
+      "lora_name": "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors",
+      "strength_model": 1,
+      "model": [
+        "96",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly (Low)"
+    }
+  },
+  "103": {
+    "inputs": {
+      "shift": 5,
+      "model": [
+        "101",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3 (High)"
+    }
+  },
+  "104": {
+    "inputs": {
+      "shift": 5,
+      "model": [
+        "102",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3 (Low)"
+    }
+  },
+  "108": {
+    "inputs": {
+      "filename_prefix": "video/ComfyStudio_wan22_flf2v",
+      "format": "auto",
+      "codec": "auto",
+      "video-preview": "",
+      "video": [
+        "94",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -230,6 +230,17 @@ function App() {
     return () => window.removeEventListener('comfystudio-open-generate-tab', handler)
   }, [])
 
+  // Generic tab switcher — components can request a specific main tab by
+  // dispatching `comfystudio-switch-tab` with `{ detail: { tab: '<name>' } }`.
+  useEffect(() => {
+    const handler = (e) => {
+      const tab = e?.detail?.tab
+      if (typeof tab === 'string') setMainTab(tab)
+    }
+    window.addEventListener('comfystudio-switch-tab', handler)
+    return () => window.removeEventListener('comfystudio-switch-tab', handler)
+  }, [])
+
   // Allow Generate tab to open ComfyUI directly (used for workflow import guidance).
   useEffect(() => {
     const handler = () => {

--- a/src/components/Flf2vDraftCard.jsx
+++ b/src/components/Flf2vDraftCard.jsx
@@ -53,14 +53,19 @@ export default function Flf2vDraftCard({
   const projectFps = Number.isFinite(Number(timelineFps)) && Number(timelineFps) > 0
     ? Number(timelineFps)
     : 24
-  const projectWidth = Number(currentResolution?.width) || 1280
-  const projectHeight = Number(currentResolution?.height) || 720
+  // Prefer the source clips' native dimensions over project resolution so
+  // the generated video matches what's actually on screen in the gap.
+  const sourceWidth = Number(frameForAI?.sourceWidth) || null
+  const sourceHeight = Number(frameForAI?.sourceHeight) || null
+  const fallbackWidth = Number(currentResolution?.width) || 1280
+  const fallbackHeight = Number(currentResolution?.height) || 720
   const gapDuration = Math.max(0, Number(frameForAI?.targetDurationSeconds) || 0)
 
-  // Form state — defaults come from the project (resolution / fps / gap
-  // duration). User can override any of them before queuing.
-  const [width, setWidth] = useState(alignDim(projectWidth))
-  const [height, setHeight] = useState(alignDim(projectHeight))
+  // Form state — defaults come from the source clips when available, then
+  // project resolution, then 1280×720. User can override any of them
+  // before queuing.
+  const [width, setWidth] = useState(alignDim(sourceWidth || fallbackWidth))
+  const [height, setHeight] = useState(alignDim(sourceHeight || fallbackHeight))
   const [fps, setFps] = useState(projectFps)
   const [duration, setDuration] = useState(round2(gapDuration || 2.5))
   const [prompt, setPrompt] = useState(DEFAULT_PROMPT)
@@ -101,6 +106,13 @@ export default function Flf2vDraftCard({
     setErrorMessage(null)
     setProgressPct(0)
     setLastResult(null)
+    // If the new gap has its own source dimensions, snap width/height to
+    // them so the form reflects the next clip pair instead of the previous
+    // run's overrides.
+    if (frameForAI?.sourceWidth && frameForAI?.sourceHeight) {
+      setWidth(alignDim(Number(frameForAI.sourceWidth)))
+      setHeight(alignDim(Number(frameForAI.sourceHeight)))
+    }
     // Also drop the cached busy guard so a leftover true doesn't lock out
     // the new run (pollStopRef guards the in-flight poll loop, not the UI).
   }, [frameForAI?.startFrame?.blobUrl, frameForAI?.endFrame?.blobUrl])

--- a/src/components/Flf2vDraftCard.jsx
+++ b/src/components/Flf2vDraftCard.jsx
@@ -92,6 +92,19 @@ export default function Flf2vDraftCard({
     pollStopRef.current = true
   }, [])
 
+  // Reset per-job UI state whenever a fresh frameForAI payload arrives
+  // (e.g. user right-clicks a second gap after a successful first fill).
+  // Without this the card kept the previous run's stage/lastResult/error
+  // and the second attempt looked like a no-op.
+  useEffect(() => {
+    setStage(null)
+    setErrorMessage(null)
+    setProgressPct(0)
+    setLastResult(null)
+    // Also drop the cached busy guard so a leftover true doesn't lock out
+    // the new run (pollStopRef guards the in-flight poll loop, not the UI).
+  }, [frameForAI?.startFrame?.blobUrl, frameForAI?.endFrame?.blobUrl])
+
   function handleSelectProfile(profile) {
     setActiveProfile(profile)
     if (profile.id.startsWith('imported:')) {

--- a/src/components/Flf2vDraftCard.jsx
+++ b/src/components/Flf2vDraftCard.jsx
@@ -1,0 +1,631 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Sparkles, Loader2, Workflow } from 'lucide-react'
+import useTimelineStore from '../stores/timelineStore'
+import useAssetsStore from '../stores/assetsStore'
+import useProjectStore from '../stores/projectStore'
+import { useFrameForAIStore } from '../stores/frameForAIStore'
+import { comfyui } from '../services/comfyui'
+import { importAsset, isElectron, getAbsoluteFileUrl } from '../services/fileSystem'
+import {
+  BUNDLED_FLF2V_PROFILES,
+  loadSelectedProfileId,
+  saveSelectedProfileId,
+} from '../services/builtinWorkflows/flf2vProfiles'
+import Flf2vWorkflowPicker from './Flf2vWorkflowPicker'
+
+const NEGATIVE_PROMPT_DEFAULT =
+  '色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走'
+
+const DEFAULT_PROMPT =
+  'Smooth transition between the first and last frame, cinematic motion, consistent subject and style'
+
+const POLL_INTERVAL_MS = 2000
+const MAX_POLL_SECONDS = 60 * 15 // 15 min cap so we never loop forever
+
+function deepClone(value) {
+  return JSON.parse(JSON.stringify(value))
+}
+
+function randomSeed() {
+  return Math.floor(Math.random() * 1e13)
+}
+
+/**
+ * Fill Gap (FLF2V) action card.
+ *
+ * Self-contained — does NOT go through the catalog / workflow browser.
+ * Takes the currently-selected FLF2V workflow profile (bundled or user-
+ * imported JSON), mutates inputs in-memory with the captured start/end
+ * frames + user-chosen duration/fps/resolution + prompt, uploads the
+ * frames to ComfyUI, queues the prompt, polls for completion, then
+ * imports the resulting video into the project and splices it back into
+ * the original timeline gap.
+ *
+ * Workflow selection is persisted to localStorage so reopening the app
+ * keeps the same workflow.
+ */
+export default function Flf2vDraftCard({
+  frameForAI,
+  timelineFps,
+  currentResolution,
+  onClear,
+}) {
+  const projectFps = Number.isFinite(Number(timelineFps)) && Number(timelineFps) > 0
+    ? Number(timelineFps)
+    : 24
+  const projectWidth = Number(currentResolution?.width) || 1280
+  const projectHeight = Number(currentResolution?.height) || 720
+  const gapDuration = Math.max(0, Number(frameForAI?.targetDurationSeconds) || 0)
+
+  // Form state — defaults come from the project (resolution / fps / gap
+  // duration). User can override any of them before queuing.
+  const [width, setWidth] = useState(alignDim(projectWidth))
+  const [height, setHeight] = useState(alignDim(projectHeight))
+  const [fps, setFps] = useState(projectFps)
+  const [duration, setDuration] = useState(round2(gapDuration || 2.5))
+  const [prompt, setPrompt] = useState(DEFAULT_PROMPT)
+  const [negativePrompt, setNegativePrompt] = useState(NEGATIVE_PROMPT_DEFAULT)
+  const [seed, setSeed] = useState(() => randomSeed())
+  const [busy, setBusy] = useState(false)
+  const [stage, setStage] = useState(null) // 'uploading' | 'queued' | 'running' | 'saving' | 'done' | 'error'
+  const [errorMessage, setErrorMessage] = useState(null)
+  const [progressPct, setProgressPct] = useState(0)
+  const [lastResult, setLastResult] = useState(null) // { assetId, filename } so the user can see what was just made
+
+  // Profile state — selected workflow + optional imported one + picker open.
+  const [activeProfile, setActiveProfile] = useState(() => resolveInitialProfile())
+  const [importedProfile, setImportedProfile] = useState(null)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const workflowBtnRef = useRef(null)
+
+  const assetsStore = useAssetsStore()
+  const timelineStore = useTimelineStore()
+  const clearFrameForAI = useFrameForAIStore((s) => s.clearFrame)
+
+  const promptIdRef = useRef(null)
+  const pollStopRef = useRef(false)
+
+  const previewStartUrl = frameForAI?.startFrame?.blobUrl || null
+  const previewEndUrl = frameForAI?.endFrame?.blobUrl || null
+
+  useEffect(() => () => {
+    pollStopRef.current = true
+  }, [])
+
+  function handleSelectProfile(profile) {
+    setActiveProfile(profile)
+    if (profile.id.startsWith('imported:')) {
+      setImportedProfile(profile)
+      saveSelectedProfileId({ kind: 'imported', profile })
+    } else {
+      saveSelectedProfileId({ kind: 'bundled', id: profile.id })
+    }
+  }
+
+  // Wan length = N*4 + 1, computed from the form's duration × fps.
+  const length = snapWanLength(Math.max(1, Math.round(duration * fps) + 1))
+
+  const mutation = activeProfile?.mutation
+  const canQueue = useMemo(() => {
+    if (busy) return false
+    if (!previewStartUrl || !previewEndUrl) return false
+    if (!frameForAI?.startFrame?.file || !frameForAI?.endFrame?.file) return false
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return false
+    if (width < 64 || height < 64) return false
+    if (!Number.isFinite(fps) || fps < 1) return false
+    if (!Number.isFinite(duration) || duration <= 0) return false
+    if (!mutation?.setStartImage || !mutation?.setEndImage) return false
+    return true
+  }, [busy, previewStartUrl, previewEndUrl, frameForAI, width, height, fps, duration, mutation])
+
+  async function handleQueue() {
+    if (!canQueue) return
+    setBusy(true)
+    setErrorMessage(null)
+    setProgressPct(0)
+    setLastResult(null)
+
+    try {
+      // 1) Upload the two captured frames to ComfyUI's input dir.
+      setStage('uploading')
+      const [startUpload, endUpload] = await Promise.all([
+        comfyui.uploadFile(frameForAI.startFrame.file),
+        comfyui.uploadFile(frameForAI.endFrame.file),
+      ])
+      if (!startUpload?.name || !endUpload?.name) {
+        throw new Error('ComfyUI did not return a filename for the uploaded frames')
+      }
+
+      // 2) Deep-clone the profile workflow and apply per-job mutations.
+      const workflow = deepClone(activeProfile.workflowJson)
+      safeCall(mutation?.setStartImage, workflow, startUpload.name)
+      safeCall(mutation?.setEndImage,   workflow, endUpload.name)
+      safeCall(mutation?.setWidth,      workflow, width)
+      safeCall(mutation?.setHeight,     workflow, height)
+      safeCall(mutation?.setLength,     workflow, length)
+      safeCall(mutation?.setPositivePrompt, workflow, prompt || DEFAULT_PROMPT)
+      safeCall(mutation?.setNegativePrompt, workflow, negativePrompt || NEGATIVE_PROMPT_DEFAULT)
+      safeCall(mutation?.setFps,        workflow, fps)
+      safeCall(mutation?.setSeeds,      workflow, seed)
+      safeCall(mutation?.setFilenamePrefix, workflow, `video/gapfill_${Date.now()}`)
+
+      // 3) Queue. comfyui.queuePrompt returns the prompt_id string directly
+      //    (NOT an object), so use it as-is — accessing .prompt_id on a
+      //    string would always be undefined and silently mask real errors.
+      setStage('queued')
+      const promptId = await comfyui.queuePrompt(workflow)
+      if (!promptId) {
+        throw new Error('ComfyUI did not return a prompt_id')
+      }
+      promptIdRef.current = promptId
+
+      // 4) Poll for completion.
+      setStage('running')
+      pollStopRef.current = false
+      const start = Date.now()
+      while (!pollStopRef.current) {
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+        if (Date.now() - start > MAX_POLL_SECONDS * 1000) {
+          throw new Error('Generation timed out')
+        }
+        const history = await fetchHistory(promptId)
+        if (history?.outputs && Object.keys(history.outputs).length > 0) {
+          const videos = collectVideoOutputs(history.outputs)
+          if (videos.length === 0) {
+            throw new Error('ComfyUI finished but produced no videos')
+          }
+          const picked = pickBestVideo(videos)
+          if (!picked) {
+            throw new Error('Could not extract video output from history')
+          }
+          const result = await spliceResultIntoGap(picked, history.outputs, {
+            assetsStore,
+            timelineStore,
+            frameForAI,
+            gapDuration: duration,
+            log,
+            setStage,
+            setProgressPct,
+          })
+          setStage('done')
+          if (result?.assetId) {
+            setLastResult({ assetId: result.assetId, filename: result.filename })
+          }
+          // Switch back to the editor tab so the user lands on the timeline
+          // and sees the freshly inserted clip immediately.
+          try {
+            window.dispatchEvent(new CustomEvent('comfystudio-switch-tab', { detail: { tab: 'editor' } }))
+          } catch (_) { /* ignore */ }
+          // Intentionally do NOT clear frameForAI here — the user wants the
+          // card to stay so they can re-queue with different params if the
+          // output is wrong.
+          return
+        }
+        const elapsed = (Date.now() - start) / 1000
+        setProgressPct(Math.min(95, 5 + (elapsed / 60) * 90))
+      }
+    } catch (err) {
+      console.error('[FillGap FLF2V] failed:', err)
+      setStage('error')
+      setErrorMessage(err?.message || String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="p-4 rounded-lg border border-sf-accent/40 bg-sf-accent/5 min-h-[48rem] relative">
+      <div className="flex items-start gap-4">
+        <div className="flex gap-1.5 flex-shrink-0">
+          <FramePreview url={previewStartUrl} label="Start" />
+          <div className="self-center text-sf-text-muted text-xs">→</div>
+          <FramePreview url={previewEndUrl} label="End" />
+        </div>
+        <div className="flex-1 min-w-0 space-y-3">
+          <div className="flex items-center gap-2 flex-wrap">
+            <div className="text-sm font-medium text-sf-text-primary">
+              Fill Gap (FLF2V) — First/Last Frame
+            </div>
+            <div className="px-2 py-0.5 rounded-full bg-sf-accent/20 text-sf-accent text-[10px] font-medium">
+              {duration.toFixed(2)}s · {length} frames @ {fps}fps · {width}×{height}
+            </div>
+            {stage && (
+              <div className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${
+                stage === 'error' ? 'bg-red-500/20 text-red-300'
+                : stage === 'done' ? 'bg-green-500/20 text-green-300'
+                : 'bg-sf-accent/15 text-sf-accent'
+              }`}>
+                {stageLabel(stage, progressPct)}
+              </div>
+            )}
+            {lastResult?.filename && (
+              <div className="px-2 py-0.5 rounded-full bg-green-500/15 text-green-200 text-[10px]">
+                inserted: {lastResult.filename}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <label className="text-[10px] uppercase tracking-wider text-sf-text-muted">
+              Prompt
+            </label>
+            <textarea
+              rows={5}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              disabled={busy}
+              className="mt-1 w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-2 py-1.5 text-xs text-sf-text-primary focus:border-sf-accent outline-none disabled:opacity-50 resize-y"
+              placeholder="Describe the motion you'd like between the two frames..."
+            />
+          </div>
+
+          <div>
+            <label className="text-[10px] uppercase tracking-wider text-sf-text-muted">
+              Negative prompt
+            </label>
+            <textarea
+              rows={3}
+              value={negativePrompt}
+              onChange={(e) => setNegativePrompt(e.target.value)}
+              disabled={busy}
+              className="mt-1 w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-2 py-1.5 text-xs text-sf-text-primary focus:border-sf-accent outline-none disabled:opacity-50 resize-y"
+              placeholder="What to avoid in the generation..."
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-2">
+            <Field
+              label="Width"
+              value={width}
+              onChange={setWidth}
+              step={16}
+              min={64}
+              max={2048}
+              disabled={busy}
+            />
+            <Field
+              label="Height"
+              value={height}
+              onChange={setHeight}
+              step={16}
+              min={64}
+              max={2048}
+              disabled={busy}
+            />
+            <Field
+              label="Seed"
+              value={seed}
+              onChange={(v) => setSeed(Number(v) || 0)}
+              step={1}
+              min={0}
+              disabled={busy}
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-2">
+            <Field
+              label="FPS"
+              value={fps}
+              onChange={setFps}
+              step={1}
+              min={1}
+              max={60}
+              disabled={busy}
+            />
+            <Field
+              label="Duration (s)"
+              value={duration}
+              onChange={setDuration}
+              step={0.1}
+              min={0.1}
+              max={30}
+              disabled={busy}
+            />
+            <div className="flex items-end">
+              <button
+                type="button"
+                onClick={() => {
+                  setWidth(alignDim(projectWidth))
+                  setHeight(alignDim(projectHeight))
+                  setFps(projectFps)
+                  setDuration(round2(gapDuration || 2.5))
+                }}
+                disabled={busy}
+                title="Reset form values to project defaults"
+                className="w-full px-2 py-1 rounded bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary text-[11px] disabled:opacity-50"
+              >
+                Use project defaults
+              </button>
+            </div>
+          </div>
+
+          {errorMessage && (
+            <div className="px-2 py-1.5 rounded bg-red-500/15 border border-red-500/40 text-[11px] text-red-200">
+              {errorMessage}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2 flex-wrap">
+            <button
+              type="button"
+              onClick={handleQueue}
+              disabled={!canQueue}
+              className="px-3 py-1.5 rounded bg-sf-accent text-black text-xs font-medium hover:bg-sf-accent/90 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
+            >
+              {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Sparkles className="w-3 h-3" />}
+              {busy ? stageLabel(stage, progressPct) : (lastResult ? 'Re-queue' : 'Queue Video')}
+            </button>
+            <button
+              type="button"
+              onClick={onClear}
+              disabled={busy}
+              className="px-2 py-1 rounded text-[11px] bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary transition-colors disabled:opacity-50"
+            >
+              Clear
+            </button>
+            <div className="ml-auto relative">
+              <button
+                ref={workflowBtnRef}
+                type="button"
+                onClick={() => setPickerOpen((v) => !v)}
+                disabled={busy}
+                title="Change workflow"
+                className="px-2 py-1 rounded text-[11px] bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary transition-colors disabled:opacity-50 flex items-center gap-1.5"
+              >
+                <Workflow className="w-3 h-3" />
+                <span className="max-w-[12rem] truncate">
+                  {activeProfile?.label || 'Workflow'}
+                </span>
+              </button>
+              {pickerOpen && (
+                <Flf2vWorkflowPicker
+                  currentProfileId={activeProfile?.id}
+                  importedProfile={importedProfile}
+                  onSelect={handleSelectProfile}
+                  onClose={() => setPickerOpen(false)}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function resolveInitialProfile() {
+  const stored = loadSelectedProfileId()
+  if (stored?.kind === 'bundled' && stored.id) {
+    const found = BUNDLED_FLF2V_PROFILES.find((p) => p.id === stored.id)
+    if (found) return found
+  }
+  if (stored?.kind === 'imported' && stored.profile) {
+    return stored.profile
+  }
+  return BUNDLED_FLF2V_PROFILES[0] || null
+}
+
+function safeCall(fn, ...args) {
+  if (typeof fn === 'function') {
+    try { fn(...args) } catch (_) { /* mutation not applicable, skip */ }
+  }
+}
+
+// Wan needs multiples of 16 for width/height.
+function alignDim(n) {
+  if (!Number.isFinite(Number(n)) || Number(n) <= 0) return 1280
+  return Math.max(64, Math.round(Number(n) / 16) * 16)
+}
+
+function round2(n) {
+  return Math.round(Number(n) * 100) / 100
+}
+
+function FramePreview({ url, label }) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="w-24 h-14 rounded overflow-hidden bg-sf-dark-800 border border-sf-dark-600">
+        {url ? (
+          <img src={url} alt={`${label} frame`} className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-[10px] text-sf-text-muted">
+            no frame
+          </div>
+        )}
+      </div>
+      <div className="text-[9px] text-sf-text-muted uppercase tracking-wider">{label}</div>
+    </div>
+  )
+}
+
+function Field({ label, value, onChange, step, min, max, disabled }) {
+  return (
+    <div>
+      <label className="text-[10px] uppercase tracking-wider text-sf-text-muted">
+        {label}
+      </label>
+      <input
+        type="number"
+        value={value}
+        step={step}
+        min={min}
+        max={max}
+        disabled={disabled}
+        onChange={(e) => {
+          const n = Number(e.target.value)
+          if (!Number.isNaN(n)) onChange(n)
+        }}
+        className="mt-1 w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-2 py-1 text-xs text-sf-text-primary focus:border-sf-accent outline-none disabled:opacity-50"
+      />
+    </div>
+  )
+}
+
+function stageLabel(stage, progressPct) {
+  if (!stage) return ''
+  switch (stage) {
+    case 'uploading': return 'Uploading frames…'
+    case 'queued': return 'Queueing…'
+    case 'running': return `Running… ${Math.round(progressPct || 0)}%`
+    case 'saving': return 'Importing result…'
+    case 'done': return 'Done'
+    case 'error': return 'Error'
+    default: return stage
+  }
+}
+
+// Snap an arbitrary length to the nearest valid WanFirstLastFrameToVideo
+// length (N*4 + 1: 1, 5, 9, 13, ..., 81, 85, ...). Non-aligned values
+// land on fractional frame indices in the VAE temporal conditioning and
+// weaken the start/end frame anchoring.
+function snapWanLength(n) {
+  const x = Math.max(1, Math.round(Number(n) || 1))
+  return Math.max(1, Math.round((x - 1) / 4) * 4 + 1)
+}
+
+async function fetchHistory(promptId) {
+  try {
+    const base = comfyui.getHttpBase?.()
+    const root = base || (typeof comfyui.getComfyURL === 'function' ? comfyui.getComfyURL() : 'http://127.0.0.1:8188')
+    const r = await fetch(`${root}/history/${encodeURIComponent(promptId)}`)
+    if (!r.ok) return null
+    const data = await r.json()
+    return data?.[promptId] || null
+  } catch (_) {
+    return null
+  }
+}
+
+function collectVideoOutputs(outputs) {
+  const out = []
+  for (const nodeOutputs of Object.values(outputs || {})) {
+    if (!nodeOutputs) continue
+    // ComfyUI's SaveVideo node (bundled) reports its saved file under the
+    // 'images' key with `animated: [true]`. Older nodes (VHS VideoCombine)
+    // report under 'videos' / 'gifs'. Handle all.
+    const images = nodeOutputs.images || []
+    const animated = nodeOutputs.animated || []
+    const isAnimated = Array.isArray(animated) && animated[0] === true
+    if (isAnimated) {
+      for (const v of images) out.push({ kind: 'video', node: nodeOutputs, ...v })
+    }
+    const videos = nodeOutputs.videos || []
+    for (const v of videos) out.push({ kind: 'video', node: nodeOutputs, ...v })
+    const gifs = nodeOutputs.gifs || []
+    for (const g of gifs) out.push({ kind: 'gif', node: nodeOutputs, ...g })
+  }
+  return out
+}
+
+function pickBestVideo(items) {
+  return items.find((it) => it.kind === 'video') || items[0] || null
+}
+
+async function spliceResultIntoGap(picked, outputs, ctx) {
+  const { assetsStore, timelineStore, frameForAI, gapDuration, setStage } = ctx
+  setStage?.('saving')
+
+  const filename = picked?.filename || picked?.name
+  const subfolder = picked?.subfolder || picked?.type || 'output'
+  if (!filename) throw new Error('No filename on the picked output')
+
+  const blob = await comfyui.downloadVideo(filename, subfolder, 'output')
+  const file = new File([blob], filename, { type: blob.type || 'video/mp4' })
+
+  const gap = {
+    trackId: frameForAI?.targetTrackId,
+    startTime: Number(frameForAI?.targetGapStartTime) || 0,
+    endTime: (Number(frameForAI?.targetGapStartTime) || 0) + (Number(frameForAI?.targetDurationSeconds) || 0),
+  }
+
+  // Save the file into the project's assets directory so it gets an
+  // absolutePath and proper media metadata (duration, width, height, fps).
+  // This is what the timeline needs to render thumbnails and to compute
+  // the clip duration correctly when inserted.
+  const projectHandle = useProjectStore.getState().getProjectHandle?.()
+  let newAsset
+  if (isElectron() && projectHandle) {
+    newAsset = await importAsset(projectHandle, file, 'video')
+    // importAsset() doesn't set `url` on the returned asset — only
+    // `absolutePath`. addClip() reads `asset.url` for both the clip
+    // source and its thumbnail (timelineStore.js), so without this the
+    // inserted clip renders blank. Resolve the file:// URL ourselves.
+    if (newAsset?.absolutePath && !newAsset.url) {
+      try {
+        newAsset = { ...newAsset, url: await getAbsoluteFileUrl(newAsset.absolutePath) }
+      } catch (err) {
+        console.warn('[FillGap FLF2V] could not resolve asset url:', err)
+      }
+    }
+    // The AssetsPanel's normal import path triggers generateAssetPoster /
+    // generateAssetSprite after importAsset. Since we're going around it,
+    // fire them ourselves so the timeline tile + scrubber thumbnail both
+    // appear. Failures are non-fatal — playback works without them.
+    if (newAsset?.id) {
+      const assetRecord = assetsStore.addAsset?.(newAsset)
+      // addAsset returns the stored copy (with id). Use it for downstream calls.
+      const stored = assetRecord || newAsset
+      try {
+        assetsStore.generateAssetPoster?.(stored.id, projectHandle)?.catch((err) => {
+          console.warn('[FillGap FLF2V] poster generation failed:', err)
+        })
+      } catch (_) { /* ignore sync throws */ }
+      try {
+        assetsStore.generateAssetSprite?.(stored.id, projectHandle)?.catch((err) => {
+          console.warn('[FillGap FLF2V] sprite generation failed:', err)
+        })
+      } catch (_) { /* ignore sync throws */ }
+      newAsset = stored
+    }
+  } else {
+    // Web fallback — at minimum register a blob-backed asset so playback
+    // still works (preview thumbnail may be missing in non-Electron).
+    const blobUrl = URL.createObjectURL(file)
+    newAsset = assetsStore.addAsset({
+      name: `Gap fill ${new Date().toISOString().slice(11, 19)}.mp4`,
+      type: 'video',
+      url: blobUrl,
+      size: file.size,
+      mimeType: file.type || 'video/mp4',
+      isImported: false,
+      settings: { source: 'gap-fill-flf2v' },
+    })
+  }
+
+  const timelineFpsNum = Number(timelineStore.timelineFps) || 24
+  const tracks = timelineStore.tracks || []
+  const targetTrack = tracks.find((t) => t?.id === gap.trackId && t?.type === 'video')
+    || tracks.find((t) => t?.type === 'video')
+  if (!targetTrack) {
+    console.warn('[FillGap FLF2V] no video track to insert into')
+    return { assetId: newAsset?.id, filename: newAsset?.name }
+  }
+
+  const inserted = timelineStore.addClip(targetTrack.id, newAsset, gap.startTime, timelineFpsNum, {
+    enabled: true,
+    selectAfterAdd: false,
+    resolveOverlaps: true,
+  })
+  if (!inserted) {
+    console.warn('[FillGap FLF2V] addClip returned null')
+    return { assetId: newAsset?.id, filename: newAsset?.name }
+  }
+
+  // If the generated clip's duration differs from the gap, surface it in
+  // the console (the card stays open so the user can re-queue).
+  if (typeof newAsset?.duration === 'number' && gapDuration > 0) {
+    const diff = Math.abs((newAsset.duration || 0) - gapDuration)
+    if (diff > 0.25) {
+      console.warn(`[FillGap FLF2V] duration mismatch: gap=${gapDuration.toFixed(2)}s asset=${newAsset.duration.toFixed(2)}s`)
+    }
+  }
+
+  return { assetId: newAsset?.id, filename: newAsset?.name }
+}
+
+function log(level, msg) {
+  const fn = level === 'warn' ? 'warn' : level === 'error' ? 'error' : 'log'
+  console[fn](`[FillGap FLF2V] ${msg}`)
+}

--- a/src/components/Flf2vDraftCard.jsx
+++ b/src/components/Flf2vDraftCard.jsx
@@ -385,7 +385,7 @@ export default function Flf2vDraftCard({
               max={30}
               disabled={busy}
             />
-            <div className="flex items-end gap-1.5">
+            <div className="flex items-end">
               <button
                 type="button"
                 onClick={() => {
@@ -396,34 +396,11 @@ export default function Flf2vDraftCard({
                 }}
                 disabled={busy}
                 title="Reset form values to project defaults"
-                className="flex-1 px-2 py-1 rounded bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary text-[11px] disabled:opacity-50"
+                className="w-full px-2 py-1 rounded bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary text-[11px] disabled:opacity-50"
               >
                 Use project defaults
               </button>
-              <button
-                type="button"
-                onClick={handleSavePromptsToWorkflow}
-                disabled={busy || !activeProfile}
-                title="Save current prompt + negative prompt as the new defaults for this workflow profile"
-                className="px-2 py-1 rounded bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary text-[11px] disabled:opacity-50 flex items-center gap-1"
-              >
-                <BookmarkPlus className="w-3 h-3" />
-                Save to workflow
-              </button>
             </div>
-            {(promptsSavedAt || loadProfilePromptOverrides(activeProfile?.id)) && (
-              <div className="-mt-2 col-span-3 flex items-center justify-end gap-2 text-[10px] text-sf-text-muted">
-                <span>Custom prompts saved for this workflow.</span>
-                <button
-                  type="button"
-                  onClick={handleResetPromptsToDefaults}
-                  disabled={busy}
-                  className="underline hover:text-sf-text-primary disabled:opacity-50"
-                >
-                  reset
-                </button>
-              </div>
-            )}
           </div>
 
           {errorMessage && (
@@ -450,7 +427,30 @@ export default function Flf2vDraftCard({
             >
               Clear
             </button>
-            <div className="ml-auto relative">
+            <button
+              type="button"
+              onClick={handleSavePromptsToWorkflow}
+              disabled={busy || !activeProfile}
+              title={loadProfilePromptOverrides(activeProfile?.id)
+                ? 'Custom prompts saved — click to overwrite with current values'
+                : 'Save current prompt + negative prompt as the new defaults for this workflow profile'}
+              className="ml-auto px-2 py-1 rounded text-[11px] bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary transition-colors disabled:opacity-50 flex items-center gap-1.5"
+            >
+              <BookmarkPlus className="w-3 h-3" />
+              Save to workflow
+            </button>
+            {(promptsSavedAt || loadProfilePromptOverrides(activeProfile?.id)) && (
+              <button
+                type="button"
+                onClick={handleResetPromptsToDefaults}
+                disabled={busy}
+                title="Clear saved overrides and revert prompts to module defaults"
+                className="px-2 py-1 rounded text-[10px] text-sf-text-muted hover:text-sf-text-primary underline disabled:opacity-50"
+              >
+                reset
+              </button>
+            )}
+            <div className="relative">
               <button
                 ref={workflowBtnRef}
                 type="button"

--- a/src/components/Flf2vDraftCard.jsx
+++ b/src/components/Flf2vDraftCard.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Sparkles, Loader2, Workflow } from 'lucide-react'
+import { Sparkles, Loader2, Workflow, BookmarkPlus } from 'lucide-react'
 import useTimelineStore from '../stores/timelineStore'
 import useAssetsStore from '../stores/assetsStore'
 import useProjectStore from '../stores/projectStore'
@@ -10,6 +10,8 @@ import {
   BUNDLED_FLF2V_PROFILES,
   loadSelectedProfileId,
   saveSelectedProfileId,
+  loadProfilePromptOverrides,
+  saveProfilePromptOverrides,
 } from '../services/builtinWorkflows/flf2vProfiles'
 import Flf2vWorkflowPicker from './Flf2vWorkflowPicker'
 
@@ -70,6 +72,7 @@ export default function Flf2vDraftCard({
   const [duration, setDuration] = useState(round2(gapDuration || 2.5))
   const [prompt, setPrompt] = useState(DEFAULT_PROMPT)
   const [negativePrompt, setNegativePrompt] = useState(NEGATIVE_PROMPT_DEFAULT)
+  const [promptsSavedAt, setPromptsSavedAt] = useState(null) // last time user saved to workflow
   const [seed, setSeed] = useState(() => randomSeed())
   const [busy, setBusy] = useState(false)
   const [stage, setStage] = useState(null) // 'uploading' | 'queued' | 'running' | 'saving' | 'done' | 'error'
@@ -96,6 +99,20 @@ export default function Flf2vDraftCard({
   useEffect(() => () => {
     pollStopRef.current = true
   }, [])
+
+  // On initial mount and whenever the active profile changes, swap the
+  // form prompts to whatever the user previously saved for that profile.
+  // Without this, the module-level constants win on first paint and a
+  // saved override only takes effect after a profile re-selection.
+  useEffect(() => {
+    const id = activeProfile?.id
+    if (!id) return
+    const overrides = loadProfilePromptOverrides(id)
+    setPrompt(overrides?.prompt ?? DEFAULT_PROMPT)
+    setNegativePrompt(overrides?.negativePrompt ?? NEGATIVE_PROMPT_DEFAULT)
+    setPromptsSavedAt(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeProfile?.id])
 
   // Reset per-job UI state whenever a fresh frameForAI payload arrives
   // (e.g. user right-clicks a second gap after a successful first fill).
@@ -125,6 +142,28 @@ export default function Flf2vDraftCard({
     } else {
       saveSelectedProfileId({ kind: 'bundled', id: profile.id })
     }
+    // Swap the form prompts to whatever the user previously saved for this
+    // profile (or fall back to module defaults if none). The current edits
+    // are intentionally NOT carried over — switching workflows discards
+    // unsaved prompt edits, matching how the form resets width/height on a
+    // new gap.
+    const overrides = loadProfilePromptOverrides(profile.id)
+    setPrompt(overrides?.prompt ?? DEFAULT_PROMPT)
+    setNegativePrompt(overrides?.negativePrompt ?? NEGATIVE_PROMPT_DEFAULT)
+    setPromptsSavedAt(null)
+  }
+
+  function handleSavePromptsToWorkflow() {
+    if (!activeProfile) return
+    saveProfilePromptOverrides(activeProfile.id, { prompt, negativePrompt })
+    setPromptsSavedAt(Date.now())
+  }
+
+  function handleResetPromptsToDefaults() {
+    setPrompt(DEFAULT_PROMPT)
+    setNegativePrompt(NEGATIVE_PROMPT_DEFAULT)
+    if (activeProfile) saveProfilePromptOverrides(activeProfile.id, {})
+    setPromptsSavedAt(null)
   }
 
   // Wan length = N*4 + 1, computed from the form's duration × fps.
@@ -346,7 +385,7 @@ export default function Flf2vDraftCard({
               max={30}
               disabled={busy}
             />
-            <div className="flex items-end">
+            <div className="flex items-end gap-1.5">
               <button
                 type="button"
                 onClick={() => {
@@ -357,11 +396,34 @@ export default function Flf2vDraftCard({
                 }}
                 disabled={busy}
                 title="Reset form values to project defaults"
-                className="w-full px-2 py-1 rounded bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary text-[11px] disabled:opacity-50"
+                className="flex-1 px-2 py-1 rounded bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary text-[11px] disabled:opacity-50"
               >
                 Use project defaults
               </button>
+              <button
+                type="button"
+                onClick={handleSavePromptsToWorkflow}
+                disabled={busy || !activeProfile}
+                title="Save current prompt + negative prompt as the new defaults for this workflow profile"
+                className="px-2 py-1 rounded bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-muted hover:text-sf-text-primary text-[11px] disabled:opacity-50 flex items-center gap-1"
+              >
+                <BookmarkPlus className="w-3 h-3" />
+                Save to workflow
+              </button>
             </div>
+            {(promptsSavedAt || loadProfilePromptOverrides(activeProfile?.id)) && (
+              <div className="-mt-2 col-span-3 flex items-center justify-end gap-2 text-[10px] text-sf-text-muted">
+                <span>Custom prompts saved for this workflow.</span>
+                <button
+                  type="button"
+                  onClick={handleResetPromptsToDefaults}
+                  disabled={busy}
+                  className="underline hover:text-sf-text-primary disabled:opacity-50"
+                >
+                  reset
+                </button>
+              </div>
+            )}
           </div>
 
           {errorMessage && (

--- a/src/components/Flf2vWorkflowPicker.jsx
+++ b/src/components/Flf2vWorkflowPicker.jsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check, FileJson, Upload, X, AlertTriangle } from 'lucide-react'
+import {
+  BUNDLED_FLF2V_PROFILES,
+  detectProfileFromJson,
+} from '../services/builtinWorkflows/flf2vProfiles'
+
+/**
+ * Inline popover for choosing the FLF2V workflow.
+ *
+ * - Lists bundled profiles (hand-tuned, ship with the app).
+ * - "Import JSON..." button lets the user load any ComfyUI API-format
+ *   workflow JSON; auto-detects schema and shows warnings if ambiguous.
+ * - Calls onSelect(profile) when a profile is chosen; caller persists.
+ *
+ * Positioning: simple absolute anchored under the trigger. No portal —
+ * the popover is small enough that overflow is rare in this card.
+ */
+export default function Flf2vWorkflowPicker({
+  currentProfileId,
+  importedProfile,            // currently active imported profile (if any)
+  onSelect,                   // (profile) => void
+  onClose,
+}) {
+  const popRef = useRef(null)
+  const fileInputRef = useRef(null)
+  const [importError, setImportError] = useState(null)
+  const [importWarnings, setImportWarnings] = useState([])
+
+  // Click-outside to close
+  useEffect(() => {
+    function onDocDown(e) {
+      if (popRef.current && !popRef.current.contains(e.target)) {
+        onClose?.()
+      }
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') onClose?.()
+    }
+    document.addEventListener('mousedown', onDocDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  function handlePickFile() {
+    fileInputRef.current?.click()
+  }
+
+  async function handleFileChange(e) {
+    const file = e.target.files?.[0]
+    e.target.value = '' // allow re-importing same file
+    if (!file) return
+    setImportError(null)
+    setImportWarnings([])
+    try {
+      const text = await file.text()
+      const json = JSON.parse(text)
+      const sourceName = file.name.replace(/\.json$/i, '')
+      const profile = detectProfileFromJson(json, sourceName)
+      setImportWarnings(profile.detectWarnings || [])
+      onSelect(profile)
+      onClose?.()
+    } catch (err) {
+      setImportError(err?.message || 'Failed to parse JSON')
+    }
+  }
+
+  const isCurrent = (id) => id === currentProfileId
+
+  return (
+    <div
+      ref={popRef}
+      className="absolute z-50 top-full right-0 mt-1 w-80 rounded-md border border-sf-dark-600 bg-sf-dark-800 shadow-xl"
+      role="dialog"
+      aria-label="Choose FLF2V workflow"
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-sf-dark-600">
+        <div className="text-[11px] uppercase tracking-wider text-sf-text-muted">
+          FLF2V workflow
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-0.5 rounded text-sf-text-muted hover:text-sf-text-primary hover:bg-sf-dark-700"
+          aria-label="Close"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div className="max-h-72 overflow-y-auto py-1">
+        {BUNDLED_FLF2V_PROFILES.map((p) => (
+          <ProfileRow
+            key={p.id}
+            profile={p}
+            active={isCurrent(p.id)}
+            onPick={() => { onSelect(p); onClose?.() }}
+          />
+        ))}
+        {importedProfile && isCurrent(importedProfile.id) && (
+          <ProfileRow
+            key={importedProfile.id}
+            profile={importedProfile}
+            active
+            imported
+            onPick={() => { onSelect(importedProfile); onClose?.() }}
+          />
+        )}
+      </div>
+
+      <div className="border-t border-sf-dark-600 p-2">
+        <button
+          type="button"
+          onClick={handlePickFile}
+          className="w-full flex items-center justify-center gap-2 px-2 py-1.5 rounded bg-sf-dark-700 hover:bg-sf-dark-600 text-sf-text-primary text-xs"
+        >
+          <Upload className="w-3.5 h-3.5" />
+          Import JSON file…
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json,.json"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        {importError && (
+          <div className="mt-2 px-2 py-1.5 rounded bg-red-500/15 border border-red-500/40 text-[11px] text-red-200">
+            {importError}
+          </div>
+        )}
+        {importWarnings.length > 0 && (
+          <div className="mt-2 px-2 py-1.5 rounded bg-yellow-500/15 border border-yellow-500/40 text-[11px] text-yellow-100">
+            <div className="flex items-center gap-1 font-medium">
+              <AlertTriangle className="w-3 h-3" />
+              Imported with warnings:
+            </div>
+            <ul className="mt-1 ml-4 list-disc">
+              {importWarnings.map((w, i) => <li key={i}>{w}</li>)}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ProfileRow({ profile, active, imported, onPick }) {
+  return (
+    <button
+      type="button"
+      onClick={onPick}
+      className={`w-full text-left px-3 py-2 flex items-start gap-2 hover:bg-sf-dark-700 ${
+        active ? 'bg-sf-accent/10' : ''
+      }`}
+    >
+      <div className="mt-0.5 flex-shrink-0">
+        {imported
+          ? <FileJson className="w-3.5 h-3.5 text-sf-text-muted" />
+          : active
+            ? <Check className="w-3.5 h-3.5 text-sf-accent" />
+            : <div className="w-3.5 h-3.5" />
+        }
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className={`text-xs truncate ${active ? 'text-sf-accent' : 'text-sf-text-primary'}`}>
+          {profile.label}
+        </div>
+        {profile.description && (
+          <div className="text-[10px] text-sf-text-muted line-clamp-2">
+            {profile.description}
+          </div>
+        )}
+        <div className="text-[9px] uppercase tracking-wider text-sf-text-muted mt-0.5">
+          {profile.kind}{imported ? ' • imported' : ' • bundled'}
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/src/components/GenerateWorkspace.jsx
+++ b/src/components/GenerateWorkspace.jsx
@@ -14,6 +14,7 @@ import MusicVideoEasyMode from './generate/MusicVideoEasyMode'
 import ShortFilmEasyMode from './generate/ShortFilmEasyMode'
 import WorkflowBrowser from './generate/WorkflowBrowser'
 import WorkflowDetail from './generate/WorkflowDetail'
+import Flf2vDraftCard from './Flf2vDraftCard'
 import { COMFY_PARTNER_KEY_CHANGED_EVENT } from '../services/comfyPartnerAuth'
 import useComfyUI from '../hooks/useComfyUI'
 import useAssetsStore from '../stores/assetsStore'
@@ -3505,14 +3506,30 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
   const showComfyGatingBanner = !isConnected && (launcherIsBooting || launcherWaitingForExternal || launcherCanAutoStart)
   const allowQueueWhileWaiting = !isConnected && (launcherIsBooting || launcherCanAutoStart || launcherWaitingForExternal)
 
-  // When opened with timeline frame, switch to video i2v and use that frame as input
+  // When opened with a timeline frame, switch to the matching video workflow
+  // and pre-populate the form so the user only has to review and hit Run.
+  //   - Single-frame payloads (mode 'extend' / 'keyframe') target the
+  //     existing wan22-i2v workflow; the frame is uploaded on Run.
+  //   - Two-frame payloads (mode 'flf2v') come from the timeline "Fill Gap"
+  //     action. We DO NOT pre-select a workflow from the catalog — the FLF2V
+  //     pipeline ships its own bundled workflow JSON that the dedicated
+  //     <Flf2vDraftCard /> (rendered below) submits directly to ComfyUI on
+  //     Queue. This keeps the Fill Gap flow self-contained: no catalog state
+  //     cascade, no route flips, no form-field stitching.
   useEffect(() => {
-    if (frameForAI) {
+    if (!frameForAI) return
+    if (frameForAI.mode === 'flf2v') {
+      // Just make sure the top-level category is video so the right-side
+      // "Workflow Info" panel doesn't look out of place. The card itself
+      // is independent of category/workflow selection.
       setCategory('video')
-      setWorkflowId('wan22-i2v')
       setFormError(null)
+      return
     }
-  }, [frameForAI?.blobUrl])
+    setCategory('video')
+    setWorkflowId('wan22-i2v')
+    setFormError(null)
+  }, [frameForAI?.blobUrl, frameForAI?.mode])
 
   // Restore selected asset from ID when assets are available
   useEffect(() => {
@@ -11133,6 +11150,75 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
     })
   }, [])
 
+  // Splice a freshly-generated FLF2V video into the original timeline gap.
+  //
+  // This is invoked from the queue run path after `saveGenerationResult` has
+  // imported the new video into the project assets. We only splice when the
+  // job was launched from the timeline "Fill Gap (FLF2V)" action — the
+  // presence of a `flf2v`-mode frame on the frameForAIStore records both the
+  // target track/time and the requested gap duration. We clear the store
+  // entry once we splice (or once we give up) so the blob URLs are released.
+  //
+  // Edge cases handled:
+  //  - No imported video: log a warning, leave the gap, clear the store.
+  //  - Target track missing: log a warning, append the clip to the active
+  //    video track at the playhead instead, clear the store.
+  //  - Generated clip's natural duration does not match the gap: we insert
+  //    the clip at the gap's startTime. The store's `resolveOverlaps` will
+  //    then shift any neighbor to make room if the generated clip is longer
+  //    than the gap. We surface a toast so the user knows the gap is not
+  //    perfectly filled.
+  const maybeInsertWan22Flf2vIntoGap = useCallback((jobRecord, importedAssetsList) => {
+    const frame = useFrameForAIStore.getState().frame
+    if (!frame || frame.mode !== 'flf2v') return
+
+    const gap = {
+      trackId: frame.targetTrackId,
+      startTime: Number(frame.targetGapStartTime),
+      endTime: Number(frame.targetGapStartTime) + Number(frame.targetDurationSeconds || 0),
+    }
+
+    const newVideoAsset = (importedAssetsList || []).find((asset) => asset?.type === 'video' && asset?.url)
+    if (!newVideoAsset) {
+      addComfyLog('warn', 'Fill Gap (FLF2V): no generated video was imported — gap was not replaced.')
+      useFrameForAIStore.getState().clearFrame()
+      return
+    }
+
+    const tracksState = useTimelineStore.getState()
+    const targetTrack = tracksState.tracks.find((track) => track?.id === gap.trackId && track.type === 'video')
+    if (!targetTrack) {
+      addComfyLog('warn', `Fill Gap (FLF2V): target track ${gap.trackId || '(none)'} not found. Appending video to first video track.`)
+    }
+    const trackIdToUse = targetTrack ? targetTrack.id : (tracksState.tracks.find((track) => track?.type === 'video') || {}).id
+    if (!trackIdToUse) {
+      addComfyLog('error', 'Fill Gap (FLF2V): no video track available — gap was not replaced.')
+      useFrameForAIStore.getState().clearFrame()
+      return
+    }
+
+    const fps = tracksState.timelineFps || jobRecord?.fps || 24
+    const insertedClip = tracksState.addClip(trackIdToUse, newVideoAsset, gap.startTime, fps, {
+      enabled: true,
+      selectAfterAdd: false,
+      resolveOverlaps: true,
+    })
+
+    if (!insertedClip) {
+      addComfyLog('error', 'Fill Gap (FLF2V): failed to insert the generated clip — gap was not replaced.')
+    } else {
+      const generatedDuration = Number(newVideoAsset.duration || newVideoAsset.settings?.duration || insertedClip.duration || 0)
+      const targetDuration = Number(frame.targetDurationSeconds || 0)
+      if (targetDuration > 0 && generatedDuration > 0) {
+        const diff = generatedDuration - targetDuration
+        if (Math.abs(diff) > 0.05) {
+          addComfyLog('status', `Fill Gap (FLF2V): generated clip duration (${generatedDuration.toFixed(2)}s) does not match the gap (${targetDuration.toFixed(2)}s); ${diff > 0 ? 'neighbors shifted' : 'residual gap left'}.`)
+        }
+      }
+    }
+    useFrameForAIStore.getState().clearFrame()
+  }, [addComfyLog])
+
   const handleCreateAngleSheetForJob = useCallback(async (job) => {
     if (!job || !Array.isArray(job.resultAssetIds) || job.resultAssetIds.length === 0) return
     const targetProjectHandle = job?.originProject?.handle || currentProjectHandle
@@ -11333,6 +11419,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
         isSingleVideoWorkflowId(job.workflowId) ||
         job.workflowId === 'ltx23-t2v' ||
         job.workflowId === 'wan22-t2v' ||
+        job.workflowId === 'wan22-flf2v' ||
         job.workflowId === 'seedance2-t2v' ||
         job.workflowId === 'seedance2-flf2v' ||
         job.workflowId === 'seedance2-r2v' ||
@@ -11404,6 +11491,13 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           }
           importedAssets = await maybeFinalizePeopleWizardJob(job, importedAssets)
           rememberLatestWorkflowPreview(job, importedAssets)
+          // If this job was launched from the timeline "Fill Gap (FLF2V)"
+          // action, splice the newly generated video into the original gap
+          // (replacing the gap exactly) instead of leaving it as a
+          // append-only asset.
+          if (job.workflowId === 'wan22-flf2v') {
+            maybeInsertWan22Flf2vIntoGap(job, importedAssets)
+          }
           updateJob(job.id, {
             status: 'done',
             progress: 100,
@@ -11977,6 +12071,13 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
         }
         importedAssets = await maybeFinalizePeopleWizardJob(job, importedAssets)
         rememberLatestWorkflowPreview(job, importedAssets)
+        // If this job was launched from the timeline "Fill Gap (FLF2V)"
+        // action, splice the newly generated video into the original gap
+        // (replacing the gap exactly) instead of leaving it as a
+        // append-only asset.
+        if (job.workflowId === 'wan22-flf2v') {
+          maybeInsertWan22Flf2vIntoGap(job, importedAssets)
+        }
         updateJob(job.id, {
           status: 'done',
           progress: 100,
@@ -12002,7 +12103,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
     } finally {
       await finalizeStoryboardPdfBatchForJob(job, importedAssets)
     }
-  }, [assets, currentProjectHandle, updateJob, saveGenerationResult, pollForResult, addComfyLog, finalizeStoryboardPdfBatchForJob, rememberLatestWorkflowPreview])
+  }, [assets, currentProjectHandle, updateJob, saveGenerationResult, pollForResult, addComfyLog, finalizeStoryboardPdfBatchForJob, rememberLatestWorkflowPreview, maybeInsertWan22Flf2vIntoGap])
 
   const processQueue = useCallback(async () => {
     if (processingRef.current) return
@@ -12327,8 +12428,17 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
         {/* Center: Settings - extra left padding in yolo mode when sidebar visible to center content with header tabs */}
         <div className={`flex-1 min-w-0 overflow-auto px-5 py-4 ${generationMode === 'yolo' && !rightSidebarCollapsed ? 'pl-40' : ''}`}>
           <div className={`mx-auto w-full space-y-4 ${generationMode === 'yolo' ? 'max-w-6xl' : 'max-w-5xl'}`}>
-            {/* Timeline frame from editor (Extend with AI / Starting keyframe for AI) */}
-            {frameForAI && generationMode === 'single' && (
+            {/* Fill Gap (FLF2V) action card — self-contained, does NOT
+                depend on the catalog workflow state. */}
+            {frameForAI && generationMode === 'single' && frameForAI.mode === 'flf2v' && (
+              <Flf2vDraftCard
+                frameForAI={frameForAI}
+                timelineFps={timelineFps}
+                currentResolution={resolution}
+                onClear={clearFrameForAI}
+              />
+            )}
+            {frameForAI && generationMode === 'single' && frameForAI.mode !== 'flf2v' && (
               <div className="p-3 rounded-lg border border-sf-accent/40 bg-sf-accent/5">
                 <div className="flex items-start gap-3">
                   <div className="w-24 h-14 flex-shrink-0 rounded overflow-hidden bg-sf-dark-800 border border-sf-dark-600">

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -38,6 +38,8 @@ import {
   matchEditorHotkey,
 } from '../services/editorHotkeys'
 import MasterAudioMeter from './AudioMeter'
+import { useFrameForAIStore } from '../stores/frameForAIStore'
+import { captureTimelineFrameAt } from '../utils/captureTimelineFrame'
 
 const TRANSITION_DEFAULT_DURATION_KEY = 'comfystudio-transition-default-duration-frames'
 const DEFAULT_WAVEFORM_SAMPLES = 8192
@@ -621,6 +623,20 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
     clipContextMenuAnchor,
     clipContextMenuRef,
   )
+
+  // Gap context menu state (for the "Fill Gap (FLF2V)" action on the
+  // empty space between two clips). Mirrors clipContextMenu shape: { x, y, gap }.
+  const [gapContextMenu, setGapContextMenu] = useState(null) // { x, y, gap }
+  const [gapFillBusy, setGapFillBusy] = useState(false)
+  const gapContextMenuRef = useRef(null)
+  const gapContextMenuAnchor = useMemo(
+    () => (gapContextMenu ? { x: gapContextMenu.x, y: gapContextMenu.y } : null),
+    [gapContextMenu?.x, gapContextMenu?.y]
+  )
+  const gapContextMenuPosition = useViewportClampedPosition(
+    gapContextMenuAnchor,
+    gapContextMenuRef,
+  )
   
   // Track rename state
   const [renamingTrackId, setRenamingTrackId] = useState(null)
@@ -887,7 +903,82 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
     e.preventDefault()
     e.stopPropagation()
     selectGap(gap)
+    // Open the gap context menu so the user can launch "Fill Gap (FLF2V)".
+    setGapContextMenu({ x: e.clientX, y: e.clientY, gap })
   }, [getTimeFromMouseEvent, getTrackGapAtTime, selectGap])
+
+  // Determine whether the gap has a usable video/image neighbor on each side
+  // (an audio-only gap should not show the Fill Gap action).
+  const isGapFillable = useCallback((gap) => {
+    if (!gap) return false
+    const trackClips = clips
+      .filter((clip) => clip.trackId === gap.trackId)
+      .sort((a, b) => a.startTime - b.startTime)
+    const beforeClip = [...trackClips].reverse().find((c) => (c.startTime + c.duration) <= gap.startTime + 0.001)
+    const afterClip = trackClips.find((c) => c.startTime >= gap.endTime - 0.001)
+    const isVisual = (clip) => clip && (clip.type === 'video' || clip.type === 'image')
+    return isVisual(beforeClip) && isVisual(afterClip)
+  }, [clips])
+
+  // Click-outside / Escape dismisses the gap context menu. We listen in the
+  // capture phase for the same reason as the clip context menu: nested
+  // handlers may call e.stopPropagation().
+  useEffect(() => {
+    if (!gapContextMenu) return
+    const handleClick = (e) => {
+      if (gapContextMenuRef.current && gapContextMenuRef.current.contains(e.target)) {
+        return
+      }
+      setGapContextMenu(null)
+    }
+    const handleEscape = (e) => {
+      if (e.key === 'Escape') setGapContextMenu(null)
+    }
+    window.addEventListener('click', handleClick, true)
+    window.addEventListener('keydown', handleEscape)
+    return () => {
+      window.removeEventListener('click', handleClick, true)
+      window.removeEventListener('keydown', handleEscape)
+    }
+  }, [gapContextMenu])
+
+  const handleFillGapFlf2v = useCallback(async () => {
+    if (gapFillBusy) return
+    const menuState = gapContextMenu
+    const gap = menuState?.gap
+    if (!gap) return
+    setGapFillBusy(true)
+    try {
+      const fps = Number(timelineFps) > 0 ? Number(timelineFps) : 24
+      const EPS = 1 / fps
+      const lastFrameTime = Math.max(0, gap.startTime - EPS)
+      const firstFrameTime = gap.endTime + EPS
+      const [startResult, endResult] = await Promise.all([
+        captureTimelineFrameAt(lastFrameTime),
+        captureTimelineFrameAt(firstFrameTime),
+      ])
+      if (!startResult || !endResult) {
+        console.warn('[FillGap FLF2V] Failed to capture one or both gap boundary frames')
+        return
+      }
+      useFrameForAIStore.getState().setFrame({
+        mode: 'flf2v',
+        startFrame: { blobUrl: startResult.blobUrl, file: startResult.file },
+        endFrame: { blobUrl: endResult.blobUrl, file: endResult.file },
+        targetDurationSeconds: Math.max(0, gap.endTime - gap.startTime),
+        targetTrackId: gap.trackId,
+        targetGapStartTime: gap.startTime,
+      })
+      // Switch the right panel to Generate so the user can review the
+      // pre-populated form and start the run.
+      window.dispatchEvent(new CustomEvent('comfystudio-open-generate-with-frame'))
+    } catch (err) {
+      console.error('[FillGap FLF2V] unexpected error:', err)
+    } finally {
+      setGapFillBusy(false)
+      setGapContextMenu(null)
+    }
+  }, [gapContextMenu, gapFillBusy, timelineFps])
   const clipContextSelectionIds = useMemo(() => (
     clipContextMenu ? selectedClipIds : []
   ), [clipContextMenu, selectedClipIds])
@@ -6633,6 +6724,56 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
             className="w-full px-3 py-1.5 text-left text-xs text-sf-error hover:bg-sf-error/20 flex items-center gap-2 transition-colors"
           >
             <span>{rippleEditMode ? (clipContextSelectionIds.length > 1 ? `Ripple Delete ${clipContextSelectionIds.length} clips` : 'Ripple Delete') : (clipContextSelectionIds.length > 1 ? `Delete ${clipContextSelectionIds.length} clips` : 'Delete')}</span>
+            <span className="ml-auto text-sf-text-muted text-[10px]">Del</span>
+          </button>
+        </div>
+      )}
+
+      {/* Gap context menu (right-click on empty space between two clips).
+          Same portal/fixed-position pattern as clipContextMenu. */}
+      {gapContextMenu && (
+        <div
+          ref={gapContextMenuRef}
+          className="fixed z-50 bg-sf-dark-800 border border-sf-dark-600 rounded-lg shadow-xl py-1 min-w-[200px]"
+          style={{
+            left: `${gapContextMenuPosition.x}px`,
+            top: `${gapContextMenuPosition.y}px`,
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="px-3 py-2 text-[10px] text-sf-text-muted uppercase tracking-wider border-b border-sf-dark-600">
+            Gap · {Math.max(0, (gapContextMenu.gap?.endTime || 0) - (gapContextMenu.gap?.startTime || 0)).toFixed(2)}s
+          </div>
+          {isGapFillable(gapContextMenu.gap) ? (
+            <button
+              onClick={handleFillGapFlf2v}
+              disabled={gapFillBusy}
+              className="w-full px-3 py-2 text-left text-xs text-sf-text-primary hover:bg-sf-dark-700 flex items-center gap-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Capture the last frame of the clip before the gap and the first frame of the clip after, then send both to Generate with the WAN 2.2 First/Last Frame to Video workflow pre-selected."
+            >
+              {gapFillBusy ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <Sparkles className="w-3 h-3" />
+              )}
+              <span>Fill Gap (FLF2V)</span>
+            </button>
+          ) : (
+            <div className="px-3 py-2 text-[10px] text-sf-text-muted">
+              Fill Gap is only available when both neighbors are video or image clips.
+            </div>
+          )}
+          <div className="h-px bg-sf-dark-600 my-1" />
+          <button
+            onClick={() => {
+              const gap = gapContextMenu.gap
+              setGapContextMenu(null)
+              if (gap) rippleDeleteSelectedGap()
+            }}
+            className="w-full px-3 py-1.5 text-left text-xs text-sf-text-primary hover:bg-sf-dark-700 flex items-center gap-2 transition-colors"
+            title="Select this gap and use the existing ripple delete action"
+          >
+            <span>Ripple-delete gap</span>
             <span className="ml-auto text-sf-text-muted text-[10px]">Del</span>
           </button>
         </div>

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -39,7 +39,7 @@ import {
 } from '../services/editorHotkeys'
 import MasterAudioMeter from './AudioMeter'
 import { useFrameForAIStore } from '../stores/frameForAIStore'
-import { captureTimelineFrameAt } from '../utils/captureTimelineFrame'
+import { captureGapBoundaryFrames, captureTimelineFrameAt, getTopmostVideoOrImageClipAtTime } from '../utils/captureTimelineFrame'
 
 const TRANSITION_DEFAULT_DURATION_KEY = 'comfystudio-transition-default-duration-frames'
 const DEFAULT_WAVEFORM_SAMPLES = 8192
@@ -964,20 +964,44 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
     console.log('[FillGap FLF2V] starting for gap', { start: gap.startTime, end: gap.endTime, trackId: gap.trackId })
     setGapFillBusy(true)
     try {
-      const fps = Number(timelineFps) > 0 ? Number(timelineFps) : 24
-      const EPS = 1 / fps
-      const lastFrameTime = Math.max(0, gap.startTime - EPS)
-      const firstFrameTime = gap.endTime + EPS
-      const [startResult, endResult] = await Promise.all([
-        captureTimelineFrameAt(lastFrameTime),
-        captureTimelineFrameAt(firstFrameTime),
-      ])
+      // Find the before / after clips on the same track. We can't use
+      // captureTimelineFrameAt (composite renderer) here because the time
+      // one frame past the gap's edge lands outside the clip range and
+      // getActiveClipsAtTime returns empty there, making the composite
+      // renderer bail. Instead, load each neighbor clip's source directly
+      // and seek to a frame STRICTLY inside its [start, start+duration]
+      // range — robust against edge cases.
+      const allClips = useTimelineStore.getState().clips || []
+      const trackClips = allClips
+        .filter((c) => c.trackId === gap.trackId)
+        .sort((a, b) => a.startTime - b.startTime)
+      const beforeClipEntry = [...trackClips].reverse().find(
+        (c) => (c.startTime + (c.duration || 0)) <= gap.startTime + 0.001
+      )
+      const afterClipEntry = trackClips.find(
+        (c) => (c.startTime || 0) >= gap.endTime - 0.001
+      )
+      const beforeNeighbor = beforeClipEntry
+        ? { clip: beforeClipEntry, track: { id: beforeClipEntry.trackId, type: 'video' } }
+        : null
+      const afterNeighbor = afterClipEntry
+        ? { clip: afterClipEntry, track: { id: afterClipEntry.trackId, type: 'video' } }
+        : null
+      if (!beforeNeighbor || !afterNeighbor) {
+        console.warn('[FillGap FLF2V] could not locate before/after neighbors on track', {
+          trackId: gap.trackId,
+          beforeClip: !!beforeClipEntry,
+          afterClip: !!afterClipEntry,
+        })
+        return
+      }
+      const { start: startResult, end: endResult } = await captureGapBoundaryFrames(beforeNeighbor, afterNeighbor)
       if (!startResult || !endResult) {
         console.warn('[FillGap FLF2V] Failed to capture one or both gap boundary frames', {
-          lastFrameTime,
-          firstFrameTime,
           startResult: !!startResult,
           endResult: !!endResult,
+          beforeClipId: beforeNeighbor.clip.id,
+          afterClipId: afterNeighbor.clip.id,
         })
         return
       }

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -1005,6 +1005,11 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
         })
         return
       }
+      // Prefer the source frame's native dimensions over project resolution.
+      // If the before / after clips disagree, fall back to whichever one
+      // reported a value (they almost always match for a coherent edit).
+      const sourceWidth = startResult.width || endResult.width || null
+      const sourceHeight = startResult.height || endResult.height || null
       useFrameForAIStore.getState().setFrame({
         mode: 'flf2v',
         startFrame: { blobUrl: startResult.blobUrl, file: startResult.file },
@@ -1012,6 +1017,8 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
         targetDurationSeconds: Math.max(0, gap.endTime - gap.startTime),
         targetTrackId: gap.trackId,
         targetGapStartTime: gap.startTime,
+        sourceWidth,
+        sourceHeight,
       })
       // Switch the right panel to Generate so the user can review the
       // pre-populated form and start the run.

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -627,6 +627,10 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
   // Gap context menu state (for the "Fill Gap (FLF2V)" action on the
   // empty space between two clips). Mirrors clipContextMenu shape: { x, y, gap }.
   const [gapContextMenu, setGapContextMenu] = useState(null) // { x, y, gap }
+  // Mirror of gapContextMenu the handler reads from, so it always sees the
+  // latest value regardless of when its useCallback closure was created.
+  const gapContextMenuStateRef = useRef(null)
+  useEffect(() => { gapContextMenuStateRef.current = gapContextMenu }, [gapContextMenu])
   const [gapFillBusy, setGapFillBusy] = useState(false)
   const gapContextMenuRef = useRef(null)
   const gapContextMenuAnchor = useMemo(
@@ -943,10 +947,21 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
   }, [gapContextMenu])
 
   const handleFillGapFlf2v = useCallback(async () => {
-    if (gapFillBusy) return
-    const menuState = gapContextMenu
+    // Always read menuState from a state-ref so we can't be running a stale
+    // closure (this used to capture gapContextMenu directly, which left the
+    // second gap's click reading the previous gap or null after a render
+    // hiccup — gapContextMenuRef points at the DOM node, not the state).
+    const menuState = gapContextMenuStateRef.current
     const gap = menuState?.gap
-    if (!gap) return
+    if (gapFillBusy) {
+      console.log('[FillGap FLF2V] click ignored — already running')
+      return
+    }
+    if (!gap) {
+      console.warn('[FillGap FLF2V] click with no gap in context menu', { menuState })
+      return
+    }
+    console.log('[FillGap FLF2V] starting for gap', { start: gap.startTime, end: gap.endTime, trackId: gap.trackId })
     setGapFillBusy(true)
     try {
       const fps = Number(timelineFps) > 0 ? Number(timelineFps) : 24
@@ -958,7 +973,12 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
         captureTimelineFrameAt(firstFrameTime),
       ])
       if (!startResult || !endResult) {
-        console.warn('[FillGap FLF2V] Failed to capture one or both gap boundary frames')
+        console.warn('[FillGap FLF2V] Failed to capture one or both gap boundary frames', {
+          lastFrameTime,
+          firstFrameTime,
+          startResult: !!startResult,
+          endResult: !!endResult,
+        })
         return
       }
       useFrameForAIStore.getState().setFrame({
@@ -978,7 +998,7 @@ function Timeline({ onOpenAudioGenerate, onActiveToolChange }) {
       setGapFillBusy(false)
       setGapContextMenu(null)
     }
-  }, [gapContextMenu, gapFillBusy, timelineFps])
+  }, [gapFillBusy, timelineFps])
   const clipContextSelectionIds = useMemo(() => (
     clipContextMenu ? selectedClipIds : []
   ), [clipContextMenu, selectedClipIds])

--- a/src/services/builtinWorkflows/flf2vProfiles.js
+++ b/src/services/builtinWorkflows/flf2vProfiles.js
@@ -210,6 +210,56 @@ export function saveSelectedProfileId(record) {
   } catch (_) { /* ignore quota errors */ }
 }
 
+// --- Per-profile prompt overrides -----------------------------------------
+// Lets the user save their modified prompt + negative prompt as the new
+// defaults for a given workflow profile (bundled or imported). Keyed by
+// profile id; survives restarts. Clear with clearProfilePromptOverrides().
+
+const LS_PROMPT_OVERRIDES_KEY = 'comfystudio.flf2v.promptOverrides'
+
+function readOverridesMap() {
+  try {
+    const raw = localStorage.getItem(LS_PROMPT_OVERRIDES_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  } catch (_) {
+    return {}
+  }
+}
+
+export function loadProfilePromptOverrides(profileId) {
+  if (!profileId) return null
+  const map = readOverridesMap()
+  return map[profileId] || null
+}
+
+export function saveProfilePromptOverrides(profileId, { prompt, negativePrompt } = {}) {
+  if (!profileId) return
+  const map = readOverridesMap()
+  if (prompt == null && negativePrompt == null) {
+    delete map[profileId]
+  } else {
+    map[profileId] = {
+      prompt: typeof prompt === 'string' ? prompt : '',
+      negativePrompt: typeof negativePrompt === 'string' ? negativePrompt : '',
+    }
+  }
+  try {
+    localStorage.setItem(LS_PROMPT_OVERRIDES_KEY, JSON.stringify(map))
+  } catch (_) { /* ignore quota errors */ }
+}
+
+export function clearProfilePromptOverrides(profileId) {
+  if (!profileId) return
+  const map = readOverridesMap()
+  if (!(profileId in map)) return
+  delete map[profileId]
+  try {
+    localStorage.setItem(LS_PROMPT_OVERRIDES_KEY, JSON.stringify(map))
+  } catch (_) { /* ignore quota errors */ }
+}
+
 // Find a profile by id. For 'imported:*' ids, callers must look the
 // imported profile up themselves — this only resolves bundled ids.
 export function getBundledProfile(id) {

--- a/src/services/builtinWorkflows/flf2vProfiles.js
+++ b/src/services/builtinWorkflows/flf2vProfiles.js
@@ -1,0 +1,217 @@
+// FLF2V workflow profile registry + auto-detect for user-imported JSON.
+//
+// A "profile" describes how to inject per-job values (start/end frames,
+// dimensions, prompts, fps, seed, filename) into a ComfyUI API-format
+// workflow JSON. Two kinds:
+//   - Bundled: shipped with the app, hand-tuned (e.g. WAN 2.2 14B).
+//   - Imported: parsed from a user JSON file. Schema is auto-detected
+//     from class_type / input names. Best-effort — if detection is
+//     ambiguous the profile is still returned but the import UI flags
+//     a warning.
+//
+// Each profile exposes the same surface so Flf2vDraftCard doesn't care:
+//   { id, label, kind, workflowJson, mutation, detectWarnings }
+//
+// mutation is a small object of `(workflow, ctx) => void` setters. Only
+// the ones the workflow actually needs must be present.
+
+import {
+  WAN22_FLF2V_WORKFLOW_JSON,
+  WAN22_FLF2V_NODES as WN,
+} from './wan22Flf2v'
+
+// --- Bundled profiles -------------------------------------------------------
+
+const wan22Mutate = {
+  setStartImage: (wf, name) => { wf[WN.LOAD_START].inputs.image = name },
+  setEndImage:   (wf, name) => { wf[WN.LOAD_END].inputs.image = name },
+  setWidth:      (wf, w)    => { wf[WN.WAN_FLF2V].inputs.width = w },
+  setHeight:     (wf, h)    => { wf[WN.WAN_FLF2V].inputs.height = h },
+  setLength:     (wf, len)  => { wf[WN.WAN_FLF2V].inputs.length = len },
+  setPositivePrompt: (wf, t) => { wf[WN.CLIP_POS].inputs.text = t },
+  setNegativePrompt: (wf, t) => { wf[WN.CLIP_NEG].inputs.text = t },
+  setFps:        (wf, fps)  => { wf[WN.CREATE_VIDEO].inputs.fps = fps },
+  setSeeds:      (wf, seed) => {
+    wf[WN.KSAMPLER_1].inputs.noise_seed = seed
+    wf[WN.KSAMPLER_2].inputs.noise_seed = seed
+  },
+  setFilenamePrefix: (wf, p) => { wf[WN.SAVE_VIDEO].inputs.filename_prefix = p },
+}
+
+const WAN22_FLF2V_PROFILE = Object.freeze({
+  id: 'wan22-flf2v',
+  label: 'WAN 2.2 14B (local)',
+  description: 'Default bundled workflow. Wan 2.2 14B high/low noise with 4-step lightx2v LoRA. 24GB+ VRAM recommended.',
+  kind: 'local',
+  workflowJson: WAN22_FLF2V_WORKFLOW_JSON,
+  mutation: wan22Mutate,
+  detectWarnings: [],
+})
+
+export const BUNDLED_FLF2V_PROFILES = Object.freeze([WAN22_FLF2V_PROFILE])
+
+// --- Auto-detect for imported workflows -------------------------------------
+
+// Walk a workflow graph and bucket nodes by class_type + a heuristic title
+// or input-field scan. Returns enough info to wire setters without knowing
+// the specific node IDs ahead of time.
+function indexNodes(workflowJson) {
+  const buckets = {
+    loadImage: [],          // LoadImage nodes
+    clipText: [],           // CLIPTextEncode nodes
+    wanFLF2V: [],           // WanFirstLastFrameToVideo or WanFunInpaintToVideo
+    byteDanceFLF2V: [],     // ByteDance2FirstLastFrameNode (Seedance)
+    createVideo: [],        // CreateVideo
+    ksampler: [],           // KSampler / KSamplerAdvanced
+    saveVideo: [],          // SaveVideo
+  }
+  for (const [id, node] of Object.entries(workflowJson || {})) {
+    if (!node || typeof node !== 'object') continue
+    const ct = node.class_type
+    if (!ct) continue
+    const title = String(node?._meta?.title || '').toLowerCase()
+    if (ct === 'LoadImage') buckets.loadImage.push({ id, node, title })
+    else if (ct === 'CLIPTextEncode') buckets.clipText.push({ id, node, title })
+    else if (ct === 'WanFirstLastFrameToVideo' || ct === 'WanFunInpaintToVideo') buckets.wanFLF2V.push({ id, node, title })
+    else if (/FirstLastFrame/i.test(ct)) buckets.byteDanceFLF2V.push({ id, node, title })
+    else if (ct === 'CreateVideo') buckets.createVideo.push({ id, node, title })
+    else if (ct === 'KSampler' || ct === 'KSamplerAdvanced') buckets.ksampler.push({ id, node, title })
+    else if (ct === 'SaveVideo') buckets.saveVideo.push({ id, node, title })
+  }
+  return buckets
+}
+
+// Pick a CLIPTextEncode node id for positive/negative based on title.
+function pickClipText(clips, want) {
+  if (!clips.length) return null
+  const exact = clips.find((c) => c.title.includes(want))
+  if (exact) return exact.id
+  // Fallback: first / last
+  return want === 'positive' ? clips[0]?.id : clips[clips.length - 1]?.id
+}
+
+// Try to detect a WanFLF2V-style schema. Returns mutation + warnings.
+function detectWanFlf2v(workflowJson) {
+  const warnings = []
+  const b = indexNodes(workflowJson)
+  if (b.loadImage.length < 2) warnings.push(`Expected 2 LoadImage nodes, found ${b.loadImage.length}.`)
+  if (!b.wanFLF2V.length) warnings.push('No WanFirstLastFrameToVideo node found.')
+  if (!b.createVideo.length) warnings.push('No CreateVideo node found.')
+  if (!b.saveVideo.length) warnings.push('No SaveVideo node found.')
+
+  // Detect which LoadImage is start vs end by inspecting WanFLF2V wiring
+  let startId = b.loadImage[0]?.id || null
+  let endId = b.loadImage[1]?.id || null
+  if (b.wanFLF2V.length) {
+    const wan = b.wanFLF2V[0].node
+    const si = wan.inputs?.start_image
+    const ei = wan.inputs?.end_image
+    if (Array.isArray(si)) startId = String(si[0])
+    if (Array.isArray(ei)) endId = String(ei[0])
+  }
+
+  const wanId = b.wanFLF2V[0]?.id || null
+  const fpsId = b.createVideo[0]?.id || null
+  const saveId = b.saveVideo[0]?.id || null
+  const seedIds = b.ksampler.map((k) => k.id)
+  const posId = pickClipText(b.clipText, 'positive')
+  const negId = pickClipText(b.clipText, 'negative')
+
+  return {
+    mutation: {
+      setStartImage: startId ? (wf, name) => { wf[startId].inputs.image = name } : null,
+      setEndImage:   endId   ? (wf, name) => { wf[endId].inputs.image = name } : null,
+      setWidth:      wanId   ? (wf, w)    => { wf[wanId].inputs.width = w } : null,
+      setHeight:     wanId   ? (wf, h)    => { wf[wanId].inputs.height = h } : null,
+      setLength:     wanId   ? (wf, len)  => { wf[wanId].inputs.length = len } : null,
+      setPositivePrompt: posId ? (wf, t) => { wf[posId].inputs.text = t } : null,
+      setNegativePrompt: negId ? (wf, t) => { wf[negId].inputs.text = t } : null,
+      setFps:        fpsId   ? (wf, fps)  => { wf[fpsId].inputs.fps = fps } : null,
+      setSeeds:      seedIds.length ? (wf, seed) => {
+        for (const sid of seedIds) wf[sid].inputs.noise_seed = seed
+      } : null,
+      setFilenamePrefix: saveId ? (wf, p) => { wf[saveId].inputs.filename_prefix = p } : null,
+    },
+    warnings,
+    meta: { startId, endId, wanId, fpsId, saveId, seedIds, posId, negId },
+  }
+}
+
+// Detect cloud-style single-node FLF2V (Seedance, etc.). For now we just
+// hand back what we know and let the caller decide. Many cloud fields don't
+// match the WAN-style mutation surface so this is a partial fit.
+function detectCloudFlf2v(workflowJson) {
+  const warnings = ['Cloud workflow detected — only frame injection is wired automatically. Edit the workflow JSON directly for prompt/dimension changes.']
+  const b = indexNodes(workflowJson)
+  let startId = b.loadImage[0]?.id || null
+  let endId = b.loadImage[1]?.id || null
+  if (b.byteDanceFLF2V.length) {
+    const cloud = b.byteDanceFLF2V[0].node
+    const ff = cloud.inputs?.first_frame
+    const lf = cloud.inputs?.last_frame
+    if (Array.isArray(ff)) startId = String(ff[0])
+    if (Array.isArray(lf)) endId = String(lf[0])
+  }
+  return {
+    mutation: {
+      setStartImage: startId ? (wf, name) => { wf[startId].inputs.image = name } : null,
+      setEndImage:   endId   ? (wf, name) => { wf[endId].inputs.image = name } : null,
+      setWidth:      null, setHeight: null, setLength: null,
+      setPositivePrompt: null, setNegativePrompt: null,
+      setFps: null, setSeeds: null,
+      setFilenamePrefix: b.saveVideo[0]
+        ? (wf, p) => { wf[b.saveVideo[0].id].inputs.filename_prefix = p }
+        : null,
+    },
+    warnings,
+    meta: { startId, endId, cloudId: b.byteDanceFLF2V[0]?.id || null },
+  }
+}
+
+export function detectProfileFromJson(workflowJson, sourceName = 'imported') {
+  if (!workflowJson || typeof workflowJson !== 'object') {
+    throw new Error('Workflow JSON must be an object')
+  }
+  const looksCloud = indexNodes(workflowJson).byteDanceFLF2V.length > 0
+  const detected = looksCloud ? detectCloudFlf2v(workflowJson) : detectWanFlf2v(workflowJson)
+  const id = `imported:${sourceName}:${Date.now()}`
+  return {
+    id,
+    label: sourceName,
+    description: looksCloud
+      ? 'Imported cloud FLF2V workflow (e.g. Seedance).'
+      : 'Imported local FLF2V workflow (auto-detected schema).',
+    kind: looksCloud ? 'cloud' : 'local',
+    workflowJson,
+    mutation: detected.mutation,
+    detectWarnings: detected.warnings,
+  }
+}
+
+// --- Persistence ------------------------------------------------------------
+
+const LS_KEY = 'comfystudio.flf2v.selectedWorkflow'
+
+export function loadSelectedProfileId() {
+  try {
+    const raw = localStorage.getItem(LS_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed : null
+  } catch (_) {
+    return null
+  }
+}
+
+export function saveSelectedProfileId(record) {
+  try {
+    if (record) localStorage.setItem(LS_KEY, JSON.stringify(record))
+    else localStorage.removeItem(LS_KEY)
+  } catch (_) { /* ignore quota errors */ }
+}
+
+// Find a profile by id. For 'imported:*' ids, callers must look the
+// imported profile up themselves — this only resolves bundled ids.
+export function getBundledProfile(id) {
+  return BUNDLED_FLF2V_PROFILES.find((p) => p.id === id) || null
+}

--- a/src/services/builtinWorkflows/wan22Flf2v.js
+++ b/src/services/builtinWorkflows/wan22Flf2v.js
@@ -1,0 +1,317 @@
+// API-format workflow JSON for WAN 2.2 14B First-Last Frame to Video (FLF2V).
+// Converted from the user's tested '▶️ Video FLF.json' (active 4-step
+// lightx2v pipeline A). The action card mutates runtime inputs at submit:
+//   - 97.image  = uploaded start frame filename
+//   - 971.image = uploaded end frame filename
+//   - 98.length = round(duration * fps) + 1
+//   - 93.text   = positive prompt
+//   - 89.text   = negative prompt
+//   - 86.noise_seed / 85.noise_seed = same seed
+//   - 94.fps    = timeline fps
+//   - 108.filename_prefix = output token per job
+
+export const WAN22_FLF2V_WORKFLOW_JSON = {
+  "84": {
+    "inputs": {
+      "clip_name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+      "type": "wan",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "89": {
+    "inputs": {
+      "text": "A bearded man with red facial hair wearing a yellow straw hat and dark coat in Van Gogh's self-portrait style, slowly and continuously transforms into a space astronaut. The transformation flows like liquid paint - his beard fades away strand by strand, the yellow hat melts and reforms smoothly into a silver space helmet, dark coat gradually lightens and restructures into a white spacesuit. The background swirling brushstrokes slowly organize and clarify into realistic stars and space, with Earth appearing gradually in the distance. Every change happens in seamless waves, maintaining visual continuity throughout the metamorphosis.\n\nConsistent soft lighting throughout, medium close-up maintaining same framing, central composition stays fixed, gentle color temperature shift from warm to cool, gradual contrast increase, smooth style transition from painterly to photorealistic. Static camera with subtle slow zoom, emphasizing the flowing transformation process without abrupt changes.",
+      "clip": [
+        "84",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "93": {
+    "inputs": {
+      "text": "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走",
+      "clip": [
+        "84",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "90": {
+    "inputs": {
+      "vae_name": "wan_2.1_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "97": {
+    "inputs": {
+      "image": "video_wan2_2_14B_flf2v_start_image.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "971": {
+    "inputs": {
+      "image": "video_wan2_2_14B_flf2v_end_image.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "98": {
+    "inputs": {
+      "width": 640,
+      "height": 640,
+      "length": 81,
+      "batch_size": 1,
+      "positive": [
+        "89",
+        0
+      ],
+      "negative": [
+        "93",
+        0
+      ],
+      "vae": [
+        "90",
+        0
+      ],
+      "start_image": [
+        "97",
+        0
+      ],
+      "end_image": [
+        "971",
+        0
+      ]
+    },
+    "class_type": "WanFirstLastFrameToVideo",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "95": {
+    "inputs": {
+      "unet_name": "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "101": {
+    "inputs": {
+      "lora_name": "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors",
+      "strength_model": 1,
+      "model": [
+        "95",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "103": {
+    "inputs": {
+      "shift": 5,
+      "model": [
+        "101",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "96": {
+    "inputs": {
+      "unet_name": "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "102": {
+    "inputs": {
+      "lora_name": "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors",
+      "strength_model": 1,
+      "model": [
+        "96",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "104": {
+    "inputs": {
+      "shift": 5,
+      "model": [
+        "102",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "86": {
+    "inputs": {
+      "add_noise": "enable",
+      "noise_seed": 984937593540091,
+      "control_after_generate": "randomize",
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 0,
+      "end_at_step": 2,
+      "return_with_leftover_noise": "enable",
+      "model": [
+        "103",
+        0
+      ],
+      "positive": [
+        "98",
+        0
+      ],
+      "negative": [
+        "98",
+        1
+      ],
+      "latent_image": [
+        "98",
+        2
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "85": {
+    "inputs": {
+      "add_noise": "disable",
+      "noise_seed": 0,
+      "control_after_generate": "fixed",
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 2,
+      "end_at_step": 10000,
+      "return_with_leftover_noise": "disable",
+      "model": [
+        "104",
+        0
+      ],
+      "positive": [
+        "98",
+        0
+      ],
+      "negative": [
+        "98",
+        1
+      ],
+      "latent_image": [
+        "86",
+        0
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "87": {
+    "inputs": {
+      "samples": [
+        "85",
+        0
+      ],
+      "vae": [
+        "90",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "94": {
+    "inputs": {
+      "fps": 16,
+      "images": [
+        "87",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": ""
+    }
+  },
+  "108": {
+    "inputs": {
+      "filename_prefix": "video/ComfyUI",
+      "format": "auto",
+      "codec": "auto",
+      "video": [
+        "94",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": ""
+    }
+  }
+}
+
+export const WAN22_FLF2V_NODES = {
+  CLIP_LOADER: '84',
+  KSAMPLER_1: '86',
+  KSAMPLER_2: '85',
+  VAE_DECODE: '87',
+  CLIP_NEG: '89',
+  VAE_LOADER: '90',
+  CLIP_POS: '93',
+  CREATE_VIDEO: '94',
+  UNET_HIGH: '95',
+  UNET_LOW: '96',
+  LOAD_START: '97',
+  LOAD_END: '971',
+  WAN_FLF2V: '98',
+  LORA_HIGH: '101',
+  LORA_LOW: '102',
+  MSAMP_HIGH: '103',
+  MSAMP_LOW: '104',
+  SAVE_VIDEO: '108',
+}

--- a/src/services/comfyui.js
+++ b/src/services/comfyui.js
@@ -1427,6 +1427,74 @@ export function modifyWAN22Workflow(workflow, options = {}) {
 }
 
 /**
+ * Workflow modifier for WAN 2.2 14B First-Last-Frame-to-Video.
+ *
+ * Mirrors modifyWAN22Workflow but the central node is WanFirstLastFrameToVideo
+ * (which takes `start_image` and `end_image` as two io.Image inputs) and the
+ * input images come from the two LoadImage nodes `97` (start) and `971` (end).
+ *
+ * `startImageFilename` / `endImageFilename` should be the filenames returned
+ * by comfyui.uploadFile() — ComfyUI then resolves them to actual inputs.
+ */
+export function modifyWan22FLF2VWorkflow(workflow, options = {}) {
+  const {
+    prompt = '',
+    negativePrompt = '',
+    startImageFilename = '',
+    endImageFilename = '',
+    width = 800,
+    height = 1424,
+    frames = 81,
+    fps = 16,
+    seed = Math.floor(Math.random() * 1000000000000),
+    filenamePrefix = 'video/ComfyStudio_wan22_flf2v',
+  } = options
+
+  const modified = JSON.parse(JSON.stringify(workflow))
+
+  // Positive prompt (node 93)
+  if (modified['93']) {
+    modified['93'].inputs.text = prompt
+  }
+  // Negative prompt (node 89)
+  if (modified['89']) {
+    modified['89'].inputs.text = negativePrompt
+  }
+  // Start frame input (LoadImage node 97)
+  if (modified['97']) {
+    if (startImageFilename) modified['97'].inputs.image = startImageFilename
+  }
+  // End frame input (LoadImage node 971)
+  if (modified['971']) {
+    if (endImageFilename) modified['971'].inputs.image = endImageFilename
+  }
+  // Resolution + frame count (node 98 - WanFirstLastFrameToVideo)
+  if (modified['98']) {
+    modified['98'].inputs.width = width
+    modified['98'].inputs.height = height
+    modified['98'].inputs.length = frames
+  }
+  // FPS (node 94 - CreateVideo)
+  if (modified['94']) {
+    modified['94'].inputs.fps = fps
+  }
+  // Seed (node 86 - KSamplerAdvanced 1st pass)
+  if (modified['86']) {
+    modified['86'].inputs.noise_seed = seed
+  }
+  // Seed (node 85 - KSamplerAdvanced 2nd pass)
+  if (modified['85']) {
+    modified['85'].inputs.noise_seed = seed
+  }
+  // Output prefix (node 108)
+  if (modified['108']) {
+    modified['108'].inputs.filename_prefix = filenamePrefix
+  }
+
+  return modified
+}
+
+/**
  * Workflow modifier for LTX 2.3 Image-to-Video
  */
 export function modifyLTX23I2VWorkflow(workflow, options = {}) {

--- a/src/stores/frameForAIStore.js
+++ b/src/stores/frameForAIStore.js
@@ -1,11 +1,25 @@
 import { create } from 'zustand'
 
 /**
- * Store for "frame from timeline" sent to Generate tab for AI extend/keyframe.
- * When set, Generate tab can use this frame as input for image-to-video workflows.
+ * Store for "frame from timeline" sent to Generate tab for AI extend/keyframe,
+ * as well as the two-frame payload used by the timeline "Fill Gap (FLF2V)"
+ * action.
+ *
+ * Shapes supported:
+ *   - Legacy single-frame:
+ *       { mode: 'extend' | 'keyframe', blobUrl, file }
+ *   - Two-frame FLF2V (used by Timeline.jsx → Generate workspace → wan22-flf2v):
+ *       {
+ *         mode: 'flf2v',
+ *         startFrame: { blobUrl, file },
+ *         endFrame:   { blobUrl, file },
+ *         targetDurationSeconds,
+ *         targetTrackId,
+ *         targetGapStartTime,
+ *       }
  */
 export const useFrameForAIStore = create((set) => ({
-  /** { blobUrl, file, mode: 'extend'|'keyframe' } or null */
+  /** Frame payload or null. See file header for supported shapes. */
   frame: null,
 
   setFrame: (frame) => {
@@ -14,10 +28,17 @@ export const useFrameForAIStore = create((set) => ({
 
   clearFrame: () => {
     set((state) => {
-      if (state.frame?.blobUrl) {
-        try {
-          URL.revokeObjectURL(state.frame.blobUrl)
-        } catch (_) {}
+      const frame = state.frame
+      if (frame) {
+        if (frame.blobUrl) {
+          try { URL.revokeObjectURL(frame.blobUrl) } catch (_) {}
+        }
+        if (frame.startFrame?.blobUrl) {
+          try { URL.revokeObjectURL(frame.startFrame.blobUrl) } catch (_) {}
+        }
+        if (frame.endFrame?.blobUrl) {
+          try { URL.revokeObjectURL(frame.endFrame.blobUrl) } catch (_) {}
+        }
       }
       return { frame: null }
     })

--- a/src/utils/captureTimelineFrame.js
+++ b/src/utils/captureTimelineFrame.js
@@ -257,3 +257,101 @@ export async function loadClipSourceAtTime(clip, asset, time) {
     return null
   }
 }
+
+/**
+ * Capture a single frame from a SINGLE clip at a given timeline time.
+ *
+ * Unlike captureTimelineFrameAt (which composites the full timeline),
+ * this only loads the named clip's source and draws it to the canvas.
+ * Use this for FLF2V gap-fill where we want one frame from the clip
+ * immediately before / after the gap.
+ *
+ * @param {object} clip   Clip record (with type, startTime, assetId, ...)
+ * @param {object} asset  Asset record (with url)
+ * @param {number} time   Timeline time to seek to (seconds)
+ * @returns Promise<{ blobUrl, file } | null>
+ */
+export async function captureSingleClipFrame(clip, asset, time) {
+  if (!clip || !asset?.url) return null
+  try {
+    const projectState = useProjectStore.getState?.()
+    const settings = projectState?.getCurrentTimelineSettings?.()
+      || projectState?.currentProject?.settings
+      || {}
+    const width = Math.max(16, Math.min(7680, Number(settings.width) || 1920))
+    const height = Math.max(16, Math.min(4320, Number(settings.height) || 1080))
+
+    const loaded = await loadClipSourceAtTime(clip, asset, time)
+    if (!loaded?.element) return null
+    try {
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d', { alpha: false })
+      if (!ctx) return null
+      ctx.fillStyle = '#000000'
+      ctx.fillRect(0, 0, width, height)
+      ctx.drawImage(loaded.element, 0, 0, width, height)
+      const blob = await new Promise((resolve) => canvas.toBlob((b) => resolve(b), 'image/png'))
+      if (!blob) return null
+      const file = new File([blob], `gapfill_frame_${Date.now()}.png`, { type: 'image/png' })
+      const blobUrl = URL.createObjectURL(blob)
+      return { blobUrl, file }
+    } finally {
+      try { loaded.cleanup?.() } catch (_) { /* ignore */ }
+    }
+  } catch (err) {
+    console.warn('[captureSingleClipFrame] failed:', err?.message || err)
+    return null
+  }
+}
+
+/**
+ * Capture the last frame of the before-clip and the first frame of the
+ * after-clip for an FLF2V gap fill.
+ *
+ * Each capture seeks STRICTLY INSIDE the source clip's [start, start+duration]
+ * range, so we never depend on getActiveClipsAtTime returning the clip at
+ * a point past its edge (the bug that broke gap #2 fill: the composite
+ * renderTimelineCompositeStill returned false because no clip was active
+ * at firstFrameTime = gap.endTime + eps).
+ *
+ * @param {object} beforeClip  { clip, track } — clip immediately before the gap
+ * @param {object} afterClip   { clip, track } — clip immediately after the gap
+ * @returns Promise<{ start: {blobUrl, file} | null, end: {blobUrl, file} | null }>
+ */
+export async function captureGapBoundaryFrames(beforeClip, afterClip) {
+  const fps = Math.max(
+    1,
+    Number(beforeClip?.clip?.timelineFps) || Number(afterClip?.clip?.timelineFps) || 24
+  )
+  const eps = 1 / fps
+
+  let startResult = null
+  let endResult = null
+
+  if (beforeClip?.clip) {
+    const assetsState = useAssetsStore.getState()
+    const asset = assetsState?.getAssetById?.(beforeClip.clip.assetId)
+    if (asset?.url) {
+      const start = Number(beforeClip.clip.startTime) || 0
+      const dur = Number(beforeClip.clip.duration) || 0
+      // Seek to last frame (start + duration - eps), but never before start.
+      const t = Math.max(start + eps, start + dur - eps)
+      startResult = await captureSingleClipFrame(beforeClip.clip, asset, t)
+    }
+  }
+
+  if (afterClip?.clip) {
+    const assetsState = useAssetsStore.getState()
+    const asset = assetsState?.getAssetById?.(afterClip.clip.assetId)
+    if (asset?.url) {
+      const start = Number(afterClip.clip.startTime) || 0
+      // Seek to first frame after the clip's start edge.
+      const t = start + eps
+      endResult = await captureSingleClipFrame(afterClip.clip, asset, t)
+    }
+  }
+
+  return { start: startResult, end: endResult }
+}

--- a/src/utils/captureTimelineFrame.js
+++ b/src/utils/captureTimelineFrame.js
@@ -341,7 +341,10 @@ export async function loadClipSourceAtTime(clip, asset, time) {
         if (video.error?.code === 4 /* MEDIA_ERR_SRC_NOT_SUPPORTED */
             || video.error?.code === 3 /* MEDIA_ERR_DECODE */
             || /DEMUXER_ERROR|no supported streams/i.test(video.error?.message || '')) {
-          const filePath = src.startsWith('file://') ? filePathFromFileUrl(src) : null
+          // The asset URL is usually blob:file:///... (timeline stores it as a
+          // blob), so filePathFromFileUrl won't match — use absolutePath instead.
+          let filePath = src.startsWith('file://') ? filePathFromFileUrl(src) : null
+          if (!filePath && asset.absolutePath) filePath = asset.absolutePath
           if (filePath && window.electronAPI?.extractVideoFrame) {
             console.log('[loadClipSourceAtTime] falling back to ffmpeg IPC', { filePath, sourceTime })
             try {

--- a/src/utils/captureTimelineFrame.js
+++ b/src/utils/captureTimelineFrame.js
@@ -222,20 +222,33 @@ export async function loadClipSourceAtTime(clip, asset, time) {
   if (!clip || !asset) return null
   try {
     if (clip.type === 'image') {
-      const src = encodeFileUrl(asset.url)
+      const src = asset.url
       if (!src) return null
+      let playableSrc = encodeFileUrl(src)
+      let blobUrl = null
+      if (src.startsWith('file://') || src.startsWith('blob:')) {
+        try {
+          const resp = await fetch(src)
+          if (resp.ok) {
+            const blob = await resp.blob()
+            blobUrl = URL.createObjectURL(blob)
+            playableSrc = blobUrl
+          }
+        } catch (_) { /* fall through to encoded file:// */ }
+      }
       const img = await new Promise((resolve, reject) => {
         const el = new Image()
-        el.crossOrigin = 'anonymous'
         el.onload = () => resolve(el)
         el.onerror = () => reject(new Error('image load failed'))
-        el.src = src
+        el.src = playableSrc
       })
       return {
         element: img,
         width: img.naturalWidth || img.width,
         height: img.naturalHeight || img.height,
-        cleanup: () => {},
+        cleanup: () => {
+          if (blobUrl) try { URL.revokeObjectURL(blobUrl) } catch (_) { /* ignore */ }
+        },
       }
     }
 
@@ -243,13 +256,33 @@ export async function loadClipSourceAtTime(clip, asset, time) {
       const src = asset.url
       if (!src) return null
       const sourceTime = getSourceTimeForClip(clip, time)
-      // file:// URLs from Electron's getFileUrlDirect are NOT URL-encoded,
-      // so a filename with non-ASCII characters (e.g. "▶️_00007.mp4")
-      // produces a src the <video> element can't decode — onerror fires
-      // with no further detail. Encode the path components before setting src.
-      const safeSrc = encodeFileUrl(src)
+      // Percent-encoding the file:// URL helps for paths with non-ASCII
+      // characters but Chromium can still refuse to load them (the issue
+      // is opaque — onerror just says "video decode failed" with no
+      // network/decoder code). Fetch the file into a Blob and create a
+      // blob: URL — that always works regardless of filename characters,
+      // CORS policy, or path encoding. The cost is one in-memory copy of
+      // the file per capture, which is fine for gap fill (one-off).
+      let playableSrc = encodeFileUrl(src)
+      let blobUrl = null
+      if (src.startsWith('file://') || src.startsWith('blob:')) {
+        try {
+          const resp = await fetch(src)
+          if (resp.ok) {
+            const blob = await resp.blob()
+            blobUrl = URL.createObjectURL(blob)
+            playableSrc = blobUrl
+            console.log('[loadClipSourceAtTime] video using blob URL', {
+              size: blob.size,
+              mime: blob.type,
+            })
+          }
+        } catch (err) {
+          console.log('[loadClipSourceAtTime] blob fallback fetch failed, using encoded src', err?.message || err)
+        }
+      }
       console.log('[loadClipSourceAtTime] video', {
-        srcPrefix: String(safeSrc).slice(0, 80),
+        srcPrefix: String(playableSrc).slice(0, 80),
         sourceTime,
         duration: clip.duration,
         timelineFps: clip.timelineFps,
@@ -257,32 +290,37 @@ export async function loadClipSourceAtTime(clip, asset, time) {
         trimEnd: clip.trimEnd,
       })
       const video = document.createElement('video')
-      video.crossOrigin = 'anonymous'
       video.muted = true
       video.preload = 'auto'
-      video.src = safeSrc
-      const result = await new Promise((resolve, reject) => {
-        let settled = false
-        const finish = (ok, err) => {
-          if (settled) return
-          settled = true
-          ok ? resolve() : reject(err)
-        }
-        video.onloadedmetadata = () => {
-          try {
-            video.currentTime = Math.min(sourceTime, Math.max(0, (video.duration || 0) - 0.01))
-          } catch (err) {
-            finish(false, err)
+      video.src = playableSrc
+      try {
+        await new Promise((resolve, reject) => {
+          let settled = false
+          const finish = (ok, err) => {
+            if (settled) return
+            settled = true
+            ok ? resolve() : reject(err)
           }
-        }
-        video.onseeked = () => finish(true)
-        video.onerror = () => finish(false, new Error('video decode failed'))
-        // Hard ceiling so a hung load never stalls a save.
-        setTimeout(() => finish(false, new Error('video seek timeout')), 4000)
-      }).catch((err) => {
-        console.log('[loadClipSourceAtTime] video load failed', err?.message || err)
+          video.onloadedmetadata = () => {
+            try {
+              video.currentTime = Math.min(sourceTime, Math.max(0, (video.duration || 0) - 0.01))
+            } catch (err) {
+              finish(false, err)
+            }
+          }
+          video.onseeked = () => finish(true)
+          video.onerror = () => {
+            const code = video.error?.code
+            console.log('[loadClipSourceAtTime] video.onerror', { code, message: video.error?.message })
+            finish(false, new Error('video decode failed'))
+          }
+          setTimeout(() => finish(false, new Error('video seek timeout')), 8000)
+        })
+      } catch (err) {
+        console.log('[loadClipSourceAtTime] video load failed', err?.message || err, { code: video.error?.code })
+        if (blobUrl) try { URL.revokeObjectURL(blobUrl) } catch (_) { /* ignore */ }
         throw err
-      })
+      }
       console.log('[loadClipSourceAtTime] video ok', { videoWidth: video.videoWidth, videoHeight: video.videoHeight })
       return {
         element: video,
@@ -290,6 +328,7 @@ export async function loadClipSourceAtTime(clip, asset, time) {
         height: video.videoHeight,
         cleanup: () => {
           try { video.removeAttribute('src'); video.load() } catch (_) { /* ignore */ }
+          if (blobUrl) try { URL.revokeObjectURL(blobUrl) } catch (_) { /* ignore */ }
         },
       }
     }

--- a/src/utils/captureTimelineFrame.js
+++ b/src/utils/captureTimelineFrame.js
@@ -455,7 +455,15 @@ export async function captureSingleClipFrame(clip, asset, time) {
       if (!blob) return null
       const file = new File([blob], `gapfill_frame_${Date.now()}.png`, { type: 'image/png' })
       const blobUrl = URL.createObjectURL(blob)
-      return { blobUrl, file }
+      // Surface the source's native dimensions so the FLF2V draft card can
+      // pre-fill width/height from the actual neighbor clips instead of
+      // defaulting to the project resolution.
+      return {
+        blobUrl,
+        file,
+        width: loaded.width || null,
+        height: loaded.height || null,
+      }
     } finally {
       try { loaded.cleanup?.() } catch (_) { /* ignore */ }
     }

--- a/src/utils/captureTimelineFrame.js
+++ b/src/utils/captureTimelineFrame.js
@@ -10,6 +10,31 @@ import {
 } from '../services/exporter'
 
 /**
+ * Encode a file:// URL so the <video> / <img> element can decode it.
+ *
+ * Electron's getFileUrlDirect returns the absolute path with literal
+ * characters — a filename like `▶️_00007.mp4` produces a src the browser
+ * rejects with no further error detail (just "video decode failed").
+ * We percent-encode every path segment after the leading `file://` so
+ * the URL is safe to set on a media element.
+ */
+export function encodeFileUrl(url) {
+  if (!url || typeof url !== 'string') return url
+  if (!url.startsWith('file://')) return url
+  // Strip the prefix, split on /, encode each segment, re-join.
+  // file:///path/to/file → prefix = 'file:///', rest = ['path','to','file']
+  const rest = url.slice('file://'.length)
+  const parts = rest.split('/').map((seg) => {
+    try {
+      return encodeURIComponent(decodeURIComponent(seg))
+    } catch (_) {
+      return seg
+    }
+  })
+  return 'file://' + parts.join('/')
+}
+
+/**
  * Get the topmost video or image clip at the given time (for capture).
  * Returns { clip, track } or null.
  */
@@ -197,7 +222,7 @@ export async function loadClipSourceAtTime(clip, asset, time) {
   if (!clip || !asset) return null
   try {
     if (clip.type === 'image') {
-      const src = asset.url
+      const src = encodeFileUrl(asset.url)
       if (!src) return null
       const img = await new Promise((resolve, reject) => {
         const el = new Image()
@@ -218,12 +243,25 @@ export async function loadClipSourceAtTime(clip, asset, time) {
       const src = asset.url
       if (!src) return null
       const sourceTime = getSourceTimeForClip(clip, time)
+      // file:// URLs from Electron's getFileUrlDirect are NOT URL-encoded,
+      // so a filename with non-ASCII characters (e.g. "▶️_00007.mp4")
+      // produces a src the <video> element can't decode — onerror fires
+      // with no further detail. Encode the path components before setting src.
+      const safeSrc = encodeFileUrl(src)
+      console.log('[loadClipSourceAtTime] video', {
+        srcPrefix: String(safeSrc).slice(0, 80),
+        sourceTime,
+        duration: clip.duration,
+        timelineFps: clip.timelineFps,
+        trimStart: clip.trimStart,
+        trimEnd: clip.trimEnd,
+      })
       const video = document.createElement('video')
       video.crossOrigin = 'anonymous'
       video.muted = true
       video.preload = 'auto'
-      video.src = src
-      await new Promise((resolve, reject) => {
+      video.src = safeSrc
+      const result = await new Promise((resolve, reject) => {
         let settled = false
         const finish = (ok, err) => {
           if (settled) return
@@ -241,7 +279,11 @@ export async function loadClipSourceAtTime(clip, asset, time) {
         video.onerror = () => finish(false, new Error('video decode failed'))
         // Hard ceiling so a hung load never stalls a save.
         setTimeout(() => finish(false, new Error('video seek timeout')), 4000)
+      }).catch((err) => {
+        console.log('[loadClipSourceAtTime] video load failed', err?.message || err)
+        throw err
       })
+      console.log('[loadClipSourceAtTime] video ok', { videoWidth: video.videoWidth, videoHeight: video.videoHeight })
       return {
         element: video,
         width: video.videoWidth,
@@ -273,6 +315,12 @@ export async function loadClipSourceAtTime(clip, asset, time) {
  */
 export async function captureSingleClipFrame(clip, asset, time) {
   if (!clip || !asset?.url) return null
+  console.log('[captureSingleClipFrame] starting', {
+    clipType: clip.type,
+    clipId: clip?.id,
+    time,
+    urlPrefix: String(asset.url).slice(0, 80),
+  })
   try {
     const projectState = useProjectStore.getState?.()
     const settings = projectState?.getCurrentTimelineSettings?.()
@@ -281,7 +329,14 @@ export async function captureSingleClipFrame(clip, asset, time) {
     const width = Math.max(16, Math.min(7680, Number(settings.width) || 1920))
     const height = Math.max(16, Math.min(4320, Number(settings.height) || 1080))
 
-    const loaded = await loadClipSourceAtTime(clip, asset, time)
+    let loaded
+    try {
+      loaded = await loadClipSourceAtTime(clip, asset, time)
+    } catch (innerErr) {
+      console.log('[captureSingleClipFrame] loadClipSourceAtTime threw', innerErr?.message || innerErr)
+      throw innerErr
+    }
+    console.log('[captureSingleClipFrame] loaded', { hasLoaded: !!loaded, hasElement: !!(loaded && loaded.element) })
     if (!loaded?.element) return null
     try {
       const canvas = document.createElement('canvas')
@@ -333,24 +388,46 @@ export async function captureGapBoundaryFrames(beforeClip, afterClip) {
   if (beforeClip?.clip) {
     const assetsState = useAssetsStore.getState()
     const asset = assetsState?.getAssetById?.(beforeClip.clip.assetId)
+    console.log('[FillGap FLF2V] before-clip capture', {
+      clipId: beforeClip.clip.id,
+      assetId: beforeClip.clip.assetId,
+      hasAsset: !!asset,
+      hasUrl: !!asset?.url,
+      start: beforeClip.clip.startTime,
+      duration: beforeClip.clip.duration,
+    })
     if (asset?.url) {
       const start = Number(beforeClip.clip.startTime) || 0
       const dur = Number(beforeClip.clip.duration) || 0
       // Seek to last frame (start + duration - eps), but never before start.
       const t = Math.max(start + eps, start + dur - eps)
       startResult = await captureSingleClipFrame(beforeClip.clip, asset, t)
+      console.log('[FillGap FLF2V] before-clip capture result', { ok: !!startResult, t })
     }
+  } else {
+    console.log('[FillGap FLF2V] no before-clip entry')
   }
 
   if (afterClip?.clip) {
     const assetsState = useAssetsStore.getState()
     const asset = assetsState?.getAssetById?.(afterClip.clip.assetId)
+    console.log('[FillGap FLF2V] after-clip capture', {
+      clipId: afterClip.clip.id,
+      assetId: afterClip.clip.assetId,
+      hasAsset: !!asset,
+      hasUrl: !!asset?.url,
+      start: afterClip.clip.startTime,
+      duration: afterClip.clip.duration,
+    })
     if (asset?.url) {
       const start = Number(afterClip.clip.startTime) || 0
       // Seek to first frame after the clip's start edge.
       const t = start + eps
       endResult = await captureSingleClipFrame(afterClip.clip, asset, t)
+      console.log('[FillGap FLF2V] after-clip capture result', { ok: !!endResult, t })
     }
+  } else {
+    console.log('[FillGap FLF2V] no after-clip entry')
   }
 
   return { start: startResult, end: endResult }

--- a/src/utils/captureTimelineFrame.js
+++ b/src/utils/captureTimelineFrame.js
@@ -35,6 +35,21 @@ export function encodeFileUrl(url) {
 }
 
 /**
+ * Convert a file:// URL back to an absolute filesystem path.
+ * Inverse of encodeFileUrl — used so we can hand a real path to
+ * ffmpeg-static via IPC for HEVC/other-codec fallback.
+ */
+export function filePathFromFileUrl(url) {
+  if (!url || typeof url !== 'string') return null
+  if (!url.startsWith('file://')) return null
+  const rest = url.slice('file://'.length)
+  // Decode each segment (inverse of encodeFileUrl's split+encodeURIComponent)
+  return '/' + rest.split('/').map((seg) => {
+    try { return decodeURIComponent(seg) } catch (_) { return seg }
+  }).join('/')
+}
+
+/**
  * Get the topmost video or image clip at the given time (for capture).
  * Returns { clip, track } or null.
  */
@@ -319,6 +334,53 @@ export async function loadClipSourceAtTime(clip, asset, time) {
       } catch (err) {
         console.log('[loadClipSourceAtTime] video load failed', err?.message || err, { code: video.error?.code })
         if (blobUrl) try { URL.revokeObjectURL(blobUrl) } catch (_) { /* ignore */ }
+
+        // Fallback: if the renderer can't decode the file (Chromium has no
+        // H.265/HEVC decoder on Linux), use ffmpeg-static via the main
+        // process to extract a single frame as PNG. Works for any codec.
+        if (video.error?.code === 4 /* MEDIA_ERR_SRC_NOT_SUPPORTED */
+            || video.error?.code === 3 /* MEDIA_ERR_DECODE */
+            || /DEMUXER_ERROR|no supported streams/i.test(video.error?.message || '')) {
+          const filePath = src.startsWith('file://') ? filePathFromFileUrl(src) : null
+          if (filePath && window.electronAPI?.extractVideoFrame) {
+            console.log('[loadClipSourceAtTime] falling back to ffmpeg IPC', { filePath, sourceTime })
+            try {
+              const projectState = useProjectStore.getState?.()
+              const settings = projectState?.getCurrentTimelineSettings?.()
+                || projectState?.currentProject?.settings || {}
+              const width = Math.max(16, Math.min(7680, Number(settings.width) || 1920))
+              const height = Math.max(16, Math.min(4320, Number(settings.height) || 1080))
+              const ipcResult = await window.electronAPI.extractVideoFrame({
+                filePath,
+                timeSeconds: sourceTime,
+                width,
+                height,
+              })
+              if (ipcResult?.success && ipcResult.data) {
+                const pngBlob = new Blob([ipcResult.data], { type: 'image/png' })
+                const pngUrl = URL.createObjectURL(pngBlob)
+                const img = await new Promise((resolve, reject) => {
+                  const el = new Image()
+                  el.onload = () => resolve(el)
+                  el.onerror = () => reject(new Error('ffmpeg frame load failed'))
+                  el.src = pngUrl
+                })
+                console.log('[loadClipSourceAtTime] ffmpeg fallback ok', {
+                  width: img.naturalWidth, height: img.naturalHeight,
+                })
+                return {
+                  element: img,
+                  width: img.naturalWidth,
+                  height: img.naturalHeight,
+                  cleanup: () => { try { URL.revokeObjectURL(pngUrl) } catch (_) {} },
+                }
+              }
+              console.log('[loadClipSourceAtTime] ffmpeg IPC failed', ipcResult?.error)
+            } catch (ffErr) {
+              console.log('[loadClipSourceAtTime] ffmpeg fallback error', ffErr?.message || ffErr)
+            }
+          }
+        }
         throw err
       }
       console.log('[loadClipSourceAtTime] video ok', { videoWidth: video.videoWidth, videoHeight: video.videoHeight })


### PR DESCRIPTION
I pushed my fork with this change, please review:
https://github.com/JaimeIsMe/comfystudio/compare/main...asgitcode-tech:feature/fill-gap-flf2v?expand=1

Adds a right-click "Fill Gap (FLF2V)" action on the timeline. When you
right-click the gap between two video clips, it captures the last frame
of the clip before and the first frame of the clip after, opens the
Generate workspace with the bundled Wan 2.2 14B first/last-frame
workflow pre-selected, and splices the resulting video back into the
original gap on completion.

Includes a workflow picker so users can switch between bundled and
imported FLF2V workflow JSONs (selection persists across restarts).

14 files changed: 3008 insertions, 36 deletions.
Branch: feature/fill-gap-flf2v