### PR TITLE
Add FCPXML timeline export

### DIFF
--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -4,6 +4,7 @@ import useProjectStore, { RESOLUTION_PRESETS, FPS_PRESETS } from '../stores/proj
 import useTimelineStore from '../stores/timelineStore'
 import useAssetsStore from '../stores/assetsStore'
 import exportTimeline from '../services/exporter'
+import buildFcpXml from '../services/fcpxmlExporter'
 
 const EXPORT_SETTINGS_STORAGE_PREFIX = 'comfystudio-export-settings-v1'
 
@@ -283,12 +284,30 @@ function saveExportSettings(storageKey, settings) {
   }
 }
 
+function isAbsoluteFilePath(filePath) {
+  const value = String(filePath || '')
+  return /^[a-zA-Z]:[\\/]/.test(value) || value.startsWith('/') || value.startsWith('\\\\')
+}
+
+function sanitizeExportBaseName(value) {
+  return String(value || 'ComfyStudio_Timeline')
+    .trim()
+    .replace(/[<>:"/\\|?*\x00-\x1F]/g, '_')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    || 'ComfyStudio_Timeline'
+}
+
 function ExportPanel() {
-  const { currentProject, currentProjectHandle, getCurrentTimelineSettings } = useProjectStore()
+  const { currentProject, currentProjectHandle, currentTimelineId, getCurrentTimelineSettings } = useProjectStore()
   const { duration, inPoint, outPoint, getTimelineEndTime, selectedClipIds, clips, transitions, tracks } = useTimelineStore()
   const { assets } = useAssetsStore()
   
   const projectName = currentProject?.name || 'Untitled'
+  const currentTimeline = useMemo(() => (
+    currentProject?.timelines?.find((timeline) => timeline.id === currentTimelineId) || null
+  ), [currentProject?.timelines, currentTimelineId])
   const defaultFilename = `${projectName}_export`
   const defaultSettings = useMemo(() => createDefaultExportSettings(defaultFilename), [defaultFilename])
   const settingsStorageKey = useMemo(
@@ -305,6 +324,7 @@ function ExportPanel() {
   const [exportResult, setExportResult] = useState(null)
   const [etaSeconds, setEtaSeconds] = useState(null)
   const [renderFps, setRenderFps] = useState(null)
+  const [isXmlExporting, setIsXmlExporting] = useState(false)
   const exportStartRef = useRef(null)
   const renderStartRef = useRef(null)
   const [nvencStatus, setNvencStatus] = useState({
@@ -923,6 +943,95 @@ function ExportPanel() {
       setIsExporting(false)
     }
   }
+
+  const handleExportFcpXml = async () => {
+    if (isExporting || queueRunning || isXmlExporting) return
+    if (!window.electronAPI?.writeFile || !window.electronAPI?.saveFileDialog || !window.electronAPI?.pathJoin) {
+      setExportError('FCPXML export is only available in the desktop app.')
+      return
+    }
+    if (typeof currentProjectHandle !== 'string') {
+      setExportError('Open a saved project before exporting FCPXML.')
+      return
+    }
+
+    setIsXmlExporting(true)
+    setExportError(null)
+    setExportResult(null)
+    setExportProgress(0)
+    setEtaSeconds(null)
+    setRenderFps(null)
+    setExportStatus('Preparing FCPXML...')
+
+    try {
+      const projectPath = currentProjectHandle
+      const resolvedAssets = await Promise.all((assets || []).map(async (asset) => {
+        if (!asset?.path) return { ...asset, absolutePath: '' }
+        const absolutePath = isAbsoluteFilePath(asset.path)
+          ? asset.path
+          : await window.electronAPI.pathJoin(projectPath, asset.path)
+        return {
+          ...asset,
+          absolutePath,
+          hasAudio: asset.hasAudio ?? asset.settings?.hasAudio,
+        }
+      }))
+      const exportableAssetIds = new Set(resolvedAssets.filter((asset) => asset.absolutePath).map((asset) => asset.id))
+      const exportableClipCount = (clips || []).filter((clip) => (
+        clip?.enabled !== false
+        && ['video', 'audio', 'image'].includes(clip?.type)
+        && exportableAssetIds.has(clip.assetId)
+      )).length
+      if (exportableClipCount === 0) {
+        throw new Error('No media clips with project file paths are available for FCPXML export.')
+      }
+
+      const timelineSettings = getCurrentTimelineSettings() || { width: 1920, height: 1080, fps: 24 }
+      const timelineName = currentTimeline?.name || 'Timeline'
+      const xml = buildFcpXml({
+        projectName,
+        timelineName,
+        timelineSettings,
+        timeline: {
+          clips,
+          tracks,
+          transitions,
+          duration: getTimelineEndTime?.() || duration,
+          timelineFps: timelineSettings.fps,
+        },
+        assets: resolvedAssets,
+      })
+
+      const outputFolder = await window.electronAPI.pathJoin(projectPath, 'renders')
+      await window.electronAPI.createDirectory(outputFolder)
+      const defaultPath = await window.electronAPI.pathJoin(
+        outputFolder,
+        `${sanitizeExportBaseName(`${projectName}_${timelineName}`)}.fcpxml`
+      )
+      const outputPath = await window.electronAPI.saveFileDialog({
+        title: 'Export FCPXML',
+        defaultPath,
+        filters: [{ name: 'Final Cut Pro XML', extensions: ['fcpxml'] }],
+      })
+      if (!outputPath) {
+        setExportStatus('FCPXML export cancelled')
+        return
+      }
+
+      const writeResult = await window.electronAPI.writeFile(outputPath, xml, { encoding: 'utf8' })
+      if (!writeResult?.success) {
+        throw new Error(writeResult?.error || 'Failed to write FCPXML file.')
+      }
+
+      setExportResult({ outputPath, encoderUsed: 'FCPXML', clipCount: exportableClipCount })
+      setExportStatus(`FCPXML export complete (${exportableClipCount} clips)`)
+    } catch (err) {
+      setExportError(err?.message || 'FCPXML export failed')
+      setExportStatus('FCPXML export failed')
+    } finally {
+      setIsXmlExporting(false)
+    }
+  }
   
   return (
     <div className="flex-1 min-h-0 flex flex-col min-w-0 overflow-hidden bg-sf-dark-950">
@@ -1471,6 +1580,19 @@ function ExportPanel() {
             >
               <Play className="w-3 h-3" />
               {isExporting ? 'Exporting...' : (queueRunning ? 'Queue Running' : 'Start Export')}
+            </button>
+            <button
+              onClick={handleExportFcpXml}
+              disabled={isExporting || queueRunning || isXmlExporting}
+              className={`px-3 py-1.5 text-xs rounded border flex items-center gap-1.5 transition-colors ${
+                isExporting || queueRunning || isXmlExporting
+                  ? 'bg-sf-dark-800 text-sf-text-muted border-sf-dark-600 cursor-not-allowed'
+                  : 'bg-sf-dark-800 text-sf-text-primary border-sf-dark-600 hover:border-sf-accent hover:text-white'
+              }`}
+              title="Export the current timeline as FCPXML for Resolve, Final Cut, or Premiere interchange"
+            >
+              <Download className="w-3 h-3" />
+              {isXmlExporting ? 'Exporting XML...' : 'Export FCPXML'}
             </button>
           </div>
 

--- a/src/services/fcpxmlExporter.js
+++ b/src/services/fcpxmlExporter.js
@@ -102,7 +102,7 @@ function buildTrackLaneMaps(tracks = []) {
   const visibleVideoTracks = tracks.filter((track) => track?.type === 'video' && track.visible !== false)
   const audibleAudioTracks = tracks.filter((track) => track?.type === 'audio' && track.muted !== true)
   return {
-    video: new Map(visibleVideoTracks.map((track, index) => [track.id, index + 1])),
+    video: new Map(visibleVideoTracks.map((track, index) => [track.id, visibleVideoTracks.length - index])),
     audio: new Map(audibleAudioTracks.map((track, index) => [track.id, -(index + 1)])),
   }
 }
@@ -116,37 +116,49 @@ function shouldExportClip(clip, track, asset) {
   return safeNumber(clip.duration, 0) > 0
 }
 
+function getClipMediaRole(clip, track, asset) {
+  if (track?.type === 'audio' || clip?.type === 'audio') return 'audio'
+  if (clip?.type === 'image' || asset?.type === 'image') return 'image'
+  return 'video'
+}
+
+function getResourceKey(asset, mediaRole) {
+  return `${asset.id}:${mediaRole}`
+}
+
 function buildResourceEntries(exportClips, timebase, formatId) {
-  const seenAssets = new Map()
+  const seenResources = new Map()
   const entries = []
 
   for (const item of exportClips) {
     const asset = item.asset
-    if (seenAssets.has(asset.id)) {
-      item.resourceId = seenAssets.get(asset.id)
+    const resourceKey = getResourceKey(asset, item.mediaRole)
+    if (seenResources.has(resourceKey)) {
+      item.resourceId = seenResources.get(resourceKey)
       continue
     }
 
-    const resourceId = `r${seenAssets.size + 2}`
-    seenAssets.set(asset.id, resourceId)
+    const resourceId = `r${seenResources.size + 2}`
+    seenResources.set(resourceKey, resourceId)
     item.resourceId = resourceId
 
-    const isImage = asset.type === 'image'
-    const isAudio = asset.type === 'audio'
+    const isImage = item.mediaRole === 'image'
+    const isAudio = item.mediaRole === 'audio'
+    const isVideoOnly = item.mediaRole === 'video'
     const mediaDurationFrames = Math.max(
       ...exportClips
-        .filter((entry) => entry.asset.id === asset.id)
+        .filter((entry) => getResourceKey(entry.asset, entry.mediaRole) === resourceKey)
         .map((entry) => getAssetMediaDuration(asset, entry.clip, timebase))
     )
     const attrs = [
       `id="${resourceId}"`,
       `name="${escapeXml(sanitizeName(asset.name, 'Media'))}"`,
-      `uid="${escapeXml(asset.id)}"`,
+      `uid="${escapeXml(`${asset.id}-${item.mediaRole}`)}"`,
       `src="${escapeXml(filePathToFileUri(asset.absolutePath))}"`,
       'start="0s"',
       `duration="${formatFrames(mediaDurationFrames, timebase)}"`,
       `hasVideo="${isAudio ? '0' : '1'}"`,
-      `hasAudio="${isImage ? '0' : (asset.hasAudio === false ? '0' : '1')}"`,
+      `hasAudio="${isImage || isVideoOnly ? '0' : (asset.hasAudio === false ? '0' : '1')}"`,
     ]
     if (!isAudio) attrs.push(`format="${formatId}"`)
     entries.push(`    <asset ${attrs.join(' ')}/>`)
@@ -162,7 +174,7 @@ function buildClipElement(item, timebase) {
   const sourceStart = Math.max(0, safeNumber(clip.trimStart, 0))
   const sourceStartFrames = secondsToFrames(sourceStart, timebase)
   const name = sanitizeName(clip.name || asset.name, 'Clip')
-  const audioAttrs = asset.type !== 'image' && asset.hasAudio !== false
+  const audioAttrs = item.mediaRole === 'audio' && asset.hasAudio !== false
     ? ' audioRole="dialogue"'
     : ''
   const enabledAttr = clip.enabled === false ? ' enabled="0"' : ''
@@ -201,6 +213,7 @@ export function buildFcpXml({
     .map((entry) => ({
       ...entry,
       lane: getClipLane(entry.clip, entry.track, trackLaneMaps),
+      mediaRole: getClipMediaRole(entry.clip, entry.track, entry.asset),
     }))
     .sort((a, b) => (
       safeNumber(a.clip.startTime, 0) - safeNumber(b.clip.startTime, 0)

--- a/src/services/fcpxmlExporter.js
+++ b/src/services/fcpxmlExporter.js
@@ -1,0 +1,248 @@
+const FCPXML_VERSION = '1.10'
+const DEFAULT_FPS = 24
+
+const SUPPORTED_CLIP_TYPES = new Set(['video', 'audio', 'image'])
+
+function safeNumber(value, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function sanitizeName(value, fallback = 'Untitled') {
+  const trimmed = String(value || '').trim()
+  return trimmed || fallback
+}
+
+function sanitizeId(value, fallback) {
+  const base = String(value || fallback || 'item').trim()
+  return base.replace(/[^a-zA-Z0-9_-]/g, '_').replace(/^([^a-zA-Z_])/, '_$1') || fallback
+}
+
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function normalizeFps(value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_FPS
+}
+
+function getTimebase(fpsValue) {
+  const fps = normalizeFps(fpsValue)
+  if (Math.abs(fps - 23.976) < 0.01) {
+    return { fps, numerator: 1001, denominator: 24000, frameDuration: '1001/24000s' }
+  }
+  if (Math.abs(fps - 29.97) < 0.01) {
+    return { fps, numerator: 1001, denominator: 30000, frameDuration: '1001/30000s' }
+  }
+  if (Math.abs(fps - 59.94) < 0.01) {
+    return { fps, numerator: 1001, denominator: 60000, frameDuration: '1001/60000s' }
+  }
+  const rounded = Math.max(1, Math.round(fps))
+  return { fps: rounded, numerator: 1, denominator: rounded, frameDuration: `1/${rounded}s` }
+}
+
+function secondsToFrames(seconds, timebase) {
+  const safeSeconds = Math.max(0, safeNumber(seconds, 0))
+  return Math.max(0, Math.round(safeSeconds * timebase.fps))
+}
+
+function formatFrames(frames, timebase) {
+  const safeFrames = Math.max(0, Math.round(safeNumber(frames, 0)))
+  if (safeFrames === 0) return '0s'
+  const numerator = safeFrames * timebase.numerator
+  const denominator = timebase.denominator
+  if (numerator % denominator === 0) return `${numerator / denominator}s`
+  return `${numerator}/${denominator}s`
+}
+
+function formatSeconds(seconds, timebase) {
+  return formatFrames(secondsToFrames(seconds, timebase), timebase)
+}
+
+function filePathToFileUri(filePath) {
+  const normalized = String(filePath || '').replace(/\\/g, '/')
+  if (!normalized) return ''
+  const withLeadingSlash = /^[a-zA-Z]:\//.test(normalized) ? `/${normalized}` : normalized
+  return `file://${encodeURI(withLeadingSlash).replace(/#/g, '%23')}`
+}
+
+function getClipTimeScale(clip) {
+  const sourceTimeScale = safeNumber(clip?.sourceTimeScale, 0)
+  const fpsScale = clip?.timelineFps && clip?.sourceFps
+    ? safeNumber(clip.timelineFps, 1) / safeNumber(clip.sourceFps, 1)
+    : 1
+  const speed = safeNumber(clip?.speed, 1)
+  return Math.max(0.0001, (sourceTimeScale > 0 ? sourceTimeScale : fpsScale) * (speed > 0 ? speed : 1))
+}
+
+function getAssetMediaDuration(asset, clip, timebase) {
+  if (asset?.type === 'image' || clip?.type === 'image') {
+    return Math.max(secondsToFrames(clip?.duration || 5, timebase), 1)
+  }
+  const sourceDuration = safeNumber(clip?.sourceDuration, 0)
+  const assetDuration = safeNumber(asset?.duration || asset?.settings?.duration, 0)
+  const duration = sourceDuration > 0 ? sourceDuration : assetDuration
+  return Math.max(secondsToFrames(duration || clip?.duration || 1, timebase), 1)
+}
+
+function getClipLane(clip, track, trackLaneMaps) {
+  if (track?.type === 'audio') {
+    return trackLaneMaps.audio.get(track.id) || -1
+  }
+  return trackLaneMaps.video.get(track?.id) || 1
+}
+
+function buildTrackLaneMaps(tracks = []) {
+  const visibleVideoTracks = tracks.filter((track) => track?.type === 'video' && track.visible !== false)
+  const audibleAudioTracks = tracks.filter((track) => track?.type === 'audio' && track.muted !== true)
+  return {
+    video: new Map(visibleVideoTracks.map((track, index) => [track.id, index + 1])),
+    audio: new Map(audibleAudioTracks.map((track, index) => [track.id, -(index + 1)])),
+  }
+}
+
+function shouldExportClip(clip, track, asset) {
+  if (!clip || clip.enabled === false) return false
+  if (!SUPPORTED_CLIP_TYPES.has(clip.type)) return false
+  if (!asset?.absolutePath) return false
+  if (track?.type === 'video' && track.visible === false) return false
+  if (track?.type === 'audio' && track.muted === true) return false
+  return safeNumber(clip.duration, 0) > 0
+}
+
+function buildResourceEntries(exportClips, timebase, formatId) {
+  const seenAssets = new Map()
+  const entries = []
+
+  for (const item of exportClips) {
+    const asset = item.asset
+    if (seenAssets.has(asset.id)) {
+      item.resourceId = seenAssets.get(asset.id)
+      continue
+    }
+
+    const resourceId = `r${seenAssets.size + 2}`
+    seenAssets.set(asset.id, resourceId)
+    item.resourceId = resourceId
+
+    const isImage = asset.type === 'image'
+    const isAudio = asset.type === 'audio'
+    const mediaDurationFrames = Math.max(
+      ...exportClips
+        .filter((entry) => entry.asset.id === asset.id)
+        .map((entry) => getAssetMediaDuration(asset, entry.clip, timebase))
+    )
+    const attrs = [
+      `id="${resourceId}"`,
+      `name="${escapeXml(sanitizeName(asset.name, 'Media'))}"`,
+      `uid="${escapeXml(asset.id)}"`,
+      `src="${escapeXml(filePathToFileUri(asset.absolutePath))}"`,
+      'start="0s"',
+      `duration="${formatFrames(mediaDurationFrames, timebase)}"`,
+      `hasVideo="${isAudio ? '0' : '1'}"`,
+      `hasAudio="${isImage ? '0' : (asset.hasAudio === false ? '0' : '1')}"`,
+    ]
+    if (!isAudio) attrs.push(`format="${formatId}"`)
+    entries.push(`    <asset ${attrs.join(' ')}/>`)
+  }
+
+  return entries
+}
+
+function buildClipElement(item, timebase) {
+  const { clip, asset, track, resourceId, lane } = item
+  const durationFrames = Math.max(secondsToFrames(clip.duration, timebase), 1)
+  const startFrames = secondsToFrames(clip.startTime, timebase)
+  const sourceStart = Math.max(0, safeNumber(clip.trimStart, 0))
+  const sourceStartFrames = secondsToFrames(sourceStart, timebase)
+  const name = sanitizeName(clip.name || asset.name, 'Clip')
+  const audioAttrs = asset.type !== 'image' && asset.hasAudio !== false
+    ? ' audioRole="dialogue"'
+    : ''
+  const enabledAttr = clip.enabled === false ? ' enabled="0"' : ''
+  const laneAttr = lane ? ` lane="${lane}"` : ''
+  const note = `comfystudio:clipId=${clip.id};assetId=${asset.id};trackId=${track?.id || 'unknown'}`
+  return [
+    `      <asset-clip name="${escapeXml(name)}" ref="${resourceId}" offset="${formatFrames(startFrames, timebase)}" start="${formatFrames(sourceStartFrames, timebase)}" duration="${formatFrames(durationFrames, timebase)}"${laneAttr}${audioAttrs}${enabledAttr}>`,
+    `        <note>${escapeXml(note)}</note>`,
+    '      </asset-clip>',
+  ].join('\n')
+}
+
+export function buildFcpXml({
+  projectName = 'ComfyStudio Project',
+  timelineName = 'Timeline',
+  timelineSettings = {},
+  timeline = {},
+  assets = [],
+} = {}) {
+  const timebase = getTimebase(timelineSettings.fps || timeline.timelineFps || DEFAULT_FPS)
+  const width = Math.max(1, Math.round(safeNumber(timelineSettings.width, 1920)))
+  const height = Math.max(1, Math.round(safeNumber(timelineSettings.height, 1080)))
+  const clips = Array.isArray(timeline.clips) ? timeline.clips : []
+  const tracks = Array.isArray(timeline.tracks) ? timeline.tracks : []
+  const assetsById = new Map((Array.isArray(assets) ? assets : []).map((asset) => [asset.id, asset]))
+  const tracksById = new Map(tracks.map((track) => [track.id, track]))
+  const trackLaneMaps = buildTrackLaneMaps(tracks)
+
+  const exportClips = clips
+    .map((clip) => {
+      const asset = assetsById.get(clip.assetId)
+      const track = tracksById.get(clip.trackId)
+      return { clip, asset, track }
+    })
+    .filter(({ clip, asset, track }) => shouldExportClip(clip, track, asset))
+    .map((entry) => ({
+      ...entry,
+      lane: getClipLane(entry.clip, entry.track, trackLaneMaps),
+    }))
+    .sort((a, b) => (
+      safeNumber(a.clip.startTime, 0) - safeNumber(b.clip.startTime, 0)
+      || safeNumber(a.lane, 0) - safeNumber(b.lane, 0)
+      || String(a.clip.id).localeCompare(String(b.clip.id))
+    ))
+
+  const computedEnd = exportClips.reduce((max, entry) => (
+    Math.max(max, safeNumber(entry.clip.startTime, 0) + safeNumber(entry.clip.duration, 0))
+  ), safeNumber(timeline.duration, 0))
+  const sequenceDurationFrames = Math.max(secondsToFrames(computedEnd || 1, timebase), 1)
+  const formatId = 'r1'
+  const resourceEntries = [
+    `    <format id="${formatId}" name="ComfyStudio ${width}x${height} ${timebase.fps}fps" frameDuration="${timebase.frameDuration}" width="${width}" height="${height}" colorSpace="1-1-1 (Rec. 709)"/>`,
+    ...buildResourceEntries(exportClips, timebase, formatId),
+  ]
+  const clipElements = exportClips.map((item) => buildClipElement(item, timebase))
+  const safeProjectId = sanitizeId(projectName, 'comfystudio_project')
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE fcpxml>',
+    `<fcpxml version="${FCPXML_VERSION}">`,
+    '  <resources>',
+    ...resourceEntries,
+    '  </resources>',
+    '  <library>',
+    `    <event name="${escapeXml(sanitizeName(projectName, 'ComfyStudio Project'))}">`,
+    `      <project name="${escapeXml(sanitizeName(timelineName, 'Timeline'))}" uid="${escapeXml(safeProjectId)}">`,
+    `        <sequence format="${formatId}" duration="${formatFrames(sequenceDurationFrames, timebase)}" tcStart="0s" tcFormat="NDF" audioLayout="stereo" audioRate="48k">`,
+    '          <spine>',
+    `            <gap name="ComfyStudio Timeline" offset="0s" start="0s" duration="${formatFrames(sequenceDurationFrames, timebase)}">`,
+    ...clipElements,
+    '            </gap>',
+    '          </spine>',
+    '        </sequence>',
+    '      </project>',
+    '    </event>',
+    '  </library>',
+    '</fcpxml>',
+    '',
+  ].join('\n')
+}
+
+export default buildFcpXml


### PR DESCRIPTION
## Summary
- Adds a first-pass FCPXML export button to the Export panel for the current timeline.
- Writes video, image, and audio clips with timeline timing, source trims, lanes, and project media file paths.
- Stores ComfyStudio clip, asset, and track ids in XML notes so we have a path toward future import/round-trip work.

## Testing
- [x] I ran `npm run build`
- [x] I smoke-tested the exported `.fcpxml` in Resolve / Final Cut / Premiere
- [ ] I updated docs when behavior, setup, onboarding, or release steps changed

## Notes
This is intentionally export-only for now. It does not attempt to round-trip XML back into ComfyStudio yet, and it does not preserve effects, transitions, text clips, or editor-specific finishing features.

## Contributor License Agreement
- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.