### PR TITLE
[codex] Improve music video director script context

### DIFF
--- a/src/components/GenerateWorkspace.jsx
+++ b/src/components/GenerateWorkspace.jsx
@@ -1255,6 +1255,7 @@ function composeMusicShotVideoPrompt({
   lyricMoment = '',
   concept = '',
   styleNotes = '',
+  cameraDirection = '',
 }) {
   const shouldUseLyricCue = Boolean(shotTypeOption?.needsVocalAlignment)
   const lyricCue = shouldUseLyricCue ? String(lyricMoment || '')
@@ -1265,10 +1266,12 @@ function composeMusicShotVideoPrompt({
   const motion = String(motionPromptRaw || '').trim()
   const conceptLine = String(concept || '').trim()
   const styleLine = String(styleNotes || '').trim()
+  const cameraLine = String(cameraDirection || '').trim()
   const shotSuffix = String(shotTypeOption?.promptSuffix || '').trim()
 
   const parts = [
     motion,
+    cameraLine ? `Camera: ${cameraLine}.` : '',
     shotSuffix,
     lyricCue ? `The artist visibly sings this exact lyric phrase: "${lyricCue}".` : '',
     conceptLine ? `Concept: ${conceptLine}.` : '',
@@ -1294,10 +1297,12 @@ function composeMusicShotReferencePrompt({
   shotTypeOption = null,
   concept = '',
   styleNotes = '',
+  cameraDirection = '',
 }) {
   const keyframe = String(keyframePromptRaw || '').trim()
   const conceptLine = String(concept || '').trim()
   const styleLine = String(styleNotes || '').trim()
+  const cameraLine = String(cameraDirection || '').trim()
   const shotFocus = shotTypeOption?.id === 'b_roll'
     ? 'Environment / cutaway composition, no performer singing on camera.'
     : shotTypeOption?.id === 'performance_wide'
@@ -1306,6 +1311,7 @@ function composeMusicShotReferencePrompt({
 
   const parts = [
     keyframe,
+    cameraLine ? `Camera setup: ${cameraLine}.` : '',
     shotFocus,
     conceptLine ? `Concept: ${conceptLine}.` : '',
     styleLine ? `Style: ${styleLine}.` : '',
@@ -1583,12 +1589,14 @@ function buildMusicVideoPlanFromScript(options = {}) {
         lyricMoment: effectiveLyricMomentHint,
         concept,
         styleNotes,
+        cameraDirection: scriptShot.cameraDirection,
       })
       const referencePrompt = composeMusicShotReferencePrompt({
         keyframePromptRaw: scriptShot.keyframePromptRaw || scriptShot.imageBeat,
         shotTypeOption,
         concept,
         styleNotes,
+        cameraDirection: scriptShot.cameraDirection,
       })
 
       // Each script shot becomes its own scene with exactly one shot, because
@@ -2093,7 +2101,11 @@ function buildMusicVideoLLMPrompt(options = {}) {
   const songMeta = []
   if (songName) songMeta.push(`Song: ${songName}`)
   if (songDurationSeconds > 0) songMeta.push(`Song length: ${formatSecondsAsMMSS(songDurationSeconds)} (${songDurationSeconds.toFixed(1)}s)`)
-  songMeta.push(`Target music-video length: ~${targetDuration}s`)
+  if (songDurationSeconds > 0) {
+    songMeta.push(`Director script length: cover the full song through approximately ${formatSecondsAsMMSS(songDurationSeconds)} (${songDurationSeconds.toFixed(1)}s).`)
+  } else {
+    songMeta.push(`Target music-video length: ~${targetDuration}s (used because no song duration is available yet).`)
+  }
   sections.push(songMeta.join('\n'))
 
   // B-roll-only passes don't need the cast roster — there are no performers
@@ -2106,8 +2118,10 @@ function buildMusicVideoLLMPrompt(options = {}) {
       for (const c of cast) {
         const slug = c?.slug || ''
         const label = c?.label || slug || 'Artist'
-        const role = c?.role ? ` (${c.role})` : ''
-        castBlock.push(`  - ${slug}: ${label}${role}`)
+        const roleLabel = getMusicVideoCastRoleLabel(c?.role)
+        const role = roleLabel ? ` (${roleLabel})` : ''
+        const notes = String(c?.notes || c?.voiceNotes || '').trim()
+        castBlock.push(`  - ${slug}: ${label}${role}${notes ? ` — ${notes}` : ''}`)
       }
       castBlock.push('For duets, use "Artist: slug1, slug2". For the full cast, use "Artist: all".')
       sections.push(castBlock.join('\n'))
@@ -2120,7 +2134,7 @@ function buildMusicVideoLLMPrompt(options = {}) {
     sections.push(`Concept / story:\n${concept.trim()}`)
   }
   if (styleNotes.trim()) {
-    sections.push(`Style / look notes:\n${styleNotes.trim()}`)
+    sections.push(`Song style / visual look notes:\n${styleNotes.trim()}`)
   }
 
   if (lyricsIsTimed) {
@@ -2580,6 +2594,11 @@ function buildMusicVideoPassIntro(pass, variantDescriptor) {
     default:
       return 'You are a music video director. I need you to write a shot-by-shot director script for the song below.'
   }
+}
+
+function getMusicVideoCastRoleLabel(roleId = '') {
+  const role = MUSIC_VIDEO_CAST_ROLE_OPTIONS.find((option) => option.id === String(roleId || '').trim())
+  return role?.label || String(roleId || '').trim()
 }
 
 function buildMusicVideoPassRules(pass, variantDescriptor) {
@@ -3502,7 +3521,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
   const [yoloMusicArtistAssetId, setYoloMusicArtistAssetId] = useState(persistedState?.yoloMusicArtistAssetId ?? null)
   // Cast roster — an ordered list of named performers (singer, duet partner,
   // backing vocalist, band member...). Each entry is:
-  //   { id, slug, label, assetId, role }
+  //   { id, slug, label, assetId, role, notes }
   // Scripts reference cast members via `Artist: rose`, `Artist: both`, or
   // lyric `[Rose]` / `[Rose, Jake]` tag lines. When a shot can't resolve an
   // explicit name, it falls back to cast[0] (the "default lead").
@@ -3515,6 +3534,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
         label: String(entry?.label || '').trim(),
         assetId: entry?.assetId ?? null,
         role: String(entry?.role || 'lead'),
+        notes: String(entry?.notes || '').trim(),
       }))
       .filter((entry) => entry.assetId || entry.label || entry.slug)
   })
@@ -4426,6 +4446,19 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
     const settingsD = Number(yoloMusicAudioAsset?.settings?.duration)
     return Number.isFinite(settingsD) && settingsD > 0 ? settingsD : 0
   }, [yoloMusicAudioAsset])
+  const yoloMusicBriefStyleNotes = useMemo(() => {
+    const manual = String(yoloMusicStyleNotes || '').trim()
+    if (manual) return manual
+    const assetStyle = String(
+      yoloMusicAudioAsset?.settings?.musicTags
+      || yoloMusicAudioAsset?.musicTags
+      || yoloMusicAudioAsset?.prompt
+      || ''
+    ).trim()
+    const currentTags = String(musicTags || '').trim()
+    const inferred = assetStyle || currentTags
+    return inferred ? `Song style / genre tags: ${inferred}` : ''
+  }, [musicTags, yoloMusicAudioAsset, yoloMusicStyleNotes])
   // Single-source-of-truth parse of the user-pasted Lyrics field. The field
   // auto-detects whether the paste is plain text, SRT, or LRC. When the
   // format is 'srt' or 'lrc', we consider the lyrics "timed" and the
@@ -5606,6 +5639,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           label,
           assetId: asset.id,
           role: entry?.role || 'lead',
+          notes: String(entry?.notes || '').trim(),
         }
       })
       .filter(Boolean)
