### PR TITLE
[codex] Add music cast image import

### DIFF
--- a/src/components/GenerateWorkspace.jsx
+++ b/src/components/GenerateWorkspace.jsx
@@ -3601,6 +3601,7 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
   const [formErrorCopyStatus, setFormErrorCopyStatus] = useState('')
   const [creatingStoryboardPdf, setCreatingStoryboardPdf] = useState(false)
   const [yoloMusicAudioImporting, setYoloMusicAudioImporting] = useState(false)
+  const [yoloMusicCastImageImporting, setYoloMusicCastImageImporting] = useState(false)
   const [yoloMusicTranscribingSrt, setYoloMusicTranscribingSrt] = useState(false)
   const [yoloMusicTranscriptionStatus, setYoloMusicTranscriptionStatus] = useState('')
   const [confirmDialog, setConfirmDialog] = useState(null) // { title, message, confirmLabel, cancelLabel, tone }
@@ -4545,6 +4546,103 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
     currentProjectHandle,
     saveProject,
     yoloMusicAudioImporting,
+  ])
+  const handleImportYoloMusicCastImage = useCallback(async () => {
+    if (yoloMusicCastImageImporting) return null
+    if (!currentProjectHandle) {
+      setFormError('Open or create a project first so ComfyStudio can import the reference image.')
+      addComfyLog('error', 'Cast reference import requires an open project folder.')
+      return null
+    }
+
+    let selectedFile = null
+    try {
+      if (isElectron() && window.electronAPI?.selectFile) {
+        selectedFile = await window.electronAPI.selectFile({
+          title: 'Select cast reference image',
+          filters: [
+            { name: 'Image Files', extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp', 'tif', 'tiff'] },
+            { name: 'All Files', extensions: ['*'] },
+          ],
+        })
+      } else {
+        selectedFile = await new Promise((resolve) => {
+          const input = document.createElement('input')
+          input.type = 'file'
+          input.accept = 'image/*,.png,.jpg,.jpeg,.webp,.gif,.bmp,.tif,.tiff'
+          input.onchange = () => resolve(input.files?.[0] || null)
+          input.click()
+        })
+      }
+    } catch (error) {
+      const message = error?.message || 'Unknown file picker error'
+      setFormError(`Could not open reference image picker: ${message}`)
+      addComfyLog('error', `Could not open reference image picker: ${message}`)
+      return null
+    }
+    if (!selectedFile) return null
+    if (typeof selectedFile !== 'string' && selectedFile.type && !String(selectedFile.type).startsWith('image/')) {
+      const message = 'Only image files can be used as cast references.'
+      setFormError(message)
+      addComfyLog('error', message)
+      return null
+    }
+
+    setFormError(null)
+    setYoloMusicCastImageImporting(true)
+
+    try {
+      const assetInfo = await importAsset(currentProjectHandle, selectedFile, 'images')
+      const sessionUrl = typeof selectedFile !== 'string'
+        ? URL.createObjectURL(selectedFile)
+        : assetInfo.path
+          ? await getProjectFileUrl(currentProjectHandle, assetInfo.path)
+          : null
+      const newAsset = addAsset({
+        ...assetInfo,
+        type: 'image',
+        url: sessionUrl || assetInfo.url || '',
+        isImported: true,
+        settings: {
+          ...(assetInfo.settings || {}),
+          width: assetInfo.width,
+          height: assetInfo.height,
+        },
+      })
+      if (!newAsset) throw new Error('Could not register imported image.')
+
+      const rawName = String(newAsset.name || assetInfo.name || 'Cast reference')
+      const displayName = rawName.replace(/\.[a-z0-9]{1,8}$/i, '').replace(/[_-]+/g, ' ').trim() || 'Cast reference'
+      const slug = normalizeCastSlug(displayName) || `person_${Date.now()}`
+      setYoloMusicCast((prev) => {
+        const list = Array.isArray(prev) ? [...prev] : []
+        list.push({
+          id: `cast-${Date.now()}-${list.length}`,
+          slug,
+          label: displayName,
+          assetId: newAsset.id,
+          role: list.length === 0 ? 'lead' : 'co_lead',
+          notes: '',
+        })
+        return list
+      })
+      await saveProject?.()
+      addComfyLog('status', `Imported cast reference image: ${newAsset.name || displayName}`)
+      return newAsset
+    } catch (error) {
+      const message = error?.message || 'Unknown import error'
+      setFormError(`Could not import cast reference image: ${message}`)
+      addComfyLog('error', `Could not import cast reference image: ${message}`)
+      return null
+    } finally {
+      setYoloMusicCastImageImporting(false)
+    }
+  }, [
+    addAsset,
+    addComfyLog,
+    currentProjectHandle,
+    saveProject,
+    yoloMusicCastImageImporting,
   ])
   const createYoloMusicCustomKeyframeStarter = useCallback(async () => {
     const starter = {
@@ -13781,6 +13879,8 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
                     handleYoloMusicCastLabelChange={handleYoloMusicCastLabelChange}
                     handleYoloMusicCastRoleChange={handleYoloMusicCastRoleChange}
                     handleYoloMusicCastNotesChange={handleYoloMusicCastNotesChange}
+                    handleImportYoloMusicCastImage={handleImportYoloMusicCastImage}
+                    yoloMusicCastImageImporting={yoloMusicCastImageImporting}
                     queuePeopleWizardJob={queuePeopleWizardJob}
                     canUsePeopleWizardGeneration={Boolean(BUILTIN_WORKFLOW_PATHS['z-image-turbo'] && BUILTIN_WORKFLOW_PATHS['multi-angles'])}
                     generationQueue={generationQueue}

--- a/src/components/generate/MusicVideoEasyMode.jsx
+++ b/src/components/generate/MusicVideoEasyMode.jsx
@@ -514,6 +514,8 @@ export default function MusicVideoEasyMode({
   handleYoloMusicCastLabelChange,
   handleYoloMusicCastRoleChange,
   handleYoloMusicCastNotesChange,
+  handleImportYoloMusicCastImage,
+  yoloMusicCastImageImporting = false,
   queuePeopleWizardJob,
   canUsePeopleWizardGeneration = false,
   yoloMusicKeyframeWorkflowId = 'nano-banana-2',
@@ -577,6 +579,7 @@ export default function MusicVideoEasyMode({
   const [runtimeImageDimensions, setRuntimeImageDimensions] = useState({})
   const [advancedAudioOpen, setAdvancedAudioOpen] = useState(false)
   const [briefStatus, setBriefStatus] = useState('')
+  const [peopleStatus, setPeopleStatus] = useState('')
   const [parseStatus, setParseStatus] = useState('')
   const [keyframeStatus, setKeyframeStatus] = useState('')
   const [videoStatus, setVideoStatus] = useState('')
@@ -1612,6 +1615,15 @@ export default function MusicVideoEasyMode({
     openPeopleWizard(entry)
   }
 
+  const handleImportCastReferenceImage = async () => {
+    if (!handleImportYoloMusicCastImage || yoloMusicCastImageImporting) return
+    setPeopleStatus('')
+    const importedAsset = await handleImportYoloMusicCastImage()
+    if (importedAsset) {
+      setPeopleStatus(`Imported ${importedAsset.name || 'reference image'} and added it to the cast.`)
+    }
+  }
+
   const handlePeopleWizardFieldChange = (field, value) => {
     updatePeopleWizard({ [field]: value })
   }
@@ -2525,20 +2537,37 @@ export default function MusicVideoEasyMode({
               {plural(yoloMusicResolvedCast.length, 'resolved person', 'resolved people')}
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => handleOpenPeopleWizard(null)}
-            className="inline-flex items-center justify-center gap-2 rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90"
-          >
-            <UserPlus className="h-4 w-4" />
-            Add Person
-          </button>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={handleImportCastReferenceImage}
+              disabled={!handleImportYoloMusicCastImage || yoloMusicCastImageImporting}
+              className="inline-flex items-center justify-center gap-2 rounded-lg border border-sf-dark-600 bg-sf-dark-950 px-3 py-2 text-xs font-semibold text-sf-text-secondary transition-colors hover:border-sf-dark-500 hover:text-sf-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              title="Import an existing portrait, character sheet, or reference image into the cast."
+            >
+              {yoloMusicCastImageImporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+              {yoloMusicCastImageImporting ? 'Importing' : 'Import Image'}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleOpenPeopleWizard(null)}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-sf-accent px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-sf-accent/90"
+            >
+              <UserPlus className="h-4 w-4" />
+              Create Person
+            </button>
+          </div>
         </div>
 
         <div className="mt-4 space-y-3">
+          {peopleStatus && (
+            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-200">
+              {peopleStatus}
+            </div>
+          )}
           {(yoloMusicCast || []).length === 0 && (
             <div className="rounded-lg border border-dashed border-sf-dark-600 px-3 py-6 text-center text-xs text-sf-text-muted">
-              Add at least one person if the video has lip-sync performance shots.
+              Import an existing image or create a person if the video has lip-sync performance shots.
             </div>
           )}
           {(yoloMusicCast || []).map((entry, index) => {


### PR DESCRIPTION
## Summary
- Add an Import Image action to Music Video Step 2 / People.
- Imported images are copied into the project assets and immediately added as cast references.
- Keep Create Person available for users who want ComfyStudio to generate a portrait or character sheet.
- Auto-fill the cast name, slug, and lead/co-lead role from the imported filename.

## Why
Users who already have a portrait, character sheet, or external reference image should not have to generate a new person inside ComfyStudio just to continue the music video flow.

Fixes #58.
Related to #47 and #55.

## Validation
- npm run build
- git diff --check

## Contributor License Agreement
- [x] I have read and agree to the Contributor License Agreement