### PR TITLE
Improve local ComfyUI connection checks

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1813,20 +1813,34 @@ async function resolveLocalComfyPort() {
   }
 }
 
-async function checkComfyUIRunning(portOverride = null) {
+async function checkComfyUIRunning(portOverride = null, timeoutMs = COMFYUI_CHECK_MS) {
   const port = sanitizeLocalComfyPort(portOverride) || await resolveLocalComfyPort()
+  const timeout = Number.isFinite(Number(timeoutMs)) && Number(timeoutMs) > 0
+    ? Number(timeoutMs)
+    : COMFYUI_CHECK_MS
   const healthUrl = `http://127.0.0.1:${port}/system_stats`
   return new Promise((resolve) => {
-    const req = http.get(healthUrl, (res) => {
+    let settled = false
+    const finish = (result) => {
+      if (settled) return
+      settled = true
       resolve({
-        ok: res.statusCode === 200 || (res.statusCode >= 200 && res.statusCode < 400),
         port,
+        httpBase: `http://127.0.0.1:${port}`,
+        ...result,
+      })
+    }
+    const req = http.get(healthUrl, (res) => {
+      res.resume()
+      finish({
+        ok: res.statusCode === 200 || (res.statusCode >= 200 && res.statusCode < 400),
+        status: res.statusCode || 0,
       })
     })
-    req.on('error', () => resolve({ ok: false, port }))
-    req.setTimeout(COMFYUI_CHECK_MS, () => {
+    req.on('error', (error) => finish({ ok: false, error: error?.message || 'Connection failed.' }))
+    req.setTimeout(timeout, () => {
       req.destroy()
-      resolve({ ok: false, port })
+      finish({ ok: false, timedOut: true, error: 'Connection timed out.' })
     })
   })
 }
@@ -3389,6 +3403,15 @@ ipcMain.handle('comfyLauncher:connectExternal', async () => {
     return { success: true, state: comfyLauncher.getState() }
   } catch (error) {
     return { success: false, error: error?.message || String(error) }
+  }
+})
+
+ipcMain.handle('comfyui:checkLocalConnection', async (_event, payload = {}) => {
+  try {
+    const result = await checkComfyUIRunning(payload?.port, payload?.timeoutMs)
+    return { success: true, ...result }
+  } catch (error) {
+    return { success: false, ok: false, error: error?.message || String(error) }
   }
 })
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -348,6 +348,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Workflow Setup Manager
   // ============================================
 
+  checkLocalComfyConnection: (payload = {}) => ipcRenderer.invoke('comfyui:checkLocalConnection', payload),
   loadComfyUiWorkflowGraph: (payload = {}) => ipcRenderer.invoke('comfyui:loadWorkflowGraph', payload),
   getComfyCloudCreditBalance: () => ipcRenderer.invoke('comfyui:getCloudCreditBalance'),
   validateWorkflowSetupRoot: (rootPath) => ipcRenderer.invoke('workflowSetup:validateRoot', rootPath),

--- a/src/services/localComfyConnection.js
+++ b/src/services/localComfyConnection.js
@@ -246,6 +246,40 @@ export async function checkLocalComfyConnection(options = {}) {
   }
 
   const config = buildConnection(normalizedPort)
+
+  if (typeof window !== 'undefined' && window?.electronAPI?.checkLocalComfyConnection) {
+    try {
+      const result = await window.electronAPI.checkLocalComfyConnection({
+        port: config.port,
+        timeoutMs,
+      })
+      if (result?.ok) {
+        return {
+          ok: true,
+          status: result.status,
+          httpBase: result.httpBase || config.httpBase,
+          port: result.port || config.port,
+          source: 'electron-main',
+        }
+      }
+      const status = Number(result?.status) || null
+      return {
+        ok: false,
+        status,
+        httpBase: result?.httpBase || config.httpBase,
+        port: result?.port || config.port,
+        source: 'electron-main',
+        error: status
+          ? `ComfyUI returned HTTP ${status}.`
+          : result?.timedOut
+            ? `Timed out connecting to ${config.httpBase}.`
+            : `Could not connect to ${config.httpBase}: ${result?.error || 'Unknown error'}`,
+      }
+    } catch {
+      // Fall back to renderer fetch so browser/dev builds still get a result.
+    }
+  }
+
   const controller = typeof AbortController !== 'undefined' ? new AbortController() : null
   const timer = setTimeout(() => {
     if (controller) controller.abort()
@@ -268,7 +302,9 @@ export async function checkLocalComfyConnection(options = {}) {
       status: response.status,
       httpBase: config.httpBase,
       port: config.port,
-      error: `ComfyUI returned HTTP ${response.status}.`,
+      error: response.status === 403
+        ? 'ComfyUI returned HTTP 403. If this is a standalone ComfyUI session, launch it with --enable-cors-header * or use ComfyStudio’s built-in launcher.'
+        : `ComfyUI returned HTTP ${response.status}.`,
     }
   } catch (err) {
     const isTimeout = err?.name === 'AbortError'


### PR DESCRIPTION
## Summary
- routes local ComfyUI connection tests through Electron main when available, avoiding renderer-side CORS false negatives for standalone local sessions
- returns status/error details from the main-process ComfyUI health check
- keeps the renderer fetch fallback for browser/dev cases and adds clearer HTTP 403 guidance

## Testing
- [x] I ran `npm run build`
- [x] Jaime smoke-tested Settings > ComfyUI Connection against a local ComfyUI session
- [x] I updated docs when behavior, setup, onboarding, or release steps changed

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.

## Notes

Ready to merge after smoke testing.