@@ -5748,6 +5782,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
       label: 'Artist',
       assetId: yoloMusicArtistAssetId,
       role: 'lead',
+      notes: '',
     }])
   }, [assets, yoloMusicArtistAssetId, yoloMusicCast])
   const yoloAdReferenceStyleNotes = useMemo(() => buildAdReferenceStyleNotes({
@@ -8534,6 +8569,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
         label: '',
         assetId: null,
         role: next.length === 0 ? 'lead' : 'co_lead',
+        notes: '',
       })
       return next
     })
@@ -8574,6 +8610,11 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
       entry?.id === castId ? { ...entry, role } : entry
     )))
   }, [])
+  const handleYoloMusicCastNotesChange = useCallback((castId, notes) => {
+    setYoloMusicCast((prev) => (prev || []).map((entry) => (
+      entry?.id === castId ? { ...entry, notes: String(notes || '').slice(0, 160) } : entry
+    )))
+  }, [])
 
   /**
    * Build the LLM prompt for a given pass configuration using the current
@@ -8586,7 +8627,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
       songDurationSeconds: yoloMusicSongDurationSeconds,
       targetDuration: yoloMusicTargetDuration,
       concept: yoloMusicConcept,
-      styleNotes: yoloMusicStyleNotes,
+      styleNotes: yoloMusicBriefStyleNotes,
       lyrics: yoloMusicLyrics,
       cast: yoloMusicResolvedCast,
       pass: passType,
@@ -8598,7 +8639,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
     yoloMusicSongDurationSeconds,
     yoloMusicTargetDuration,
     yoloMusicConcept,
-    yoloMusicStyleNotes,
+    yoloMusicBriefStyleNotes,
     yoloMusicLyrics,
     yoloMusicResolvedCast,
     yoloMusicScript,
@@ -8609,6 +8650,8 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
       songName: yoloMusicAudioAsset?.name || '',
       songDurationSeconds: yoloMusicSongDurationSeconds,
       targetDuration: yoloMusicTargetDuration,
+      concept: yoloMusicConcept,
+      styleNotes: yoloMusicBriefStyleNotes,
       lyrics: yoloMusicLyrics,
       cast: yoloMusicResolvedCast,
       coveragePlan: options.coveragePlan || null,
@@ -8621,6 +8664,8 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
     yoloMusicAudioAsset?.name,
     yoloMusicSongDurationSeconds,
     yoloMusicTargetDuration,
+    yoloMusicConcept,
+    yoloMusicBriefStyleNotes,
     yoloMusicLyrics,
     yoloMusicResolvedCast,
   ])
@@ -11840,7 +11885,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           yolo: directorMeta || undefined,
           shortFilm: shortFilmMeta || undefined,
           folderId: generatedAudioFolderId,
-          settings: { duration: job?.musicDuration, bpm: job?.bpm, keyscale: job?.keyscale, voice: shortFilmMeta?.voicePreset || job?.elevenLabsTts?.voice }
+          settings: { duration: job?.musicDuration, bpm: job?.bpm, keyscale: job?.keyscale, musicTags: jobTags || undefined, voice: shortFilmMeta?.voicePreset || job?.elevenLabsTts?.voice }
         }, generatedAudioFolderPath)
         if (newAsset) importedAssets.push(newAsset)
         didImportAny = true
@@ -11856,7 +11901,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
           yolo: directorMeta || undefined,
           shortFilm: shortFilmMeta || undefined,
           folderId: generatedAudioFolderId,
-          settings: { duration: job?.musicDuration, bpm: job?.bpm },
+          settings: { duration: job?.musicDuration, bpm: job?.bpm, musicTags: jobTags || undefined },
         })
         if (fallbackAsset) importedAssets.push(fallbackAsset)
         didImportAny = true
@@ -13663,6 +13708,8 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                     yoloMusicAsrLanguage={yoloMusicAsrLanguage}
                     setYoloMusicAsrLanguage={setYoloMusicAsrLanguage}
                     yoloMusicAudioAsset={yoloMusicAudioAsset}
+                    yoloMusicStyleNotes={yoloMusicStyleNotes}
+                    setYoloMusicStyleNotes={setYoloMusicStyleNotes}
                     yoloMusicTranscribingSrt={yoloMusicTranscribingSrt}
                     yoloMusicTranscriptionStatus={yoloMusicTranscriptionStatus}
                     handleYoloMusicTranscribeSrt={handleYoloMusicTranscribeSrt}
@@ -13704,6 +13751,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                     handleYoloMusicCastSlugChange={handleYoloMusicCastSlugChange}
                     handleYoloMusicCastLabelChange={handleYoloMusicCastLabelChange}
                     handleYoloMusicCastRoleChange={handleYoloMusicCastRoleChange}
+                    handleYoloMusicCastNotesChange={handleYoloMusicCastNotesChange}
                     queuePeopleWizardJob={queuePeopleWizardJob}
                     canUsePeopleWizardGeneration={Boolean(BUILTIN_WORKFLOW_PATHS['z-image-turbo'] && BUILTIN_WORKFLOW_PATHS['multi-angles'])}
                     generationQueue={generationQueue}
@@ -13993,7 +14041,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                             />
                           </div>
                           <div>
-                            <label className="text-[10px] text-sf-text-muted uppercase tracking-wider">Style / Look Notes (optional)</label>
+                            <label className="text-[10px] text-sf-text-muted uppercase tracking-wider">Song Style / Look Notes (optional)</label>
                             <textarea
                               value={yoloMusicStyleNotes}
                               onChange={e => setYoloMusicStyleNotes(e.target.value)}
@@ -14107,6 +14155,13 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                                         <X className="h-3 w-3" />
                                       </button>
                                     </div>
+                                    <input
+                                      type="text"
+                                      value={entry?.notes || ''}
+                                      onChange={(e) => handleYoloMusicCastNotesChange(entry.id, e.target.value)}
+                                      placeholder="Optional notes for the LLM brief, e.g. female voice, harsh vocal, guitarist, never sings"
+                                      className="mt-1.5 w-full bg-sf-dark-900 border border-sf-dark-600 rounded px-2 py-1 text-[11px] text-sf-text-primary focus:outline-none focus:border-sf-accent"
+                                    />
                                     {isDefault && (
                                       <div className="mt-1 text-[10px] text-sf-text-muted">
                                         Default lead — used when a shot has no <span className="font-mono">Artist:</span> override and the matched lyric line has no <span className="font-mono">[Name]</span> tag.
@@ -14182,7 +14237,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                                         songDurationSeconds: yoloMusicSongDurationSeconds,
                                         targetDuration: yoloMusicTargetDuration,
                                         concept: yoloMusicConcept,
-                                        styleNotes: yoloMusicStyleNotes,
+                                        styleNotes: yoloMusicBriefStyleNotes,
                                         lyrics: yoloMusicLyrics,
                                         cast: yoloMusicResolvedCast,
                                       })

--- a/src/components/generate/MusicVideoEasyMode.jsx
+++ b/src/components/generate/MusicVideoEasyMode.jsx
@@ -490,6 +490,8 @@ export default function MusicVideoEasyMode({
   yoloMusicAsrLanguage = 'English',
   setYoloMusicAsrLanguage,
   yoloMusicAudioAsset,
+  yoloMusicStyleNotes = '',
+  setYoloMusicStyleNotes,
   yoloMusicTranscribingSrt,
   yoloMusicTranscriptionStatus,
   handleYoloMusicTranscribeSrt,
@@ -511,6 +513,7 @@ export default function MusicVideoEasyMode({
   handleYoloMusicCastSlugChange,
   handleYoloMusicCastLabelChange,
   handleYoloMusicCastRoleChange,
+  handleYoloMusicCastNotesChange,
   queuePeopleWizardJob,
   canUsePeopleWizardGeneration = false,
   yoloMusicKeyframeWorkflowId = 'nano-banana-2',
@@ -652,6 +655,7 @@ export default function MusicVideoEasyMode({
       name: String(entry?.label || ''),
       slug: String(entry?.slug || ''),
       role: String(entry?.role || 'lead'),
+      notes: String(entry?.notes || ''),
       assetPrefix: normalizeCastSlug(entry?.slug || entry?.label || entry?.assetId || 'person') || 'person',
       assetId: entry?.assetId || '',
       sheetAssetId: entry?.assetId || '',
@@ -1371,7 +1375,7 @@ export default function MusicVideoEasyMode({
     setParseStatus('')
     const nextPlan = handleBuildActiveYoloPlan({
       conceptOverride: '',
-      styleNotesOverride: '',
+      styleNotesOverride: yoloMusicStyleNotes,
     })
     const count = flattenPlanShots(nextPlan).length
     if (count > 0) {
@@ -1707,6 +1711,7 @@ export default function MusicVideoEasyMode({
       slug: normalizedSlug,
       assetId: finalAssetId,
       role: String(peopleWizard.role || 'lead'),
+      notes: String(peopleWizard.notes || '').trim().slice(0, 160),
     }
     setYoloMusicCast((prev) => {
       const list = Array.isArray(prev) ? [...prev] : []
@@ -1887,6 +1892,20 @@ export default function MusicVideoEasyMode({
             {yoloMusicAudioAssets.length === 0 && (
               <p className="mt-2 text-xs text-sf-text-muted">No audio assets in this project yet. Import song audio in Assets first.</p>
             )}
+          </div>
+
+          <div className="mt-4">
+            <FieldLabel>Song Style / Genre</FieldLabel>
+            <textarea
+              value={yoloMusicStyleNotes || ''}
+              onChange={(event) => setYoloMusicStyleNotes?.(event.target.value)}
+              rows={3}
+              className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent resize-y"
+              placeholder="e.g. symphonic metal, operatic female vocal, dark fantasy, huge drums, gothic cathedral atmosphere."
+            />
+            <p className="mt-1 text-[10px] leading-4 text-sf-text-muted">
+              Included in the copied Director Script brief so the LLM does not infer the visual style from lyrics alone.
+            </p>
           </div>
 
           <div className="mt-4 rounded-lg border border-amber-400/30 bg-amber-400/10 p-3">
@@ -2184,6 +2203,19 @@ export default function MusicVideoEasyMode({
                       Used for the generated image and sheet file names.
                     </p>
                   </div>
+                  <div>
+                    <FieldLabel>Notes for Director Script</FieldLabel>
+                    <textarea
+                      value={peopleWizard.notes || ''}
+                      onChange={(event) => handlePeopleWizardFieldChange('notes', event.target.value)}
+                      rows={2}
+                      className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent resize-y"
+                      placeholder="Optional: female voice, harsh vocal, guitarist, never sings, lead performer energy."
+                    />
+                    <p className="mt-1 text-[10px] text-sf-text-muted">
+                      Included in the copied LLM brief so the script understands voice and performance context.
+                    </p>
+                  </div>
                 </div>
               )}
 
@@ -2438,6 +2470,9 @@ export default function MusicVideoEasyMode({
                 <div><span className="text-sf-text-muted">Name:</span> {peopleWizard.name || 'Untitled'}</div>
                 <div><span className="text-sf-text-muted">Slug:</span> {peopleWizard.slug || 'unset'}</div>
                 <div><span className="text-sf-text-muted">Role:</span> {peopleWizard.role || 'lead'}</div>
+                {String(peopleWizard.notes || '').trim() && (
+                  <div><span className="text-sf-text-muted">Notes:</span> {String(peopleWizard.notes || '').trim()}</div>
+                )}
                 <div><span className="text-sf-text-muted">Path:</span> {wizardStep}</div>
               </div>
             </div>
@@ -2563,6 +2598,16 @@ export default function MusicVideoEasyMode({
                   >
                     Remove
                   </button>
+                </div>
+                <div className="lg:col-span-5">
+                  <FieldLabel>Notes for Director Script</FieldLabel>
+                  <input
+                    type="text"
+                    value={entry?.notes || ''}
+                    onChange={(event) => handleYoloMusicCastNotesChange?.(entry.id, event.target.value)}
+                    placeholder="Optional: female voice, harsh vocal, guitarist, never sings"
+                    className="mt-1 w-full rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs text-sf-text-primary outline-none focus:border-sf-accent"
+                  />
                 </div>
               </div>
             )


### PR DESCRIPTION
## Summary

Fixes the music-video Director Script workflow so the copied LLM brief and generated prompts carry the context users expect.

This includes:
- adding a `Song Style / Genre` field in Music Video Step 1
- passing concept/style context into the Easy Mode LLM brief
- falling back to generated music tags or the selected audio prompt when no style notes are typed
- replacing the confusing `Target music-video length: ~30s` line with full-song coverage wording when song duration is known
- adding simple cast notes for context like `female voice`, `guitarist`, or `never sings`
- including parsed `Camera:` lines in the actual keyframe and video prompts

Fixes #63.

## Testing

- [x] I ran `npm run build`
- [x] I smoke-tested the area I changed
- [ ] I updated docs when behavior, setup, onboarding, or release steps changed

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.

## Notes

`npm run build` initially failed because this checkout had `node_modules` without the Vite binary. I ran `npm ci`, then the build passed.