### PR TITLE
Add FCPXML timeline import

### DIFF
--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -6,7 +6,7 @@ import useAssetsStore from '../stores/assetsStore'
 import exportTimeline from '../services/exporter'
 import buildFcpXml from '../services/fcpxmlExporter'
 import parseFcpXml from '../services/fcpxmlImporter'
-import { importAsset } from '../services/fileSystem'
+import { getAbsoluteFileUrl, importAsset } from '../services/fileSystem'
 
 const EXPORT_SETTINGS_STORAGE_PREFIX = 'comfystudio-export-settings-v1'
 
@@ -1130,11 +1130,17 @@ function ExportPanel() {
           continue
         }
         const assetInfo = await importAsset(currentProjectHandle, resource.sourcePath, category)
+        const assetUrl = assetInfo.absolutePath
+          ? await getAbsoluteFileUrl(assetInfo.absolutePath)
+          : assetInfo.url
         const importedAsset = addAsset({
           ...assetInfo,
+          url: assetUrl || assetInfo.url || null,
           name: resource.name || assetInfo.name,
           settings: {
             ...(assetInfo.settings || {}),
+            duration: assetInfo.duration ?? assetInfo.settings?.duration,
+            fps: assetInfo.fps ?? assetInfo.settings?.fps,
             importedFromFcpXml: {
               resourceId: resource.id,
               originalPath: resource.sourcePath,

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Download, Plus, Trash2, Play, Settings, Film, Clock, RotateCcw } from 'lucide-react'
+import { Download, Upload, Plus, Trash2, Play, Settings, Film, Clock, RotateCcw } from 'lucide-react'
 import useProjectStore, { RESOLUTION_PRESETS, FPS_PRESETS } from '../stores/projectStore'
 import useTimelineStore from '../stores/timelineStore'
 import useAssetsStore from '../stores/assetsStore'
 import exportTimeline from '../services/exporter'
 import buildFcpXml from '../services/fcpxmlExporter'
+import parseFcpXml from '../services/fcpxmlImporter'
+import { importAsset } from '../services/fileSystem'
 
 const EXPORT_SETTINGS_STORAGE_PREFIX = 'comfystudio-export-settings-v1'
 
@@ -299,10 +301,24 @@ function sanitizeExportBaseName(value) {
     || 'ComfyStudio_Timeline'
 }
 
+function getFcpXmlImportCategory(resource, mediaType) {
+  if (mediaType === 'image' || resource?.kind === 'image') return 'images'
+  if (mediaType === 'audio' || resource?.kind === 'audio') return 'audio'
+  return 'video'
+}
+
 function ExportPanel() {
-  const { currentProject, currentProjectHandle, currentTimelineId, getCurrentTimelineSettings } = useProjectStore()
+  const {
+    currentProject,
+    currentProjectHandle,
+    currentTimelineId,
+    getCurrentTimelineSettings,
+    createTimeline,
+    switchTimeline,
+    saveProject,
+  } = useProjectStore()
   const { duration, inPoint, outPoint, getTimelineEndTime, selectedClipIds, clips, transitions, tracks } = useTimelineStore()
-  const { assets } = useAssetsStore()
+  const { assets, addAsset } = useAssetsStore()
   
   const projectName = currentProject?.name || 'Untitled'
   const currentTimeline = useMemo(() => (
@@ -325,6 +341,7 @@ function ExportPanel() {
   const [etaSeconds, setEtaSeconds] = useState(null)
   const [renderFps, setRenderFps] = useState(null)
   const [isXmlExporting, setIsXmlExporting] = useState(false)
+  const [isXmlImporting, setIsXmlImporting] = useState(false)
   const exportStartRef = useRef(null)
   const renderStartRef = useRef(null)
   const [nvencStatus, setNvencStatus] = useState({
@@ -1032,6 +1049,196 @@ function ExportPanel() {
       setIsXmlExporting(false)
     }
   }
+
+  const handleImportFcpXml = async () => {
+    if (isExporting || queueRunning || isXmlExporting || isXmlImporting) return
+    if (!window.electronAPI?.selectFile || !window.electronAPI?.readFile || !window.electronAPI?.exists) {
+      setExportError('FCPXML import is only available in the desktop app.')
+      return
+    }
+    if (typeof currentProjectHandle !== 'string') {
+      setExportError('Open a saved project before importing FCPXML.')
+      return
+    }
+
+    setIsXmlImporting(true)
+    setExportError(null)
+    setExportResult(null)
+    setExportProgress(0)
+    setEtaSeconds(null)
+    setRenderFps(null)
+    setExportStatus('Choosing FCPXML...')
+
+    try {
+      const filePath = await window.electronAPI.selectFile({
+        title: 'Import FCPXML',
+        filters: [
+          { name: 'Final Cut Pro XML', extensions: ['fcpxml', 'xml'] },
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      })
+      if (!filePath) {
+        setExportStatus('FCPXML import cancelled')
+        return
+      }
+
+      setExportStatus('Reading FCPXML...')
+      const readResult = await window.electronAPI.readFile(filePath, { encoding: 'utf8' })
+      if (!readResult?.success) {
+        throw new Error(readResult?.error || 'Could not read FCPXML file.')
+      }
+
+      const fileBaseName = window.electronAPI.pathBasename
+        ? await window.electronAPI.pathBasename(filePath, '.fcpxml')
+        : 'Imported FCPXML'
+      const importPlan = parseFcpXml(readResult.data, {
+        name: `Imported ${fileBaseName || 'FCPXML'}`,
+      })
+      if (!importPlan.clips.length) {
+        throw new Error('No supported media clips were found in this FCPXML.')
+      }
+
+      setExportStatus('Importing referenced media...')
+      const resourcesById = new Map((importPlan.assets || []).map((resource) => [resource.id, resource]))
+      const warnings = [...(importPlan.warnings || [])]
+      const importedAssetsByResourceId = new Map()
+      const assetNeeds = new Map()
+
+      for (const clip of importPlan.clips) {
+        const resource = resourcesById.get(clip.resourceId)
+        if (!resource) continue
+        if (clip.mediaType === 'audio' && resource.kind === 'video') {
+          warnings.push(`Skipped audio-only clip "${clip.name}" from video source "${resource.name}".`)
+          continue
+        }
+        if (!resource.sourcePath) {
+          warnings.push(`Skipped "${resource.name}" because the FCPXML media path is missing.`)
+          continue
+        }
+        if (!assetNeeds.has(resource.id)) {
+          assetNeeds.set(resource.id, {
+            resource,
+            category: getFcpXmlImportCategory(resource, clip.mediaType),
+          })
+        }
+      }
+
+      for (const { resource, category } of assetNeeds.values()) {
+        const exists = await window.electronAPI.exists(resource.sourcePath)
+        if (!exists) {
+          warnings.push(`Skipped "${resource.name}" because the media file was not found: ${resource.sourcePath}`)
+          continue
+        }
+        const assetInfo = await importAsset(currentProjectHandle, resource.sourcePath, category)
+        const importedAsset = addAsset({
+          ...assetInfo,
+          name: resource.name || assetInfo.name,
+          settings: {
+            ...(assetInfo.settings || {}),
+            importedFromFcpXml: {
+              resourceId: resource.id,
+              originalPath: resource.sourcePath,
+            },
+          },
+        })
+        importedAssetsByResourceId.set(resource.id, importedAsset)
+      }
+
+      if (importedAssetsByResourceId.size === 0) {
+        throw new Error('No referenced media files could be imported. Check that the FCPXML media paths still exist on this machine.')
+      }
+
+      setExportStatus('Creating imported timeline...')
+      const newTimeline = createTimeline({
+        name: importPlan.name,
+        width: importPlan.settings.width,
+        height: importPlan.settings.height,
+        fps: importPlan.settings.fps,
+      })
+      if (!newTimeline?.id) {
+        throw new Error('Could not create a timeline for the FCPXML import.')
+      }
+      await switchTimeline(newTimeline.id)
+
+      const timelineApi = useTimelineStore.getState()
+      const latestAssets = useAssetsStore.getState().assets || []
+      timelineApi.loadFromProject({
+        ...newTimeline,
+        width: importPlan.settings.width,
+        height: importPlan.settings.height,
+        fps: importPlan.settings.fps,
+        duration: importPlan.duration,
+        tracks: importPlan.tracks,
+        clips: [],
+        transitions: [],
+        markers: [],
+        clipCounter: 1,
+        transitionCounter: 1,
+        markerCounter: 1,
+      }, latestAssets, importPlan.settings.fps)
+
+      let addedClipCount = 0
+      let skippedClipCount = 0
+      for (const clip of importPlan.clips) {
+        const resource = resourcesById.get(clip.resourceId)
+        if (clip.mediaType === 'audio' && resource?.kind === 'video') {
+          skippedClipCount += 1
+          continue
+        }
+        const importedAsset = importedAssetsByResourceId.get(clip.resourceId)
+        if (!importedAsset || !clip.trackId) {
+          skippedClipCount += 1
+          continue
+        }
+        const addedClip = useTimelineStore.getState().addClip(
+          clip.trackId,
+          importedAsset,
+          clip.startTime,
+          importPlan.settings.fps,
+          {
+            duration: clip.duration,
+            trimStart: clip.trimStart,
+            trimEnd: clip.trimStart + clip.duration,
+            resolveOverlaps: false,
+            saveHistory: false,
+            selectAfterAdd: false,
+            metadata: {
+              importedFromFcpXml: {
+                originalClipId: clip.id,
+                resourceId: clip.resourceId,
+                lane: clip.lane,
+                mediaType: clip.mediaType,
+              },
+            },
+          }
+        )
+        if (addedClip) {
+          addedClipCount += 1
+        } else {
+          skippedClipCount += 1
+        }
+      }
+
+      if (addedClipCount === 0) {
+        throw new Error('No FCPXML clips could be placed on the imported timeline.')
+      }
+
+      await saveProject?.()
+      const warningSuffix = warnings.length || skippedClipCount
+        ? ` (${warnings.length + skippedClipCount} skipped/warnings)`
+        : ''
+      setExportResult({ outputPath: filePath, encoderUsed: 'FCPXML Import', clipCount: addedClipCount })
+      setExportStatus(`FCPXML import complete: ${addedClipCount} clips${warningSuffix}`)
+      if (warnings.length) {
+        console.warn('[FCPXML Import]', warnings)
+      }
+    } catch (err) {
+      setExportError(err?.message || 'FCPXML import failed')
+      setExportStatus('FCPXML import failed')
+    } finally {
+      setIsXmlImporting(false)
+    }
+  }
   
   return (
     <div className="flex-1 min-h-0 flex flex-col min-w-0 overflow-hidden bg-sf-dark-950">
@@ -1571,9 +1778,9 @@ function ExportPanel() {
             </button>
             <button
               onClick={handleStartExport}
-              disabled={isExporting || queueRunning}
+              disabled={isExporting || queueRunning || isXmlImporting}
               className={`px-3 py-1.5 text-xs rounded border flex items-center gap-1.5 transition-colors ${
-                isExporting || queueRunning
+                isExporting || queueRunning || isXmlImporting
                   ? 'bg-sf-dark-800 text-sf-text-muted border-sf-dark-600 cursor-not-allowed'
                   : 'bg-sf-accent text-white border-sf-accent hover:bg-sf-accent-hover'
               }`}
@@ -1583,9 +1790,9 @@ function ExportPanel() {
             </button>
             <button
               onClick={handleExportFcpXml}
-              disabled={isExporting || queueRunning || isXmlExporting}
+              disabled={isExporting || queueRunning || isXmlExporting || isXmlImporting}
               className={`px-3 py-1.5 text-xs rounded border flex items-center gap-1.5 transition-colors ${
-                isExporting || queueRunning || isXmlExporting
+                isExporting || queueRunning || isXmlExporting || isXmlImporting
                   ? 'bg-sf-dark-800 text-sf-text-muted border-sf-dark-600 cursor-not-allowed'
                   : 'bg-sf-dark-800 text-sf-text-primary border-sf-dark-600 hover:border-sf-accent hover:text-white'
               }`}
@@ -1593,6 +1800,19 @@ function ExportPanel() {
             >
               <Download className="w-3 h-3" />
               {isXmlExporting ? 'Exporting XML...' : 'Export FCPXML'}
+            </button>
+            <button
+              onClick={handleImportFcpXml}
+              disabled={isExporting || queueRunning || isXmlExporting || isXmlImporting}
+              className={`px-3 py-1.5 text-xs rounded border flex items-center gap-1.5 transition-colors ${
+                isExporting || queueRunning || isXmlExporting || isXmlImporting
+                  ? 'bg-sf-dark-800 text-sf-text-muted border-sf-dark-600 cursor-not-allowed'
+                  : 'bg-sf-dark-800 text-sf-text-primary border-sf-dark-600 hover:border-sf-accent hover:text-white'
+              }`}
+              title="Import an FCPXML as a new ComfyStudio timeline"
+            >
+              <Upload className="w-3 h-3" />
+              {isXmlImporting ? 'Importing XML...' : 'Import FCPXML'}
             </button>
           </div>
 

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -1,12 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Download, Upload, Plus, Trash2, Play, Settings, Film, Clock, RotateCcw } from 'lucide-react'
+import { Download, Plus, Trash2, Play, Settings, Film, Clock, RotateCcw } from 'lucide-react'
 import useProjectStore, { RESOLUTION_PRESETS, FPS_PRESETS } from '../stores/projectStore'
 import useTimelineStore from '../stores/timelineStore'
 import useAssetsStore from '../stores/assetsStore'
 import exportTimeline from '../services/exporter'
 import buildFcpXml from '../services/fcpxmlExporter'
-import parseFcpXml from '../services/fcpxmlImporter'
-import { getAbsoluteFileUrl, importAsset } from '../services/fileSystem'
 
 const EXPORT_SETTINGS_STORAGE_PREFIX = 'comfystudio-export-settings-v1'
 
@@ -301,24 +299,15 @@ function sanitizeExportBaseName(value) {
     || 'ComfyStudio_Timeline'
 }
 
-function getFcpXmlImportCategory(resource, mediaType) {
-  if (mediaType === 'image' || resource?.kind === 'image') return 'images'
-  if (resource?.kind === 'audio' || (mediaType === 'audio' && resource?.kind !== 'video')) return 'audio'
-  return 'video'
-}
-
 function ExportPanel() {
   const {
     currentProject,
     currentProjectHandle,
     currentTimelineId,
     getCurrentTimelineSettings,
-    createTimeline,
-    switchTimeline,
-    saveProject,
   } = useProjectStore()
   const { duration, inPoint, outPoint, getTimelineEndTime, selectedClipIds, clips, transitions, tracks } = useTimelineStore()
-  const { assets, addAsset } = useAssetsStore()
+  const { assets } = useAssetsStore()
   
   const projectName = currentProject?.name || 'Untitled'
   const currentTimeline = useMemo(() => (
@@ -341,7 +330,6 @@ function ExportPanel() {
   const [etaSeconds, setEtaSeconds] = useState(null)
   const [renderFps, setRenderFps] = useState(null)
   const [isXmlExporting, setIsXmlExporting] = useState(false)
-  const [isXmlImporting, setIsXmlImporting] = useState(false)
   const exportStartRef = useRef(null)
   const renderStartRef = useRef(null)
   const [nvencStatus, setNvencStatus] = useState({
@@ -1050,199 +1038,6 @@ function ExportPanel() {
     }
   }
 
-  const handleImportFcpXml = async () => {
-    if (isExporting || queueRunning || isXmlExporting || isXmlImporting) return
-    if (!window.electronAPI?.selectFile || !window.electronAPI?.readFile || !window.electronAPI?.exists) {
-      setExportError('FCPXML import is only available in the desktop app.')
-      return
-    }
-    if (typeof currentProjectHandle !== 'string') {
-      setExportError('Open a saved project before importing FCPXML.')
-      return
-    }
-
-    setIsXmlImporting(true)
-    setExportError(null)
-    setExportResult(null)
-    setExportProgress(0)
-    setEtaSeconds(null)
-    setRenderFps(null)
-    setExportStatus('Choosing FCPXML...')
-
-    try {
-      const filePath = await window.electronAPI.selectFile({
-        title: 'Import FCPXML',
-        filters: [
-          { name: 'Final Cut Pro XML', extensions: ['fcpxml', 'xml'] },
-          { name: 'All Files', extensions: ['*'] },
-        ],
-      })
-      if (!filePath) {
-        setExportStatus('FCPXML import cancelled')
-        return
-      }
-
-      setExportStatus('Reading FCPXML...')
-      const readResult = await window.electronAPI.readFile(filePath, { encoding: 'utf8' })
-      if (!readResult?.success) {
-        throw new Error(readResult?.error || 'Could not read FCPXML file.')
-      }
-
-      const fileBaseName = window.electronAPI.pathBasename
-        ? await window.electronAPI.pathBasename(filePath, '.fcpxml')
-        : 'Imported FCPXML'
-      const importPlan = parseFcpXml(readResult.data, {
-        name: `Imported ${fileBaseName || 'FCPXML'}`,
-      })
-      if (!importPlan.clips.length) {
-        throw new Error('No supported media clips were found in this FCPXML.')
-      }
-
-      setExportStatus('Importing referenced media...')
-      const resourcesById = new Map((importPlan.assets || []).map((resource) => [resource.id, resource]))
-      const warnings = [...(importPlan.warnings || [])]
-      const importedAssetsByResourceId = new Map()
-      const assetNeeds = new Map()
-
-      for (const clip of importPlan.clips) {
-        const resource = resourcesById.get(clip.resourceId)
-        if (!resource) continue
-        if (!resource.sourcePath) {
-          warnings.push(`Skipped "${resource.name}" because the FCPXML media path is missing.`)
-          continue
-        }
-        if (!assetNeeds.has(resource.id)) {
-          assetNeeds.set(resource.id, {
-            resource,
-            category: getFcpXmlImportCategory(resource, clip.mediaType),
-          })
-        }
-      }
-
-      for (const { resource, category } of assetNeeds.values()) {
-        const exists = await window.electronAPI.exists(resource.sourcePath)
-        if (!exists) {
-          warnings.push(`Skipped "${resource.name}" because the media file was not found: ${resource.sourcePath}`)
-          continue
-        }
-        const assetInfo = await importAsset(currentProjectHandle, resource.sourcePath, category)
-        const assetUrl = assetInfo.absolutePath
-          ? await getAbsoluteFileUrl(assetInfo.absolutePath)
-          : assetInfo.url
-        const importedAsset = addAsset({
-          ...assetInfo,
-          url: assetUrl || assetInfo.url || null,
-          name: resource.name || assetInfo.name,
-          settings: {
-            ...(assetInfo.settings || {}),
-            duration: assetInfo.duration ?? assetInfo.settings?.duration,
-            fps: assetInfo.fps ?? assetInfo.settings?.fps,
-            importedFromFcpXml: {
-              resourceId: resource.id,
-              originalPath: resource.sourcePath,
-            },
-          },
-        })
-        importedAssetsByResourceId.set(resource.id, importedAsset)
-      }
-
-      if (importedAssetsByResourceId.size === 0) {
-        throw new Error('No referenced media files could be imported. Check that the FCPXML media paths still exist on this machine.')
-      }
-
-      setExportStatus('Creating imported timeline...')
-      const newTimeline = createTimeline({
-        name: importPlan.name,
-        width: importPlan.settings.width,
-        height: importPlan.settings.height,
-        fps: importPlan.settings.fps,
-      })
-      if (!newTimeline?.id) {
-        throw new Error('Could not create a timeline for the FCPXML import.')
-      }
-      await switchTimeline(newTimeline.id)
-
-      const timelineApi = useTimelineStore.getState()
-      const latestAssets = useAssetsStore.getState().assets || []
-      timelineApi.loadFromProject({
-        ...newTimeline,
-        width: importPlan.settings.width,
-        height: importPlan.settings.height,
-        fps: importPlan.settings.fps,
-        duration: importPlan.duration,
-        tracks: importPlan.tracks,
-        clips: [],
-        transitions: [],
-        markers: [],
-        clipCounter: 1,
-        transitionCounter: 1,
-        markerCounter: 1,
-      }, latestAssets, importPlan.settings.fps)
-
-      let addedClipCount = 0
-      let skippedClipCount = 0
-      for (const clip of importPlan.clips) {
-        const resource = resourcesById.get(clip.resourceId)
-        const importedAsset = importedAssetsByResourceId.get(clip.resourceId)
-        if (!importedAsset || !clip.trackId) {
-          skippedClipCount += 1
-          continue
-        }
-        const timelineAsset = clip.mediaType === 'audio' && importedAsset.type === 'video'
-          ? { ...importedAsset, type: 'audio' }
-          : importedAsset
-        const addedClip = useTimelineStore.getState().addClip(
-          clip.trackId,
-          timelineAsset,
-          clip.startTime,
-          importPlan.settings.fps,
-          {
-            duration: clip.duration,
-            trimStart: clip.trimStart,
-            trimEnd: clip.trimStart + clip.duration,
-            resolveOverlaps: false,
-            saveHistory: false,
-            selectAfterAdd: false,
-            ...(clip.linkGroupId ? { linkGroupId: clip.linkGroupId } : {}),
-            metadata: {
-              importedFromFcpXml: {
-                originalClipId: clip.id,
-                resourceId: clip.resourceId,
-                lane: clip.lane,
-                mediaType: clip.mediaType,
-                hasEmbeddedAudio: !!clip.hasEmbeddedAudio,
-              },
-            },
-          }
-        )
-        if (addedClip) {
-          addedClipCount += 1
-        } else {
-          skippedClipCount += 1
-        }
-      }
-
-      if (addedClipCount === 0) {
-        throw new Error('No FCPXML clips could be placed on the imported timeline.')
-      }
-
-      await saveProject?.()
-      const warningSuffix = warnings.length || skippedClipCount
-        ? ` (${warnings.length + skippedClipCount} skipped/warnings)`
-        : ''
-      setExportResult({ outputPath: filePath, encoderUsed: 'FCPXML Import', clipCount: addedClipCount })
-      setExportStatus(`FCPXML import complete: ${addedClipCount} clips${warningSuffix}`)
-      if (warnings.length) {
-        console.warn('[FCPXML Import]', warnings)
-      }
-    } catch (err) {
-      setExportError(err?.message || 'FCPXML import failed')
-      setExportStatus('FCPXML import failed')
-    } finally {
-      setIsXmlImporting(false)
-    }
-  }
-  
   return (
     <div className="flex-1 min-h-0 flex flex-col min-w-0 overflow-hidden bg-sf-dark-950">
       {/* Header */}
@@ -1781,9 +1576,9 @@ function ExportPanel() {
             </button>
             <button
               onClick={handleStartExport}
-              disabled={isExporting || queueRunning || isXmlImporting}
+              disabled={isExporting || queueRunning}
               className={`px-3 py-1.5 text-xs rounded border flex items-center gap-1.5 transition-colors ${
-                isExporting || queueRunning || isXmlImporting
+                isExporting || queueRunning
                   ? 'bg-sf-dark-800 text-sf-text-muted border-sf-dark-600 cursor-not-allowed'
                   : 'bg-sf-accent text-white border-sf-accent hover:bg-sf-accent-hover'
               }`}
@@ -1793,9 +1588,9 @@ function ExportPanel() {
             </button>
             <button
               onClick={handleExportFcpXml}
-              disabled={isExporting || queueRunning || isXmlExporting || isXmlImporting}
+              disabled={isExporting || queueRunning || isXmlExporting}
               className={`px-3 py-1.5 text-xs rounded border flex items-center gap-1.5 transition-colors ${
-                isExporting || queueRunning || isXmlExporting || isXmlImporting
+                isExporting || queueRunning || isXmlExporting
                   ? 'bg-sf-dark-800 text-sf-text-muted border-sf-dark-600 cursor-not-allowed'
                   : 'bg-sf-dark-800 text-sf-text-primary border-sf-dark-600 hover:border-sf-accent hover:text-white'
               }`}
@@ -1803,19 +1598,6 @@ function ExportPanel() {
             >
               <Download className="w-3 h-3" />
               {isXmlExporting ? 'Exporting XML...' : 'Export FCPXML'}
-            </button>
-            <button
-              onClick={handleImportFcpXml}
-              disabled={isExporting || queueRunning || isXmlExporting || isXmlImporting}
-              className={`px-3 py-1.5 text-xs rounded border flex items-center gap-1.5 transition-colors ${
-                isExporting || queueRunning || isXmlExporting || isXmlImporting
-                  ? 'bg-sf-dark-800 text-sf-text-muted border-sf-dark-600 cursor-not-allowed'
-                  : 'bg-sf-dark-800 text-sf-text-primary border-sf-dark-600 hover:border-sf-accent hover:text-white'
-              }`}
-              title="Import an FCPXML as a new ComfyStudio timeline"
-            >
-              <Upload className="w-3 h-3" />
-              {isXmlImporting ? 'Importing XML...' : 'Import FCPXML'}
             </button>
           </div>
 

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -303,7 +303,7 @@ function sanitizeExportBaseName(value) {
 
 function getFcpXmlImportCategory(resource, mediaType) {
   if (mediaType === 'image' || resource?.kind === 'image') return 'images'
-  if (mediaType === 'audio' || resource?.kind === 'audio') return 'audio'
+  if (resource?.kind === 'audio' || (mediaType === 'audio' && resource?.kind !== 'video')) return 'audio'
   return 'video'
 }
 
@@ -1107,10 +1107,6 @@ function ExportPanel() {
       for (const clip of importPlan.clips) {
         const resource = resourcesById.get(clip.resourceId)
         if (!resource) continue
-        if (clip.mediaType === 'audio' && resource.kind === 'video') {
-          warnings.push(`Skipped audio-only clip "${clip.name}" from video source "${resource.name}".`)
-          continue
-        }
         if (!resource.sourcePath) {
           warnings.push(`Skipped "${resource.name}" because the FCPXML media path is missing.`)
           continue
@@ -1187,18 +1183,17 @@ function ExportPanel() {
       let skippedClipCount = 0
       for (const clip of importPlan.clips) {
         const resource = resourcesById.get(clip.resourceId)
-        if (clip.mediaType === 'audio' && resource?.kind === 'video') {
-          skippedClipCount += 1
-          continue
-        }
         const importedAsset = importedAssetsByResourceId.get(clip.resourceId)
         if (!importedAsset || !clip.trackId) {
           skippedClipCount += 1
           continue
         }
+        const timelineAsset = clip.mediaType === 'audio' && importedAsset.type === 'video'
+          ? { ...importedAsset, type: 'audio' }
+          : importedAsset
         const addedClip = useTimelineStore.getState().addClip(
           clip.trackId,
-          importedAsset,
+          timelineAsset,
           clip.startTime,
           importPlan.settings.fps,
           {
@@ -1208,12 +1203,14 @@ function ExportPanel() {
             resolveOverlaps: false,
             saveHistory: false,
             selectAfterAdd: false,
+            ...(clip.linkGroupId ? { linkGroupId: clip.linkGroupId } : {}),
             metadata: {
               importedFromFcpXml: {
                 originalClipId: clip.id,
                 resourceId: clip.resourceId,
                 lane: clip.lane,
                 mediaType: clip.mediaType,
+                hasEmbeddedAudio: !!clip.hasEmbeddedAudio,
               },
             },
           }

--- a/src/components/panels/AssetsPanel.jsx
+++ b/src/components/panels/AssetsPanel.jsx
@@ -3,7 +3,8 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import useAssetsStore from '../../stores/assetsStore'
 import useProjectStore from '../../stores/projectStore'
 import useTimelineStore from '../../stores/timelineStore'
-import { importAsset, isElectron, writeGeneratedOverlayToProject, deleteProjectFile } from '../../services/fileSystem'
+import { getAbsoluteFileUrl, importAsset, isElectron, writeGeneratedOverlayToProject, deleteProjectFile } from '../../services/fileSystem'
+import parseFcpXml from '../../services/fcpxmlImporter'
 import { enqueuePlaybackTranscode, generatePlaybackCachesForAllVideos, isPlaybackCacheableVideoAsset } from '../../services/playbackCache'
 import { enqueueProxyTranscode, isProxyPlaybackEnabled } from '../../services/proxyCache'
 import { unstitchSequenceAsset } from '../../services/comfyAutoImport'
@@ -32,6 +33,12 @@ const FOLDER_TILE_ICON_SIZES = {
   large: 'w-20 h-20',
 }
 let transparentAssetDragImage = null
+
+function getFcpXmlImportCategory(resource, mediaType) {
+  if (mediaType === 'image' || resource?.kind === 'image') return 'images'
+  if (resource?.kind === 'audio' || (mediaType === 'audio' && resource?.kind !== 'video')) return 'audio'
+  return 'video'
+}
 
 const getTransparentAssetDragImage = () => {
   if (transparentAssetDragImage) return transparentAssetDragImage
@@ -334,7 +341,7 @@ function AssetsPanel({ isActive = true }) {
     hydrateAssetBrowserMedia,
     setAssetAudioEnabled,
   } = useAssetsStore()
-  const { currentProject, currentProjectHandle, currentTimelineId, switchTimeline, renameTimeline, setTimelineColor, moveTimelineToFolder, duplicateTimeline, deleteTimeline, getCurrentTimelineSettings } = useProjectStore()
+  const { currentProject, currentProjectHandle, currentTimelineId, createTimeline, switchTimeline, saveProject, renameTimeline, setTimelineColor, moveTimelineToFolder, duplicateTimeline, deleteTimeline, getCurrentTimelineSettings } = useProjectStore()
   const { isPlaying: timelineIsPlaying, togglePlay: timelineTogglePlay, removeAudioClipsForAsset, clearSelection: clearTimelineSelection } = useTimelineStore()
   
   // Load thumbnail size from localStorage
@@ -441,6 +448,214 @@ function AssetsPanel({ isActive = true }) {
     const files = Array.from(e.target.files || [])
     handleImport(files)
     e.target.value = ''
+  }
+
+  const handleImportFcpXml = async () => {
+    setContextMenu(null)
+    if (isImporting) return
+
+    const api = window.electronAPI
+    if (!api?.selectFile || !api?.readFile || !api?.exists) {
+      window.alert?.('FCPXML import is only available in the desktop app.')
+      return
+    }
+    if (typeof currentProjectHandle !== 'string') {
+      window.alert?.('Open a saved project before importing FCPXML.')
+      return
+    }
+
+    setIsImporting(true)
+    try {
+      const filePath = await api.selectFile({
+        title: 'Import FCPXML',
+        filters: [
+          { name: 'Final Cut Pro XML', extensions: ['fcpxml', 'fcpxmld', 'xml'] },
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      })
+      if (!filePath) return
+
+      const readResult = await api.readFile(filePath, { encoding: 'utf8' })
+      if (!readResult?.success) {
+        throw new Error(readResult?.error || 'Could not read FCPXML file.')
+      }
+
+      const selectedFileName = api.pathBasename
+        ? await api.pathBasename(filePath)
+        : 'Imported FCPXML'
+      const fileBaseName = String(selectedFileName || 'FCPXML').replace(/\.(fcpxml|fcpxmld|xml)$/i, '')
+      const importPlan = parseFcpXml(readResult.data, {
+        name: `Imported ${fileBaseName || 'FCPXML'}`,
+      })
+      if (!importPlan.clips.length) {
+        throw new Error('No supported media clips were found in this FCPXML.')
+      }
+
+      const resourcesById = new Map((importPlan.assets || []).map((resource) => [resource.id, resource]))
+      const warnings = [...(importPlan.warnings || [])]
+      const importedAssetsByResourceId = new Map()
+      const importedVideoAssets = []
+      const assetNeeds = new Map()
+
+      for (const clip of importPlan.clips) {
+        const resource = resourcesById.get(clip.resourceId)
+        if (!resource) continue
+        if (!resource.sourcePath) {
+          warnings.push(`Skipped "${resource.name}" because the FCPXML media path is missing.`)
+          continue
+        }
+        if (!assetNeeds.has(resource.id)) {
+          assetNeeds.set(resource.id, {
+            resource,
+            category: getFcpXmlImportCategory(resource, clip.mediaType),
+          })
+        }
+      }
+
+      for (const { resource, category } of assetNeeds.values()) {
+        const exists = await api.exists(resource.sourcePath)
+        if (!exists) {
+          warnings.push(`Skipped "${resource.name}" because the media file was not found: ${resource.sourcePath}`)
+          continue
+        }
+
+        const assetInfo = await importAsset(currentProjectHandle, resource.sourcePath, category)
+        const assetUrl = assetInfo.absolutePath
+          ? await getAbsoluteFileUrl(assetInfo.absolutePath)
+          : assetInfo.url
+        const importedAsset = addAsset({
+          ...assetInfo,
+          url: assetUrl || assetInfo.url || null,
+          name: resource.name || assetInfo.name,
+          folderId: currentFolderId,
+          settings: {
+            ...(assetInfo.settings || {}),
+            duration: assetInfo.duration ?? assetInfo.settings?.duration,
+            fps: assetInfo.fps ?? assetInfo.settings?.fps,
+            importedFromFcpXml: {
+              resourceId: resource.id,
+              originalPath: resource.sourcePath,
+            },
+          },
+        })
+        importedAssetsByResourceId.set(resource.id, importedAsset)
+        if (category === 'video') importedVideoAssets.push(importedAsset)
+      }
+
+      if (importedAssetsByResourceId.size === 0) {
+        throw new Error('No referenced media files could be imported. Check that the FCPXML media paths still exist on this machine.')
+      }
+
+      const newTimeline = createTimeline({
+        name: importPlan.name,
+        width: importPlan.settings.width,
+        height: importPlan.settings.height,
+        fps: importPlan.settings.fps,
+        folderId: currentFolderId,
+      })
+      if (!newTimeline?.id) {
+        throw new Error('Could not create a timeline for the FCPXML import.')
+      }
+
+      await switchTimeline(newTimeline.id)
+
+      const timelineApi = useTimelineStore.getState()
+      const latestAssets = useAssetsStore.getState().assets || []
+      timelineApi.loadFromProject({
+        ...newTimeline,
+        width: importPlan.settings.width,
+        height: importPlan.settings.height,
+        fps: importPlan.settings.fps,
+        duration: importPlan.duration,
+        tracks: importPlan.tracks,
+        clips: [],
+        transitions: [],
+        markers: [],
+        clipCounter: 1,
+        transitionCounter: 1,
+        markerCounter: 1,
+      }, latestAssets, importPlan.settings.fps)
+
+      let addedClipCount = 0
+      let skippedClipCount = 0
+      for (const clip of importPlan.clips) {
+        const importedAsset = importedAssetsByResourceId.get(clip.resourceId)
+        if (!importedAsset || !clip.trackId) {
+          skippedClipCount += 1
+          continue
+        }
+        const timelineAsset = clip.mediaType === 'audio' && importedAsset.type === 'video'
+          ? { ...importedAsset, type: 'audio' }
+          : importedAsset
+        const addedClip = useTimelineStore.getState().addClip(
+          clip.trackId,
+          timelineAsset,
+          clip.startTime,
+          importPlan.settings.fps,
+          {
+            duration: clip.duration,
+            trimStart: clip.trimStart,
+            trimEnd: clip.trimStart + clip.duration,
+            resolveOverlaps: false,
+            saveHistory: false,
+            selectAfterAdd: false,
+            ...(clip.transform && clip.mediaType !== 'audio' ? { transform: clip.transform } : {}),
+            ...(clip.linkGroupId ? { linkGroupId: clip.linkGroupId } : {}),
+            metadata: {
+              importedFromFcpXml: {
+                originalClipId: clip.id,
+                resourceId: clip.resourceId,
+                lane: clip.lane,
+                mediaType: clip.mediaType,
+                hasEmbeddedAudio: !!clip.hasEmbeddedAudio,
+                hasStaticTransform: !!clip.transform && clip.mediaType !== 'audio',
+              },
+            },
+          }
+        )
+        if (addedClip) {
+          addedClipCount += 1
+        } else {
+          skippedClipCount += 1
+        }
+      }
+
+      if (addedClipCount === 0) {
+        throw new Error('No FCPXML clips could be placed on the imported timeline.')
+      }
+
+      await saveProject?.()
+      setSelectedAssetIds([])
+      setSelectedSequenceId(newTimeline.id)
+      setPreviewMode('timeline')
+
+      for (const videoAsset of importedVideoAssets) {
+        if (isElectron() && currentProjectHandle && videoAsset?.absolutePath) {
+          enqueuePlaybackTranscode(currentProjectHandle, videoAsset.id, videoAsset.absolutePath).catch(() => {})
+          if (isProxyPlaybackEnabled()) {
+            enqueueProxyTranscode(currentProjectHandle, videoAsset.id, videoAsset.absolutePath).catch(() => {})
+          }
+        }
+        if (videoAsset?.duration > 0.5) {
+          const projectPath = typeof currentProjectHandle === 'string' ? currentProjectHandle : null
+          generateAssetSprite(videoAsset.id, projectPath).catch(err => {
+            console.warn('Auto-sprite generation failed:', err)
+          })
+          generateAssetPoster(videoAsset.id, projectPath).catch(err => {
+            console.warn('Auto-poster generation failed:', err)
+          })
+        }
+      }
+
+      if (warnings.length || skippedClipCount) {
+        console.warn('[FCPXML Import]', { warnings, skippedClipCount })
+      }
+    } catch (err) {
+      console.error('FCPXML import failed:', err)
+      window.alert?.(err?.message || 'FCPXML import failed')
+    } finally {
+      setIsImporting(false)
+    }
   }
   
   // Handle drag and drop
@@ -2479,11 +2694,23 @@ function AssetsPanel({ isActive = true }) {
               </button>
               <button
                 onClick={handleEmptyMenuImport}
-                disabled={!currentProjectHandle}
+                disabled={!currentProjectHandle || isImporting}
                 className="w-full px-3 py-1.5 text-left text-xs text-sf-text-primary hover:bg-sf-dark-700 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Upload className="w-3 h-3 text-sf-accent" />
                 Import
+              </button>
+              <button
+                onClick={handleImportFcpXml}
+                disabled={!currentProjectHandle || isImporting}
+                className="w-full px-3 py-1.5 text-left text-xs text-sf-text-primary hover:bg-sf-dark-700 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isImporting ? (
+                  <Loader2 className="w-3 h-3 text-sf-accent animate-spin" />
+                ) : (
+                  <FileVideo className="w-3 h-3 text-sf-accent" />
+                )}
+                Import FCPXML...
               </button>
               <div className="border-t border-sf-dark-600 my-1" />
               <div className="px-2 py-1 text-[10px] text-sf-text-muted uppercase tracking-wider">Create overlay</div>

--- a/src/services/fcpxmlExporter.js
+++ b/src/services/fcpxmlExporter.js
@@ -72,6 +72,18 @@ function filePathToFileUri(filePath) {
   return `file://${encodeURI(withLeadingSlash).replace(/#/g, '%23')}`
 }
 
+function formatNumber(value, precision = 4) {
+  const parsed = safeNumber(value, 0)
+  const rounded = Math.round(parsed * (10 ** precision)) / (10 ** precision)
+  return String(Object.is(rounded, -0) ? 0 : rounded)
+}
+
+function pixelsToFcpXmlPosition(value, sequenceHeight) {
+  const height = safeNumber(sequenceHeight, 0)
+  if (height <= 0) return safeNumber(value, 0)
+  return (safeNumber(value, 0) * 100) / height
+}
+
 function getClipTimeScale(clip) {
   const sourceTimeScale = safeNumber(clip?.sourceTimeScale, 0)
   const fpsScale = clip?.timelineFps && clip?.sourceFps
@@ -167,7 +179,29 @@ function buildResourceEntries(exportClips, timebase, formatId) {
   return entries
 }
 
-function buildClipElement(item, timebase) {
+function buildAdjustTransformElement(clip, timelineHeight) {
+  const transform = clip?.transform || {}
+  const positionX = safeNumber(transform.positionX, 0)
+  const positionY = safeNumber(transform.positionY, 0)
+  const scaleX = safeNumber(transform.scaleX, 100)
+  const scaleY = safeNumber(transform.scaleY, scaleX)
+  const rotation = safeNumber(transform.rotation, 0)
+  const hasPosition = Math.abs(positionX) > 0.0001 || Math.abs(positionY) > 0.0001
+  const hasScale = Math.abs(scaleX - 100) > 0.0001 || Math.abs(scaleY - 100) > 0.0001
+  const hasRotation = Math.abs(rotation) > 0.0001
+
+  if (!hasPosition && !hasScale && !hasRotation) return ''
+
+  const attrs = [
+    'anchor="0 0"',
+    `scale="${formatNumber(scaleX / 100)} ${formatNumber(scaleY / 100)}"`,
+    `position="${formatNumber(pixelsToFcpXmlPosition(positionX, timelineHeight))} ${formatNumber(pixelsToFcpXmlPosition(positionY, timelineHeight))}"`,
+  ]
+  if (hasRotation) attrs.push(`rotation="${formatNumber(rotation)}"`)
+  return `        <adjust-transform ${attrs.join(' ')}/>`
+}
+
+function buildClipElement(item, timebase, timelineHeight) {
   const { clip, asset, track, resourceId, lane } = item
   const durationFrames = Math.max(secondsToFrames(clip.duration, timebase), 1)
   const startFrames = secondsToFrames(clip.startTime, timebase)
@@ -180,11 +214,18 @@ function buildClipElement(item, timebase) {
   const enabledAttr = clip.enabled === false ? ' enabled="0"' : ''
   const laneAttr = lane ? ` lane="${lane}"` : ''
   const note = `comfystudio:clipId=${clip.id};assetId=${asset.id};trackId=${track?.id || 'unknown'}`
-  return [
+  const adjustTransform = item.mediaRole === 'video' || item.mediaRole === 'image'
+    ? buildAdjustTransformElement(clip, timelineHeight)
+    : ''
+  const lines = [
     `      <asset-clip name="${escapeXml(name)}" ref="${resourceId}" offset="${formatFrames(startFrames, timebase)}" start="${formatFrames(sourceStartFrames, timebase)}" duration="${formatFrames(durationFrames, timebase)}"${laneAttr}${audioAttrs}${enabledAttr}>`,
     `        <note>${escapeXml(note)}</note>`,
+  ]
+  if (adjustTransform) lines.push(adjustTransform)
+  lines.push(
     '      </asset-clip>',
-  ].join('\n')
+  )
+  return lines.join('\n')
 }
 
 export function buildFcpXml({
@@ -230,7 +271,7 @@ export function buildFcpXml({
     `    <format id="${formatId}" name="ComfyStudio ${width}x${height} ${timebase.fps}fps" frameDuration="${timebase.frameDuration}" width="${width}" height="${height}" colorSpace="1-1-1 (Rec. 709)"/>`,
     ...buildResourceEntries(exportClips, timebase, formatId),
   ]
-  const clipElements = exportClips.map((item) => buildClipElement(item, timebase))
+  const clipElements = exportClips.map((item) => buildClipElement(item, timebase, height))
   const safeProjectId = sanitizeId(projectName, 'comfystudio_project')
 
   return [

--- a/src/services/fcpxmlImporter.js
+++ b/src/services/fcpxmlImporter.js
@@ -34,6 +34,12 @@ function parseNumberList(value) {
     .filter((entry) => Number.isFinite(entry))
 }
 
+function fcpxmlPositionToPixels(value, sequenceHeight) {
+  const height = Number(sequenceHeight)
+  if (!Number.isFinite(value) || !Number.isFinite(height) || height <= 0) return value
+  return Math.round(value * height) / 100
+}
+
 function getAssetSource(assetElement) {
   const directSrc = assetElement.getAttribute('src')
   if (directSrc) return directSrc
@@ -43,15 +49,15 @@ function getAssetSource(assetElement) {
   return originalMedia?.getAttribute('src') || mediaReps[0]?.getAttribute('src') || ''
 }
 
-function parseStaticTransform(element) {
+function parseStaticTransform(element, sequenceInfo) {
   const transformElement = Array.from(element.getElementsByTagName('adjust-transform') || [])[0]
   if (!transformElement) return null
 
   const transform = {}
   const position = parseNumberList(transformElement.getAttribute('position'))
   if (position.length >= 2) {
-    transform.positionX = position[0]
-    transform.positionY = position[1]
+    transform.positionX = fcpxmlPositionToPixels(position[0], sequenceInfo?.height)
+    transform.positionY = fcpxmlPositionToPixels(position[1], sequenceInfo?.height)
   }
 
   const scale = parseNumberList(transformElement.getAttribute('scale'))
@@ -214,7 +220,7 @@ function getSequenceInfo(doc, formatMap) {
   }
 }
 
-function collectMediaClips(root, assetMap, warnings) {
+function collectMediaClips(root, assetMap, sequenceInfo, warnings) {
   const clips = []
 
   const addMediaClip = (clip) => {
@@ -247,7 +253,7 @@ function collectMediaClips(root, assetMap, warnings) {
           const mediaType = inferClipMediaType(child, resource, lane)
           const duration = parseFcpXmlTime(child.getAttribute('duration'), resource.duration || 1)
           const sourceStart = Math.max(0, parseFcpXmlTime(child.getAttribute('start'), resource.start || 0) - (resource.start || 0))
-          const transform = parseStaticTransform(child)
+          const transform = parseStaticTransform(child, sequenceInfo)
           const clipNumber = clips.length + 1
           const linkGroupId = mediaType === 'video' && resource.hasAudio
             ? `fcpxml-link-${clipNumber}`
@@ -336,7 +342,7 @@ export function parseFcpXml(xmlText, options = {}) {
   }
 
   const spine = sequenceInfo.sequence.getElementsByTagName('spine')?.[0] || sequenceInfo.sequence
-  const rawClips = collectMediaClips(spine, assetMap, warnings)
+  const rawClips = collectMediaClips(spine, assetMap, sequenceInfo, warnings)
   const shouldApplyTcStart = sequenceInfo.tcStart > 0
     && rawClips.length > 0
     && rawClips.every((clip) => clip.startTime >= sequenceInfo.tcStart)

--- a/src/services/fcpxmlImporter.js
+++ b/src/services/fcpxmlImporter.js
@@ -181,6 +181,20 @@ function getSequenceInfo(doc, formatMap) {
 function collectMediaClips(root, assetMap, warnings) {
   const clips = []
 
+  const addMediaClip = (clip) => {
+    clips.push(clip)
+
+    if (clip.mediaType === 'video' && clip.hasEmbeddedAudio) {
+      clips.push({
+        ...clip,
+        id: `${clip.id}-audio`,
+        name: `${clip.name} Audio`,
+        mediaType: 'audio',
+        lane: -1,
+      })
+    }
+  }
+
   const walk = (node, parentOffset = 0) => {
     for (const child of getDirectChildren(node)) {
       const tagName = getLocalName(child)
@@ -197,8 +211,12 @@ function collectMediaClips(root, assetMap, warnings) {
           const mediaType = inferClipMediaType(child, resource, lane)
           const duration = parseFcpXmlTime(child.getAttribute('duration'), resource.duration || 1)
           const sourceStart = Math.max(0, parseFcpXmlTime(child.getAttribute('start'), resource.start || 0) - (resource.start || 0))
-          clips.push({
-            id: `fcpxml-clip-${clips.length + 1}`,
+          const clipNumber = clips.length + 1
+          const linkGroupId = mediaType === 'video' && resource.hasAudio
+            ? `fcpxml-link-${clipNumber}`
+            : null
+          addMediaClip({
+            id: `fcpxml-clip-${clipNumber}`,
             name: sanitizeName(child.getAttribute('name'), resource.name),
             resourceId: ref,
             mediaType,
@@ -207,6 +225,8 @@ function collectMediaClips(root, assetMap, warnings) {
             duration: Math.max(1 / DEFAULT_FPS, duration),
             trimStart: sourceStart,
             sourceDuration: resource.duration || 0,
+            hasEmbeddedAudio: mediaType === 'video' && resource.hasAudio,
+            ...(linkGroupId ? { linkGroupId } : {}),
           })
           continue
         }

--- a/src/services/fcpxmlImporter.js
+++ b/src/services/fcpxmlImporter.js
@@ -1,0 +1,298 @@
+const DEFAULT_FPS = 24
+
+const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'tif', 'tiff'])
+const AUDIO_EXTENSIONS = new Set(['wav', 'mp3', 'm4a', 'aac', 'aif', 'aiff', 'ogg', 'flac'])
+const VIDEO_EXTENSIONS = new Set(['mp4', 'mov', 'm4v', 'webm', 'mkv', 'avi', 'mpeg', 'mpg'])
+
+function safeNumber(value, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function sanitizeName(value, fallback = 'Imported FCPXML') {
+  const trimmed = String(value || '').trim()
+  return trimmed || fallback
+}
+
+function getLocalName(node) {
+  return String(node?.localName || node?.nodeName || '').toLowerCase()
+}
+
+function getDirectChildren(node) {
+  return Array.from(node?.children || [])
+}
+
+function getFirstElementByTagName(doc, tagName) {
+  return doc.getElementsByTagName(tagName)?.[0] || null
+}
+
+function parseXml(xmlText) {
+  if (typeof DOMParser === 'undefined') {
+    throw new Error('FCPXML import needs the desktop app browser parser.')
+  }
+  const doc = new DOMParser().parseFromString(String(xmlText || ''), 'application/xml')
+  const parserError = doc.getElementsByTagName('parsererror')?.[0]
+  if (parserError) {
+    throw new Error('Could not parse FCPXML. The file may be invalid or incomplete.')
+  }
+  return doc
+}
+
+export function parseFcpXmlTime(value, fallback = 0) {
+  const raw = String(value || '').trim()
+  if (!raw) return fallback
+  const withoutSeconds = raw.endsWith('s') ? raw.slice(0, -1) : raw
+  const fractionMatch = withoutSeconds.match(/^(-?\d+(?:\.\d+)?)\/(\d+(?:\.\d+)?)$/)
+  if (fractionMatch) {
+    const numerator = Number(fractionMatch[1])
+    const denominator = Number(fractionMatch[2])
+    return denominator ? numerator / denominator : fallback
+  }
+  const plain = Number(withoutSeconds)
+  if (Number.isFinite(plain)) return plain
+  const timecodeMatch = withoutSeconds.match(/^(\d+):(\d{2}):(\d{2})(?:[;:.](\d{2}))?$/)
+  if (timecodeMatch) {
+    const hours = Number(timecodeMatch[1])
+    const minutes = Number(timecodeMatch[2])
+    const seconds = Number(timecodeMatch[3])
+    const frames = Number(timecodeMatch[4] || 0)
+    return (hours * 3600) + (minutes * 60) + seconds + (frames / DEFAULT_FPS)
+  }
+  return fallback
+}
+
+function fpsFromFrameDuration(frameDuration) {
+  const seconds = parseFcpXmlTime(frameDuration, 0)
+  if (!seconds || seconds <= 0) return DEFAULT_FPS
+  const fps = 1 / seconds
+  if (Math.abs(fps - 23.976) < 0.02) return 23.976
+  if (Math.abs(fps - 29.97) < 0.02) return 29.97
+  if (Math.abs(fps - 59.94) < 0.02) return 59.94
+  return Math.max(1, Math.round(fps * 1000) / 1000)
+}
+
+function getExtensionFromPath(value) {
+  const clean = String(value || '').split(/[?#]/)[0]
+  const match = clean.match(/\.([a-zA-Z0-9]+)$/)
+  return match ? match[1].toLowerCase() : ''
+}
+
+function fileUriToPath(src) {
+  const raw = String(src || '').trim()
+  if (!raw) return ''
+  if (!/^file:/i.test(raw)) return raw
+
+  let path = raw.replace(/^file:\/\//i, '')
+  path = path.replace(/^localhost\//i, '')
+  try {
+    path = decodeURIComponent(path)
+  } catch (_) {
+    // Keep the original best-effort path if decoding fails.
+  }
+  if (/^\/[a-zA-Z]:\//.test(path)) path = path.slice(1)
+  if (/^[a-zA-Z]:\//.test(path)) return path.replace(/\//g, '\\')
+  return path
+}
+
+function inferAssetKind(resource) {
+  const extension = getExtensionFromPath(resource.sourcePath || resource.src || resource.name)
+  if (IMAGE_EXTENSIONS.has(extension)) return 'image'
+  if (AUDIO_EXTENSIONS.has(extension)) return 'audio'
+  if (VIDEO_EXTENSIONS.has(extension)) return 'video'
+  if (resource.hasVideo && !resource.hasAudio) return 'video'
+  if (!resource.hasVideo && resource.hasAudio) return 'audio'
+  return resource.hasVideo ? 'video' : 'audio'
+}
+
+function inferClipMediaType(element, resource, lane) {
+  const tagName = getLocalName(element)
+  if (tagName === 'audio' || lane < 0) return 'audio'
+  if (tagName === 'video') return 'video'
+  const assetKind = inferAssetKind(resource)
+  if (assetKind === 'image') return 'image'
+  if (assetKind === 'audio') return 'audio'
+  return 'video'
+}
+
+function getResourceMaps(doc) {
+  const formatMap = new Map()
+  const assetMap = new Map()
+
+  for (const format of Array.from(doc.getElementsByTagName('format') || [])) {
+    const id = format.getAttribute('id')
+    if (!id) continue
+    const width = safeNumber(format.getAttribute('width'), null)
+    const height = safeNumber(format.getAttribute('height'), null)
+    formatMap.set(id, {
+      id,
+      width,
+      height,
+      fps: fpsFromFrameDuration(format.getAttribute('frameDuration')),
+    })
+  }
+
+  for (const asset of Array.from(doc.getElementsByTagName('asset') || [])) {
+    const id = asset.getAttribute('id')
+    if (!id) continue
+    const sourcePath = fileUriToPath(asset.getAttribute('src'))
+    const resource = {
+      id,
+      name: sanitizeName(asset.getAttribute('name'), sourcePath ? sourcePath.split(/[\\/]/).pop() : 'Media'),
+      src: asset.getAttribute('src') || '',
+      sourcePath,
+      duration: parseFcpXmlTime(asset.getAttribute('duration'), 0),
+      start: parseFcpXmlTime(asset.getAttribute('start'), 0),
+      formatId: asset.getAttribute('format') || '',
+      hasVideo: asset.getAttribute('hasVideo') !== '0',
+      hasAudio: asset.getAttribute('hasAudio') === '1',
+    }
+    resource.kind = inferAssetKind(resource)
+    assetMap.set(id, resource)
+  }
+
+  return { formatMap, assetMap }
+}
+
+function getSequenceInfo(doc, formatMap) {
+  const project = getFirstElementByTagName(doc, 'project')
+  const sequence = project?.getElementsByTagName('sequence')?.[0] || getFirstElementByTagName(doc, 'sequence')
+  const format = sequence ? formatMap.get(sequence.getAttribute('format')) : null
+  return {
+    projectName: sanitizeName(project?.getAttribute('name'), 'Imported FCPXML'),
+    sequence,
+    duration: parseFcpXmlTime(sequence?.getAttribute('duration'), 60),
+    tcStart: parseFcpXmlTime(sequence?.getAttribute('tcStart'), 0),
+    width: format?.width || 1920,
+    height: format?.height || 1080,
+    fps: format?.fps || DEFAULT_FPS,
+  }
+}
+
+function collectMediaClips(root, assetMap, warnings) {
+  const clips = []
+
+  const walk = (node, parentOffset = 0) => {
+    for (const child of getDirectChildren(node)) {
+      const tagName = getLocalName(child)
+      const isMediaTag = ['asset-clip', 'video', 'audio', 'clip'].includes(tagName)
+      const ref = child.getAttribute('ref')
+      const resource = ref ? assetMap.get(ref) : null
+      const offset = parentOffset + parseFcpXmlTime(child.getAttribute('offset'), 0)
+
+      if (isMediaTag && ref) {
+        if (!resource) {
+          warnings.push(`Skipped a clip because FCPXML resource "${ref}" was not found.`)
+        } else {
+          const lane = safeNumber(child.getAttribute('lane'), 0)
+          const mediaType = inferClipMediaType(child, resource, lane)
+          const duration = parseFcpXmlTime(child.getAttribute('duration'), resource.duration || 1)
+          const sourceStart = Math.max(0, parseFcpXmlTime(child.getAttribute('start'), resource.start || 0) - (resource.start || 0))
+          clips.push({
+            id: `fcpxml-clip-${clips.length + 1}`,
+            name: sanitizeName(child.getAttribute('name'), resource.name),
+            resourceId: ref,
+            mediaType,
+            lane,
+            startTime: Math.max(0, offset),
+            duration: Math.max(1 / DEFAULT_FPS, duration),
+            trimStart: sourceStart,
+            sourceDuration: resource.duration || 0,
+          })
+          continue
+        }
+      }
+
+      if (['spine', 'gap', 'clip', 'mc-clip', 'sync-clip', 'sequence'].includes(tagName)) {
+        walk(child, offset)
+      }
+    }
+  }
+
+  walk(root, 0)
+  return clips
+}
+
+function buildTracksAndAssignClips(clips) {
+  const videoLanes = Array.from(new Set(
+    clips
+      .filter((clip) => clip.mediaType === 'video' || clip.mediaType === 'image')
+      .map((clip) => clip.lane > 0 ? clip.lane : 1)
+  )).sort((a, b) => b - a)
+  const audioLanes = Array.from(new Set(
+    clips
+      .filter((clip) => clip.mediaType === 'audio')
+      .map((clip) => clip.lane < 0 ? clip.lane : -1)
+  )).sort((a, b) => b - a)
+
+  const tracks = []
+  const videoTrackByLane = new Map()
+  const audioTrackByLane = new Map()
+
+  videoLanes.forEach((lane, index) => {
+    const id = `fcpxml-video-${index + 1}`
+    videoTrackByLane.set(lane, id)
+    tracks.push({ id, name: `Video ${index + 1}`, type: 'video', muted: false, locked: false, visible: true })
+  })
+  audioLanes.forEach((lane, index) => {
+    const id = `fcpxml-audio-${index + 1}`
+    audioTrackByLane.set(lane, id)
+    tracks.push({ id, name: `Audio ${index + 1}`, type: 'audio', channels: 'stereo', muted: false, locked: false, visible: true })
+  })
+
+  const assignedClips = clips.map((clip) => {
+    const lane = clip.mediaType === 'audio'
+      ? (clip.lane < 0 ? clip.lane : -1)
+      : (clip.lane > 0 ? clip.lane : 1)
+    const trackId = clip.mediaType === 'audio'
+      ? audioTrackByLane.get(lane)
+      : videoTrackByLane.get(lane)
+    return { ...clip, lane, trackId }
+  })
+
+  return {
+    tracks: tracks.length > 0 ? tracks : [
+      { id: 'fcpxml-video-1', name: 'Video 1', type: 'video', muted: false, locked: false, visible: true },
+      { id: 'fcpxml-audio-1', name: 'Audio 1', type: 'audio', channels: 'stereo', muted: false, locked: false, visible: true },
+    ],
+    clips: assignedClips,
+  }
+}
+
+export function parseFcpXml(xmlText, options = {}) {
+  const warnings = []
+  const doc = parseXml(xmlText)
+  const { formatMap, assetMap } = getResourceMaps(doc)
+  const sequenceInfo = getSequenceInfo(doc, formatMap)
+  if (!sequenceInfo.sequence) {
+    throw new Error('No FCPXML sequence found.')
+  }
+
+  const spine = sequenceInfo.sequence.getElementsByTagName('spine')?.[0] || sequenceInfo.sequence
+  const rawClips = collectMediaClips(spine, assetMap, warnings)
+  const shouldApplyTcStart = sequenceInfo.tcStart > 0
+    && rawClips.length > 0
+    && rawClips.every((clip) => clip.startTime >= sequenceInfo.tcStart)
+  const normalizedRawClips = shouldApplyTcStart
+    ? rawClips.map((clip) => ({ ...clip, startTime: Math.max(0, clip.startTime - sequenceInfo.tcStart) }))
+    : rawClips
+  const { tracks, clips } = buildTracksAndAssignClips(normalizedRawClips)
+  const usedResourceIds = new Set(clips.map((clip) => clip.resourceId))
+  const assets = Array.from(assetMap.values()).filter((asset) => usedResourceIds.has(asset.id))
+  const computedDuration = clips.reduce((max, clip) => Math.max(max, clip.startTime + clip.duration), sequenceInfo.duration || 0)
+
+  return {
+    name: sanitizeName(options.name, sequenceInfo.projectName),
+    settings: {
+      width: sequenceInfo.width,
+      height: sequenceInfo.height,
+      fps: sequenceInfo.fps,
+    },
+    duration: Math.max(1, computedDuration || sequenceInfo.duration || 60),
+    assets,
+    tracks,
+    clips,
+    warnings,
+  }
+}
+
+export default parseFcpXml

--- a/src/services/fcpxmlImporter.js
+++ b/src/services/fcpxmlImporter.js
@@ -26,6 +26,15 @@ function getFirstElementByTagName(doc, tagName) {
   return doc.getElementsByTagName(tagName)?.[0] || null
 }
 
+function getAssetSource(assetElement) {
+  const directSrc = assetElement.getAttribute('src')
+  if (directSrc) return directSrc
+
+  const mediaReps = Array.from(assetElement.getElementsByTagName('media-rep') || [])
+  const originalMedia = mediaReps.find((entry) => entry.getAttribute('kind') === 'original-media')
+  return originalMedia?.getAttribute('src') || mediaReps[0]?.getAttribute('src') || ''
+}
+
 function parseXml(xmlText) {
   if (typeof DOMParser === 'undefined') {
     throw new Error('FCPXML import needs the desktop app browser parser.')
@@ -134,11 +143,12 @@ function getResourceMaps(doc) {
   for (const asset of Array.from(doc.getElementsByTagName('asset') || [])) {
     const id = asset.getAttribute('id')
     if (!id) continue
-    const sourcePath = fileUriToPath(asset.getAttribute('src'))
+    const src = getAssetSource(asset)
+    const sourcePath = fileUriToPath(src)
     const resource = {
       id,
       name: sanitizeName(asset.getAttribute('name'), sourcePath ? sourcePath.split(/[\\/]/).pop() : 'Media'),
-      src: asset.getAttribute('src') || '',
+      src,
       sourcePath,
       duration: parseFcpXmlTime(asset.getAttribute('duration'), 0),
       start: parseFcpXmlTime(asset.getAttribute('start'), 0),

--- a/src/services/fcpxmlImporter.js
+++ b/src/services/fcpxmlImporter.js
@@ -26,6 +26,14 @@ function getFirstElementByTagName(doc, tagName) {
   return doc.getElementsByTagName(tagName)?.[0] || null
 }
 
+function parseNumberList(value) {
+  return String(value || '')
+    .trim()
+    .split(/\s+/)
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isFinite(entry))
+}
+
 function getAssetSource(assetElement) {
   const directSrc = assetElement.getAttribute('src')
   if (directSrc) return directSrc
@@ -33,6 +41,34 @@ function getAssetSource(assetElement) {
   const mediaReps = Array.from(assetElement.getElementsByTagName('media-rep') || [])
   const originalMedia = mediaReps.find((entry) => entry.getAttribute('kind') === 'original-media')
   return originalMedia?.getAttribute('src') || mediaReps[0]?.getAttribute('src') || ''
+}
+
+function parseStaticTransform(element) {
+  const transformElement = Array.from(element.getElementsByTagName('adjust-transform') || [])[0]
+  if (!transformElement) return null
+
+  const transform = {}
+  const position = parseNumberList(transformElement.getAttribute('position'))
+  if (position.length >= 2) {
+    transform.positionX = position[0]
+    transform.positionY = position[1]
+  }
+
+  const scale = parseNumberList(transformElement.getAttribute('scale'))
+  if (scale.length >= 1) {
+    const scaleX = scale[0]
+    const scaleY = scale.length >= 2 ? scale[1] : scaleX
+    transform.scaleX = Math.round(scaleX * 1000) / 10
+    transform.scaleY = Math.round(scaleY * 1000) / 10
+    transform.scaleLinked = Math.abs(scaleX - scaleY) < 0.0001
+  }
+
+  const rotation = Number(transformElement.getAttribute('rotation'))
+  if (Number.isFinite(rotation)) {
+    transform.rotation = rotation
+  }
+
+  return Object.keys(transform).length > 0 ? transform : null
 }
 
 function parseXml(xmlText) {
@@ -211,6 +247,7 @@ function collectMediaClips(root, assetMap, warnings) {
           const mediaType = inferClipMediaType(child, resource, lane)
           const duration = parseFcpXmlTime(child.getAttribute('duration'), resource.duration || 1)
           const sourceStart = Math.max(0, parseFcpXmlTime(child.getAttribute('start'), resource.start || 0) - (resource.start || 0))
+          const transform = parseStaticTransform(child)
           const clipNumber = clips.length + 1
           const linkGroupId = mediaType === 'video' && resource.hasAudio
             ? `fcpxml-link-${clipNumber}`
@@ -226,6 +263,7 @@ function collectMediaClips(root, assetMap, warnings) {
             trimStart: sourceStart,
             sourceDuration: resource.duration || 0,
             hasEmbeddedAudio: mediaType === 'video' && resource.hasAudio,
+            ...(transform && (mediaType === 'video' || mediaType === 'image') ? { transform } : {}),
             ...(linkGroupId ? { linkGroupId } : {}),
           })
           continue

--- a/src/stores/timelineStore.js
+++ b/src/stores/timelineStore.js
@@ -995,6 +995,10 @@ export const useTimelineStore = create(
       asset?.settings?.defaultTransform
       && typeof asset.settings.defaultTransform === 'object'
     ) ? asset.settings.defaultTransform : null
+    const optionTransform = (
+      options?.transform
+      && typeof options.transform === 'object'
+    ) ? options.transform : null
     const isGeneratedOverlay = isImage && Boolean(asset?.settings?.overlayKind)
     let defaultDuration = isImage ? 5 : sourceDuration // Keep video/audio duration in real seconds
     if (isGeneratedOverlay) {
@@ -1067,7 +1071,8 @@ export const useTimelineStore = create(
       transform: {
         ...createDefaultClipTransform(),
         ...(assetDefaultTransform || {}),
-        blendMode: assetDefaultTransform?.blendMode ?? 'normal',
+        ...(optionTransform || {}),
+        blendMode: optionTransform?.blendMode ?? assetDefaultTransform?.blendMode ?? 'normal',
       },
     }, fps), fps)
     


### PR DESCRIPTION
## Summary
- adds an Import FCPXML action next to Export FCPXML in the Export panel
- parses FCPXML assets, tracks, lanes, timing, trims, and timeline settings into a ComfyStudio import plan
- copies referenced media into the project, creates a new timeline, places clips, and saves the project

## Testing
- [x] I ran `npm run build`
- [ ] I smoke-tested with a Resolve-exported `.fcpxml`
- [ ] I updated docs when behavior, setup, onboarding, or release steps changed

## Notes
Draft until Jaime tests with a small Resolve-exported FCPXML.

MVP limitations: effects, transitions, titles, speed ramps, multicam, compound clips, and advanced FCPXML media resources are not imported yet. Audio-only components from video sources are skipped for now, and referenced media paths must still exist on the same machine doing the import.

## Contributor License Agreement
- [x] I have read and agree to the Contributor License Agreement terms in `CONTRIBUTING.md`.