### PR TITLE
Enable LAN browser access to ComfyUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ Velorn talks to a local ComfyUI server and can also help launch it.
 
 Only localhost/loopback ComfyUI endpoints are supported in the desktop app.
 
+When the Vite development UI is deliberately exposed to a LAN, browser mode
+connects to ComfyUI on the same hostname used to open Velorn and on the port
+configured in Settings. For example, a page opened at
+`http://192.168.1.20:5173` connects to `http://192.168.1.20:8188` by default.
+ComfyUI must be started with LAN listening and CORS enabled (for example,
+`--listen 0.0.0.0 --enable-cors-header *`), and the relevant Windows Firewall
+ports must be allowed. This development setup has no Velorn authentication;
+use it only on a trusted network.
+
 ### AI Agents (MCP)
 
 Velorn includes a local MCP server with 100+ tools for Codex, Claude Code, Cursor-compatible tools, and other MCP clients.
@@ -263,6 +272,19 @@ npm run electron:dev
 ```
 
 Browser-only `npm run dev` is useful for frontend work, but Electron is the normal development path because many features depend on desktop APIs.
+
+To expose the browser UI on a trusted LAN while also running the Electron app
+on the host machine:
+
+```bash
+npm run electron:dev:lan
+```
+
+Or run only the browser UI with `npm run dev:lan`. Open
+`http://<host-ip>:5173` from the other machine. Browser mode will connect to
+ComfyUI at `<host-ip>` using the port selected in Velorn Settings; start
+ComfyUI with `--listen 0.0.0.0 --enable-cors-header *` and allow ports 5173
+and 8188 (or your configured port) through the Windows Firewall.
 
 ## Build Commands
 

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "main": "electron/main.js",
   "scripts": {
     "dev": "vite",
+    "dev:lan": "vite --host 0.0.0.0 --port 5173 --strictPort",
     "build": "vite build",
     "icons:generate": "icon-gen -i build/icon.png -o build --ico --ico-name icon --icns --icns-name icon",
     "preview": "vite preview",
     "electron": "electron .",
     "electron:dev": "concurrently -k \"vite --host 127.0.0.1 --port 5173 --strictPort\" \"wait-on http://127.0.0.1:5173 && electron .\"",
+    "electron:dev:lan": "concurrently -k \"vite --host 0.0.0.0 --port 5173 --strictPort\" \"wait-on http://127.0.0.1:5173 && electron .\"",
     "electron:build": "npm run build && electron-builder",
     "electron:build:win": "npm run build && electron-builder --win",
     "electron:build:mac": "npm run build && electron-builder --mac",
@@ -26,7 +28,8 @@
     "test:premiere-xml": "node --experimental-default-type=module --test ./src/services/premiereXmlExporter.test.js",
     "test:export-frame-source": "node --experimental-default-type=module --test ./src/services/exportFrameSource.test.js",
     "test:export-source-preparation": "node --test ./tests/exportSourcePreparation.test.js",
-    "test:mcp-h3": "node --test ./tests/mcpH3ReferenceVideo.test.js"
+    "test:mcp-h3": "node --test ./tests/mcpH3ReferenceVideo.test.js",
+    "test:local-comfy-connection": "node --test ./tests/localComfyConnection.test.mjs"
   },
   "keywords": [
     "animatic",

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -76,7 +76,7 @@ const SETTINGS_SECTIONS = [
     id: 'connection',
     title: 'ComfyUI Connection',
     icon: Server,
-    description: 'Configure the local ComfyUI endpoint, partner API key, and advanced tab visibility.',
+    description: 'Configure the ComfyUI endpoint, partner API key, and advanced tab visibility.',
   },
   {
     id: 'agents',
@@ -175,7 +175,7 @@ function GeneralTab({ initialSection = null }) {
   const [comfyPortInput, setComfyPortInput] = useState(String(initialComfyConnection.port || DEFAULT_COMFY_PORT))
   const [comfyConnectionState, setComfyConnectionState] = useState({
     status: 'idle',
-    message: `Local endpoint: ${initialComfyConnection.httpBase}`,
+    message: `Endpoint: ${initialComfyConnection.httpBase}`,
   })
   const [outputPath, setOutputPath] = useState('')
   const [workflowPath, setWorkflowPath] = useState('')
@@ -266,7 +266,7 @@ function GeneralTab({ initialSection = null }) {
         setComfyPortInput(String(connection.port || DEFAULT_COMFY_PORT))
         setComfyConnectionState({
           status: 'idle',
-          message: `Local endpoint: ${connection.httpBase}`,
+          message: `Endpoint: ${connection.httpBase}`,
         })
       } catch {
         setComfyConnectionState({
@@ -427,7 +427,7 @@ function GeneralTab({ initialSection = null }) {
     setComfyPortInput(String(result.config.port))
     setComfyConnectionState({
       status: 'idle',
-      message: `Saved local endpoint: ${result.config.httpBase}`,
+      message: `Saved endpoint: ${result.config.httpBase}`,
     })
     return true
   }
@@ -442,9 +442,10 @@ function GeneralTab({ initialSection = null }) {
       return
     }
 
+    const targetHost = getLocalComfyConnectionSync().host
     setComfyConnectionState({
       status: 'testing',
-      message: `Testing localhost:${parsed.port}...`,
+      message: `Testing ${targetHost}:${parsed.port}...`,
     })
 
     const testResult = await checkLocalComfyConnection({ port: parsed.port })
@@ -458,7 +459,7 @@ function GeneralTab({ initialSection = null }) {
 
     setComfyConnectionState({
       status: 'error',
-      message: testResult.error || `Could not connect to localhost:${parsed.port}.`,
+      message: testResult.error || `Could not connect to ${targetHost}:${parsed.port}.`,
     })
   }
 
@@ -474,7 +475,7 @@ function GeneralTab({ initialSection = null }) {
     }
     setComfyConnectionState({
       status: 'idle',
-      message: `Reset to local endpoint: ${result.config.httpBase}`,
+      message: `Reset endpoint: ${result.config.httpBase}`,
     })
   }
 
@@ -803,7 +804,7 @@ function GeneralTab({ initialSection = null }) {
       activeSectionContent = (
         <div className="space-y-4">
           <div>
-            <label className="block text-xs text-sf-text-muted mb-1">Local ComfyUI Port</label>
+            <label className="block text-xs text-sf-text-muted mb-1">ComfyUI Port</label>
             <input
               type="number"
               min={1}
@@ -816,7 +817,7 @@ function GeneralTab({ initialSection = null }) {
               className="w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-3 py-2 text-sm text-sf-text-primary focus:outline-none focus:border-sf-accent"
             />
             <p className="text-[10px] text-sf-text-muted mt-1">
-              Local-only mode. Remote/LAN ComfyUI is disabled in this build.
+              The desktop app uses loopback. Browser mode uses the Velorn page&apos;s host, allowing a LAN-hosted page to connect back to ComfyUI on that machine.
             </p>
           </div>
 

--- a/src/components/panels/SettingsPanel.jsx
+++ b/src/components/panels/SettingsPanel.jsx
@@ -21,7 +21,7 @@ function SettingsPanel() {
   const [comfyPortInput, setComfyPortInput] = useState(String(initialComfyConnection.port || DEFAULT_COMFY_PORT))
   const [comfyConnectionState, setComfyConnectionState] = useState({
     status: 'idle',
-    message: `Local endpoint: ${initialComfyConnection.httpBase}`,
+    message: `Endpoint: ${initialComfyConnection.httpBase}`,
   })
   const [outputPath, setOutputPath] = useState('')
   const [workflowPath, setWorkflowPath] = useState('')
@@ -58,7 +58,7 @@ function SettingsPanel() {
       setComfyPortInput(String(connection.port || DEFAULT_COMFY_PORT))
       setComfyConnectionState({
         status: 'idle',
-        message: `Local endpoint: ${connection.httpBase}`,
+        message: `Endpoint: ${connection.httpBase}`,
       })
     }).catch(() => {
       setComfyConnectionState({
@@ -90,7 +90,7 @@ function SettingsPanel() {
     setComfyPortInput(String(result.config.port))
     setComfyConnectionState({
       status: 'idle',
-      message: `Saved local endpoint: ${result.config.httpBase}`,
+      message: `Saved endpoint: ${result.config.httpBase}`,
     })
     return true
   }
@@ -104,9 +104,10 @@ function SettingsPanel() {
       })
       return
     }
+    const targetHost = getLocalComfyConnectionSync().host
     setComfyConnectionState({
       status: 'testing',
-      message: `Testing localhost:${parsed.port}...`,
+      message: `Testing ${targetHost}:${parsed.port}...`,
     })
     const testResult = await checkLocalComfyConnection({ port: parsed.port })
     if (testResult.ok) {
@@ -118,7 +119,7 @@ function SettingsPanel() {
     }
     setComfyConnectionState({
       status: 'error',
-      message: testResult.error || `Could not connect to localhost:${parsed.port}.`,
+      message: testResult.error || `Could not connect to ${targetHost}:${parsed.port}.`,
     })
   }
 
@@ -134,7 +135,7 @@ function SettingsPanel() {
     }
     setComfyConnectionState({
       status: 'idle',
-      message: `Reset to local endpoint: ${result.config.httpBase}`,
+      message: `Reset endpoint: ${result.config.httpBase}`,
     })
   }
 
@@ -295,7 +296,7 @@ function SettingsPanel() {
         <Section id="connection" icon={Server} title="ComfyUI Connection">
           <div className="space-y-2">
             <div>
-              <label className="block text-[10px] text-sf-text-muted mb-1">Local ComfyUI Port</label>
+              <label className="block text-[10px] text-sf-text-muted mb-1">ComfyUI Port</label>
               <input
                 type="number"
                 min={1}
@@ -308,7 +309,7 @@ function SettingsPanel() {
                 className="w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-2 py-1.5 text-[11px] text-sf-text-primary focus:outline-none focus:border-sf-accent"
               />
               <p className="text-[9px] text-sf-text-muted mt-1">
-                Local-only mode. Remote/LAN ComfyUI is disabled in this build.
+                The desktop app uses loopback. Browser mode uses the Velorn page&apos;s host, allowing a LAN-hosted page to connect back to ComfyUI on that machine.
               </p>
             </div>
             <div className="flex items-center justify-between gap-1.5">

--- a/src/services/localComfyConnection.js
+++ b/src/services/localComfyConnection.js
@@ -30,13 +30,34 @@ function isLoopbackHost(hostname) {
     .every((value) => Number.isInteger(value) && value >= 0 && value <= 255)
 }
 
+function getRuntimeComfyHost() {
+  if (typeof window === 'undefined' || window?.electronAPI?.isElectron === true) {
+    return LOCAL_COMFY_HOST
+  }
+
+  const pageHost = String(window?.location?.hostname || '')
+    .trim()
+    .replace(/^\[|\]$/g, '')
+
+  if (!pageHost || pageHost === '0.0.0.0' || isLoopbackHost(pageHost)) {
+    return LOCAL_COMFY_HOST
+  }
+  return pageHost
+}
+
+function formatHostForUrl(host) {
+  return host.includes(':') ? `[${host}]` : host
+}
+
 function buildConnection(port) {
   const safePort = normalizePort(port) || DEFAULT_COMFY_PORT
+  const host = getRuntimeComfyHost()
+  const urlHost = formatHostForUrl(host)
   return {
-    host: LOCAL_COMFY_HOST,
+    host,
     port: safePort,
-    httpBase: `http://${LOCAL_COMFY_HOST}:${safePort}`,
-    wsBase: `ws://${LOCAL_COMFY_HOST}:${safePort}`,
+    httpBase: `http://${urlHost}:${safePort}`,
+    wsBase: `ws://${urlHost}:${safePort}`,
   }
 }
 
@@ -320,4 +341,3 @@ export async function checkLocalComfyConnection(options = {}) {
     clearTimeout(timer)
   }
 }
-

--- a/tests/localComfyConnection.test.mjs
+++ b/tests/localComfyConnection.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+// The app deliberately remains a CommonJS Electron package while renderer
+// services use ESM syntax through Vite. Load this dependency-free service as
+// a data URL so the focused Node test does not need a package-wide module-mode
+// flag (removed in newer Node releases).
+const serviceSource = await readFile(
+  new URL('../src/services/localComfyConnection.js', import.meta.url),
+  'utf8',
+)
+const {
+  getLocalComfyConnectionSync,
+} = await import(`data:text/javascript;base64,${Buffer.from(serviceSource).toString('base64')}`)
+
+function withWindow(value, callback) {
+  const previous = globalThis.window
+  globalThis.window = value
+  try {
+    callback()
+  } finally {
+    if (previous === undefined) {
+      delete globalThis.window
+    } else {
+      globalThis.window = previous
+    }
+  }
+}
+
+test('uses loopback outside a browser', () => {
+  const connection = getLocalComfyConnectionSync()
+  assert.equal(connection.host, '127.0.0.1')
+  assert.equal(connection.httpBase, 'http://127.0.0.1:8188')
+  assert.equal(connection.wsBase, 'ws://127.0.0.1:8188')
+})
+
+test('uses the page hostname in LAN browser mode', () => {
+  withWindow({ location: { hostname: '192.168.1.20' } }, () => {
+    const connection = getLocalComfyConnectionSync()
+    assert.equal(connection.host, '192.168.1.20')
+    assert.equal(connection.httpBase, 'http://192.168.1.20:8188')
+    assert.equal(connection.wsBase, 'ws://192.168.1.20:8188')
+  })
+})
+
+test('keeps Electron on loopback even when its page has a LAN hostname', () => {
+  withWindow({
+    electronAPI: { isElectron: true },
+    location: { hostname: '192.168.1.20' },
+  }, () => {
+    const connection = getLocalComfyConnectionSync()
+    assert.equal(connection.host, '127.0.0.1')
+    assert.equal(connection.httpBase, 'http://127.0.0.1:8188')
+  })
+})
+
+test('formats IPv6 browser hostnames for URLs', () => {
+  withWindow({ location: { hostname: '[fd00::20]' } }, () => {
+    const connection = getLocalComfyConnectionSync()
+    assert.equal(connection.host, 'fd00::20')
+    assert.equal(connection.httpBase, 'http://[fd00::20]:8188')
+    assert.equal(connection.wsBase, 'ws://[fd00::20]:8188')
+  })
+})


### PR DESCRIPTION
## Summary

- make browser-mode Velorn connect to ComfyUI on the hostname serving the page
- preserve loopback-only ComfyUI access in the packaged Electron app
- add LAN development scripts, settings guidance, documentation, and focused connection tests

## Why

When Velorn's Vite UI is opened from another machine, `127.0.0.1` refers to the viewing machine rather than the Windows host running ComfyUI. Browser mode now derives the ComfyUI host from the Velorn page hostname, while continuing to use the configured port.

This supports explicitly trusted LAN setups where ComfyUI is started with LAN listening and CORS enabled. It does not expose or change the desktop app's local-only default.

## Validation

- `npm run test:local-comfy-connection`
- `npm run build`
- Vite LAN binding and HTTP response smoke test
