### PR TITLE
Add generation completion sound

### DIFF
--- a/src/components/GenerateWorkspace.jsx
+++ b/src/components/GenerateWorkspace.jsx
@@ -26,6 +26,11 @@ import { BUILTIN_WORKFLOW_PATHS } from '../config/workflowRegistry'
 import { comfyui, validateCustomKeyframeWorkflow, validateCustomVideoWorkflow } from '../services/comfyui'
 import { markPromptHandledByApp } from '../services/comfyPromptGuard'
 import {
+  GENERATION_COMPLETION_SOUND_CHANGED_EVENT,
+  getGenerationCompletionSoundSettings,
+  playGenerationCompletionSound,
+} from '../services/generationCompletionSoundSettings'
+import {
   getProjectFileUrl,
   importAsset,
   isElectron,
@@ -3593,6 +3598,9 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
 
   // Generation queue state
   const [generationQueue, setGenerationQueue] = useState(() => loadPersistedGenerationQueue())
+  const [generationCompletionSoundSettings, setGenerationCompletionSoundSettingsState] = useState(() => (
+    getGenerationCompletionSoundSettings()
+  ))
   const [activeJobId, setActiveJobId] = useState(null)
   const processingRef = useRef(false)
   const queueRef = useRef([])
@@ -3600,6 +3608,10 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
   const queuePausedRef = useRef(false)
   const consecutiveRapidFailsRef = useRef(0)
   const lastJobFinishTimeRef = useRef(0)
+  const generationCompletionSoundSettingsRef = useRef(generationCompletionSoundSettings)
+  const queueCompletionSoundInitializedRef = useRef(false)
+  const previousNonTerminalQueueCountRef = useRef(0)
+  const lastQueueCompletionSoundSignatureRef = useRef('')
   const RAPID_FAIL_THRESHOLD_MS = 5000
   const MAX_CONSECUTIVE_RAPID_FAILS = 3
   const MIN_JOB_INTERVAL_MS = 2000
@@ -3931,6 +3943,58 @@ function GenerateWorkspace({ onOpenWorkflowSetup = null }) {
   // Keep queue ref in sync
   useEffect(() => {
     queueRef.current = generationQueue
+  }, [generationQueue])
+
+  useEffect(() => {
+    generationCompletionSoundSettingsRef.current = generationCompletionSoundSettings
+  }, [generationCompletionSoundSettings])
+
+  useEffect(() => {
+    const handleCompletionSoundSettingsChanged = (event) => {
+      const nextSettings = event?.detail || getGenerationCompletionSoundSettings()
+      generationCompletionSoundSettingsRef.current = nextSettings
+      setGenerationCompletionSoundSettingsState(nextSettings)
+    }
+
+    window.addEventListener(GENERATION_COMPLETION_SOUND_CHANGED_EVENT, handleCompletionSoundSettingsChanged)
+    return () => {
+      window.removeEventListener(GENERATION_COMPLETION_SOUND_CHANGED_EVENT, handleCompletionSoundSettingsChanged)
+    }
+  }, [])
+
+  useEffect(() => {
+    const nonTerminalCount = generationQueue.filter((job) => (
+      NON_TERMINAL_JOB_STATUSES.includes(job.status)
+    )).length
+    const terminalJobs = generationQueue.filter((job) => job.status === 'done' || job.status === 'error')
+    const terminalSignature = terminalJobs
+      .map((job) => [
+        job.id,
+        job.status,
+        Array.isArray(job.resultAssetIds) ? job.resultAssetIds.join(',') : '',
+        job.error || '',
+      ].join(':'))
+      .join('|')
+
+    if (!queueCompletionSoundInitializedRef.current) {
+      queueCompletionSoundInitializedRef.current = true
+      previousNonTerminalQueueCountRef.current = nonTerminalCount
+      lastQueueCompletionSoundSignatureRef.current = terminalSignature
+      return
+    }
+
+    if (
+      previousNonTerminalQueueCountRef.current > 0
+      && nonTerminalCount === 0
+      && terminalJobs.length > 0
+      && terminalSignature
+      && terminalSignature !== lastQueueCompletionSoundSignatureRef.current
+    ) {
+      playGenerationCompletionSound(generationCompletionSoundSettingsRef.current)
+      lastQueueCompletionSoundSignatureRef.current = terminalSignature
+    }
+
+    previousNonTerminalQueueCountRef.current = nonTerminalCount
   }, [generationQueue])
 
   useEffect(() => {

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -3,6 +3,7 @@ import {
   X, Server, FolderOpen, Palette, Monitor, Save,
   HardDrive, Film, Keyboard, Wrench, Power,
   KeyRound, CheckCircle2, ExternalLink, Loader2, RefreshCcw,
+  Volume2, Play,
 } from 'lucide-react'
 import useProjectStore, { RESOLUTION_PRESETS, FPS_PRESETS } from '../stores/projectStore'
 import useTimelineStore from '../stores/timelineStore'
@@ -43,6 +44,13 @@ import {
   hasUsablePlaybackCache,
   isPlaybackCacheableVideoAsset,
 } from '../services/playbackCache'
+import {
+  GENERATION_COMPLETION_SOUND_CHANGED_EVENT,
+  GENERATION_COMPLETION_SOUND_OPTIONS,
+  getGenerationCompletionSoundSettings,
+  playGenerationCompletionSound,
+  setGenerationCompletionSoundSettings,
+} from '../services/generationCompletionSoundSettings'
 
 const AUTO_IMPORT_KEY = 'comfystudio-auto-import-comfy-outputs'
 const OUTPUT_DIRECTORY_SETTING_KEY = 'outputDirectory'
@@ -92,6 +100,12 @@ const SETTINGS_SECTIONS = [
     title: 'Appearance',
     icon: Palette,
     description: 'Pick the editor theme that best fits your workspace.',
+  },
+  {
+    id: 'notifications',
+    title: 'Notifications',
+    icon: Volume2,
+    description: 'Control completion sounds and lightweight app alerts.',
   },
   {
     id: 'hotkeys',
@@ -153,6 +167,9 @@ function GeneralTab({ initialSection = null }) {
   const [outputPath, setOutputPath] = useState('')
   const [workflowPath, setWorkflowPath] = useState('')
   const [activeThemeId, setActiveThemeId] = useState(() => getStoredThemeId())
+  const [generationCompletionSoundSettings, setGenerationCompletionSoundSettingsState] = useState(() => (
+    getGenerationCompletionSoundSettings()
+  ))
   const [pexelsApiKey, setPexelsApiKeyLocal] = useState('')
   const [comfyOrgApiKey, setComfyOrgApiKey] = useState('')
   const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false)
@@ -298,6 +315,14 @@ function GeneralTab({ initialSection = null }) {
     setActiveSection(resolveInitialSection(initialSection))
   }, [initialSection])
 
+  useEffect(() => {
+    const handler = (event) => {
+      setGenerationCompletionSoundSettingsState(event?.detail || getGenerationCompletionSoundSettings())
+    }
+    window.addEventListener(GENERATION_COMPLETION_SOUND_CHANGED_EVENT, handler)
+    return () => window.removeEventListener(GENERATION_COMPLETION_SOUND_CHANGED_EVENT, handler)
+  }, [])
+
   // Keep the Settings view in sync if the key is saved/cleared from any
   // other surface (Onboarding, Workflow Setup gallery, Generate tab).
   useEffect(() => {
@@ -314,6 +339,14 @@ function GeneralTab({ initialSection = null }) {
     try {
       localStorage.setItem(AUTO_IMPORT_KEY, String(next))
     } catch (_) {}
+  }
+
+  const handleGenerationCompletionSoundChange = (updates) => {
+    const next = setGenerationCompletionSoundSettings({
+      ...generationCompletionSoundSettings,
+      ...updates,
+    })
+    setGenerationCompletionSoundSettingsState(next)
   }
 
   const handleSavePexelsKey = () => {
@@ -947,6 +980,96 @@ function GeneralTab({ initialSection = null }) {
         </div>
       )
       break
+    case 'notifications': {
+      const soundEnabled = generationCompletionSoundSettings.enabled
+      const soundVolume = generationCompletionSoundSettings.volume
+      activeSectionContent = (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between rounded-lg border border-sf-dark-700 bg-sf-dark-900/60 px-3 py-3">
+            <div>
+              <label className="text-sm text-sf-text-primary">Generation complete sound</label>
+              <p className="text-[10px] text-sf-text-muted">Play a short sound when the Generate queue finishes.</p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={soundEnabled}
+              onClick={() => handleGenerationCompletionSoundChange({ enabled: !soundEnabled })}
+              className={`w-10 h-5 rounded-full transition-colors ${soundEnabled ? 'bg-sf-accent' : 'bg-sf-dark-600'}`}
+            >
+              <div className={`w-4 h-4 bg-white rounded-full transition-transform ${soundEnabled ? 'translate-x-5' : 'translate-x-0.5'}`} />
+            </button>
+          </div>
+
+          <div className={`rounded-lg border border-sf-dark-700 bg-sf-dark-900/60 px-3 py-3 ${soundEnabled ? '' : 'opacity-60'}`}>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <label className="text-sm text-sf-text-primary">Volume</label>
+                <p className="text-[10px] text-sf-text-muted">0 is muted, 10 is loudest.</p>
+              </div>
+              <div className="rounded bg-sf-dark-800 px-2 py-1 text-xs text-sf-text-secondary">
+                {soundVolume === 0 ? 'Off' : `${soundVolume}/10`}
+              </div>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={10}
+              step={1}
+              value={soundVolume}
+              disabled={!soundEnabled}
+              onChange={(event) => handleGenerationCompletionSoundChange({ volume: Number(event.target.value) })}
+              className="mt-3 w-full accent-sf-accent disabled:cursor-not-allowed"
+            />
+          </div>
+
+          <div className={`rounded-lg border border-sf-dark-700 bg-sf-dark-900/60 px-3 py-3 ${soundEnabled ? '' : 'opacity-60'}`}>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <label className="text-sm text-sf-text-primary">Sound</label>
+                <p className="text-[10px] text-sf-text-muted">Choose the completion sound style.</p>
+              </div>
+              <button
+                type="button"
+                disabled={!soundEnabled || soundVolume <= 0}
+                onClick={() => playGenerationCompletionSound(generationCompletionSoundSettings)}
+                className="inline-flex items-center gap-1.5 rounded bg-sf-dark-700 px-3 py-1.5 text-xs text-sf-text-secondary transition-colors hover:bg-sf-dark-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Play className="h-3.5 w-3.5" />
+                Preview
+              </button>
+            </div>
+
+            <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-3">
+              {GENERATION_COMPLETION_SOUND_OPTIONS.map((option) => {
+                const isSelected = option.id === generationCompletionSoundSettings.soundId
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => handleGenerationCompletionSoundChange({ soundId: option.id })}
+                    className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                      isSelected
+                        ? 'border-sf-accent bg-sf-accent/10'
+                        : 'border-sf-dark-700 bg-sf-dark-800 hover:bg-sf-dark-700'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-medium text-sf-text-primary">{option.label}</span>
+                      {isSelected && (
+                        <span className="text-[10px] text-sf-accent">Active</span>
+                      )}
+                    </div>
+                    <p className="mt-1 text-[10px] text-sf-text-muted">{option.description}</p>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )
+      break
+    }
     case 'hotkeys':
       activeSectionContent = (
         <div className="space-y-5">

--- a/src/services/generationCompletionSoundSettings.js
+++ b/src/services/generationCompletionSoundSettings.js
@@ -1,0 +1,145 @@
+const GENERATION_COMPLETION_SOUND_STORAGE_KEY = 'comfystudio-generation-completion-sound'
+let generationCompletionAudioContext = null
+
+export const GENERATION_COMPLETION_SOUND_CHANGED_EVENT = 'comfystudio-generation-completion-sound-changed'
+
+export const GENERATION_COMPLETION_SOUND_OPTIONS = Object.freeze([
+  {
+    id: 'soft-chime',
+    label: 'Soft chime',
+    description: 'A gentle three-note finish sound.',
+    oscillatorType: 'sine',
+    frequencies: [523.25, 659.25, 783.99],
+    spacingSeconds: 0.11,
+    toneSeconds: 0.22,
+    tailSeconds: 0.62,
+    gain: 1,
+  },
+  {
+    id: 'clean-ding',
+    label: 'Clean ding',
+    description: 'A brighter two-note alert.',
+    oscillatorType: 'triangle',
+    frequencies: [880, 1174.66],
+    spacingSeconds: 0.09,
+    toneSeconds: 0.26,
+    tailSeconds: 0.52,
+    gain: 1,
+  },
+  {
+    id: 'subtle-beep',
+    label: 'Subtle beep',
+    description: 'A short, minimal notification.',
+    oscillatorType: 'sine',
+    frequencies: [659.25],
+    spacingSeconds: 0,
+    toneSeconds: 0.2,
+    tailSeconds: 0.32,
+    gain: 1,
+  },
+])
+
+export const DEFAULT_GENERATION_COMPLETION_SOUND_SETTINGS = Object.freeze({
+  enabled: true,
+  volume: 5,
+  soundId: 'soft-chime',
+})
+
+export function getGenerationCompletionSoundOption(soundId) {
+  return GENERATION_COMPLETION_SOUND_OPTIONS.find((option) => option.id === soundId)
+    || GENERATION_COMPLETION_SOUND_OPTIONS[0]
+}
+
+export function normalizeGenerationCompletionSoundSettings(value = {}) {
+  const soundId = String(value?.soundId || DEFAULT_GENERATION_COMPLETION_SOUND_SETTINGS.soundId)
+  const option = getGenerationCompletionSoundOption(soundId)
+  const rawVolume = Number(value?.volume)
+  return {
+    enabled: typeof value?.enabled === 'boolean'
+      ? value.enabled
+      : DEFAULT_GENERATION_COMPLETION_SOUND_SETTINGS.enabled,
+    volume: Number.isFinite(rawVolume)
+      ? Math.max(0, Math.min(10, Math.round(rawVolume)))
+      : DEFAULT_GENERATION_COMPLETION_SOUND_SETTINGS.volume,
+    soundId: option.id,
+  }
+}
+
+export function getGenerationCompletionSoundSettings() {
+  if (typeof localStorage === 'undefined') return { ...DEFAULT_GENERATION_COMPLETION_SOUND_SETTINGS }
+  try {
+    const raw = localStorage.getItem(GENERATION_COMPLETION_SOUND_STORAGE_KEY)
+    if (!raw) return { ...DEFAULT_GENERATION_COMPLETION_SOUND_SETTINGS }
+    return normalizeGenerationCompletionSoundSettings(JSON.parse(raw))
+  } catch {
+    return { ...DEFAULT_GENERATION_COMPLETION_SOUND_SETTINGS }
+  }
+}
+
+export function setGenerationCompletionSoundSettings(nextSettings) {
+  const normalized = normalizeGenerationCompletionSoundSettings(nextSettings)
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.setItem(GENERATION_COMPLETION_SOUND_STORAGE_KEY, JSON.stringify(normalized))
+    } catch (_) {}
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(GENERATION_COMPLETION_SOUND_CHANGED_EVENT, {
+      detail: normalized,
+    }))
+  }
+  return normalized
+}
+
+export function playGenerationCompletionSound(settings = getGenerationCompletionSoundSettings()) {
+  const normalizedSettings = normalizeGenerationCompletionSoundSettings(settings)
+  const normalizedVolume = Math.max(0, Math.min(10, Number(normalizedSettings.volume) || 0))
+  if (!normalizedSettings.enabled || normalizedVolume <= 0) return
+  if (typeof window === 'undefined') return
+
+  const AudioContextCtor = window.AudioContext || window.webkitAudioContext
+  if (!AudioContextCtor) return
+
+  const soundOption = getGenerationCompletionSoundOption(normalizedSettings.soundId)
+
+  try {
+    const context = generationCompletionAudioContext && generationCompletionAudioContext.state !== 'closed'
+      ? generationCompletionAudioContext
+      : new AudioContextCtor()
+    generationCompletionAudioContext = context
+
+    const play = () => {
+      const masterGain = context.createGain()
+      const startAt = context.currentTime + 0.02
+      const outputGain = Math.min(1, soundOption.gain * (normalizedVolume / 10))
+      masterGain.gain.setValueAtTime(0.0001, startAt)
+      masterGain.gain.exponentialRampToValueAtTime(outputGain, startAt + 0.035)
+      masterGain.gain.exponentialRampToValueAtTime(0.0001, startAt + soundOption.tailSeconds)
+      masterGain.connect(context.destination)
+
+      soundOption.frequencies.forEach((frequency, index) => {
+        const oscillator = context.createOscillator()
+        const toneGain = context.createGain()
+        const toneStart = startAt + (index * soundOption.spacingSeconds)
+        const toneEnd = toneStart + soundOption.toneSeconds
+        oscillator.type = soundOption.oscillatorType
+        oscillator.frequency.setValueAtTime(frequency, toneStart)
+        toneGain.gain.setValueAtTime(0.0001, toneStart)
+        toneGain.gain.exponentialRampToValueAtTime(1, toneStart + 0.025)
+        toneGain.gain.exponentialRampToValueAtTime(0.0001, toneEnd)
+        oscillator.connect(toneGain)
+        toneGain.connect(masterGain)
+        oscillator.start(toneStart)
+        oscillator.stop(toneEnd + 0.02)
+      })
+    }
+
+    if (context.state === 'suspended') {
+      context.resume().then(play).catch(() => {})
+      return
+    }
+    play()
+  } catch (error) {
+    console.warn('Failed to play generation completion sound:', error)
+  }
+}


### PR DESCRIPTION
## Summary
- Add a soft generated sound when the Generate queue finishes all pending/running jobs
- Add Settings > Notifications controls for enabling/disabling the sound, setting volume from 0-10, choosing between three sound styles, and previewing the selected sound
- Guard against playing on app load from restored queue history or when the queue is cleared without completed/error jobs

## Testing
- npm run build

Related to #46. This intentionally handles the completion sound request only; the enlarged-preview prompt editing/regenerate request should stay separate.

- [x] I have read and agree to the Contributor License Agreement