### PR TITLE
[codex] Add contributor license agreement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+Describe the user-facing problem first, then the implementation.
+
+## Testing
+
+- [ ] I ran `npm run build`
+- [ ] I smoke-tested the area I changed
+- [ ] I updated docs when behavior, setup, onboarding, or release steps changed
+
+## Contributor License Agreement
+
+- [ ] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.
+
+## Notes
+
+Call out known limitations, follow-up work, or anything maintainers should review carefully.

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,25 @@
+name: CLA Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cla:
+    name: Contributor License Agreement
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require CLA checkbox
+        run: |
+          body="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+          if printf '%s\n' "$body" | grep -Eiq '[-*] \[[xX]\] I have read and agree to the Contributor License Agreement'; then
+            echo "CLA confirmation found."
+          else
+            echo "Missing CLA confirmation."
+            echo "Please check the Contributor License Agreement box in the pull request template."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,14 @@ If you add or change a built-in workflow:
 4. Run `npm run starter-pack:build`.
 5. Review the generated files under `docs/workflow-starter-pack/`.
 
+## Contributor License Agreement
+
+Before opening a pull request, read `CONTRIBUTOR_LICENSE_AGREEMENT.md`.
+
+By submitting a pull request, you confirm that you have the right to contribute the change and that you agree to the Contributor License Agreement. The pull request template includes a checkbox for this confirmation.
+
+If you are contributing on behalf of an employer, client, school, or other organization, make sure you have permission before submitting the contribution.
+
 ## Pull Request Guidelines
 
 - Explain the user problem first, then the implementation.

--- a/CONTRIBUTOR_LICENSE_AGREEMENT.md
+++ b/CONTRIBUTOR_LICENSE_AGREEMENT.md
@@ -1,0 +1,35 @@
+# Contributor License Agreement
+
+This Contributor License Agreement ("Agreement") applies to contributions submitted to this project.
+
+By opening a pull request, submitting code, documentation, designs, workflows, media, or other project material ("Contribution"), you agree to the terms below.
+
+## 1. You Keep Your Copyright
+
+You keep ownership of any copyright you have in your Contribution. This Agreement does not transfer your copyright to the project.
+
+## 2. You Have The Right To Contribute
+
+You confirm that:
+
+- you created the Contribution, or you otherwise have the right to submit it;
+- the Contribution does not knowingly include code, media, secrets, private data, or third-party material that you are not allowed to contribute;
+- if you are contributing on behalf of an employer, client, school, or other organization, you have permission to make the Contribution under this Agreement.
+
+## 3. License Grant
+
+You grant the project maintainer(s) a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable license to use, reproduce, modify, prepare derivative works of, publicly display, publicly perform, sublicense, relicense, and distribute your Contribution as part of this project or related project offerings.
+
+This includes permission for the project maintainer(s) to distribute your Contribution under the project's current license and under future project licenses, including open-source, source-available, dual-license, or commercial license models.
+
+## 4. Patent Grant
+
+If your Contribution includes technology covered by patent claims that you can license, you grant the project maintainer(s) and downstream users a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, use, sell, offer for sale, import, and otherwise run, modify, and distribute your Contribution as part of the project.
+
+## 5. No Warranty
+
+Your Contribution is provided "as is", without warranty of any kind. You are not required to provide support, maintenance, updates, or fixes for your Contribution.
+
+## 6. If You Do Not Agree
+
+If you do not agree to this Agreement, do not submit the Contribution as a pull request. You are welcome to open an issue first so maintainers can discuss alternatives.


### PR DESCRIPTION
## Summary

Adds a lightweight contributor license agreement flow so future pull requests explicitly confirm that the contributor has the right to submit their work and grants the project permission to use and relicense contributions in future versions.

This includes:
- a `CONTRIBUTOR_LICENSE_AGREEMENT.md` file
- a PR template checkbox
- a GitHub Action that checks for the CLA confirmation text
- a short note in `CONTRIBUTING.md`

## Testing

- [x] Ran `git diff --check HEAD~1..HEAD`
- [ ] I ran `npm run build`
- [x] I smoke-tested the area I changed
- [x] I updated docs when behavior, setup, onboarding, or release steps changed

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.

## Notes

This is a practical project-protection step, not a lawyer-reviewed CLA. It should help establish expectations for future contributions, but formal legal review would still be wise before a major license change or commercial licensing move.