### PR TITLE
Add standalone NVIDIA RTX 4K export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ coverage/
 *.tmp
 *.temp
 .cache/
+tmp/
+__pycache__/
+*.py[cod]
 
 # Electron
 release/

--- a/docs/RELEASE_NOTES_0.3.24.md
+++ b/docs/RELEASE_NOTES_0.3.24.md
@@ -1,0 +1,31 @@
+# Velorn v0.3.24
+
+Velorn can now upscale finished exports to 4K directly with NVIDIA RTX Video Super Resolution. The new path runs independently of ComfyUI, streams one frame at a time to keep memory bounded, and preserves the timeline's audio and aspect ratio.
+
+## Highlights
+
+- **Direct NVIDIA RTX 4K upscale.** Enable NVIDIA RTX 4K upscale in Export to enhance the finished MP4 with NVIDIA's AI video super-resolution engine.
+- **No ComfyUI process required.** The upscale runs through a small optional Velorn-managed RTX runtime. Users who only use Velorn as an editor can still use the feature.
+- **Bounded memory usage.** Frames are decoded, enhanced on the GPU, and encoded one at a time instead of loading the full video into system memory.
+- **Landscape and vertical delivery.** The output uses a 3840-pixel long edge while preserving the source aspect ratio, including 2160x3840 vertical exports.
+- **H.264 and H.265 support.** The final RTX export follows the selected delivery codec, uses NVIDIA NVENC, and preserves or converts the source audio as needed.
+- **Four enhancement levels.** Low, Medium, High, and Ultra allow users to trade processing speed for AI reconstruction quality. High remains the recommended default.
+- **Safer long-running exports.** Velorn reports RTX progress and ETA, supports cancellation, removes temporary source renders after success, and keeps the normal render when the upscale fails.
+
+## Downloads
+
+- `Windows Installer`: standard Windows install experience for most users
+- `Windows Portable`: no-install Windows build for quick testing or portable use
+- `Mac (Apple Silicon)`: for M1, M2, M3, M4, and newer Macs
+- `Mac (Intel)`: for older Intel-based Macs
+- `Linux AppImage`: portable Linux build
+- `Linux deb`: Debian/Ubuntu package
+
+Ignore the auto-generated source-code archives unless you plan to build Velorn from source.
+
+## Notes
+
+- Direct NVIDIA RTX upscaling currently requires 64-bit Windows, a compatible NVIDIA RTX GPU, current NVIDIA drivers, and NVENC support.
+- The optional standalone runtime downloads about 595 MB on first setup and uses roughly 1 GB after installation.
+- NVIDIA RTX upscaling is an export post-process. ComfyUI is still used separately for Velorn's local generation workflows.
+- High is the recommended quality setting for most final exports. Ultra favors maximum detail preservation but takes longer.

--- a/electron/main.js
+++ b/electron/main.js
@@ -15,6 +15,12 @@ const ffprobeStaticPath = ffprobeStatic?.path || ffprobeStatic
 const { inspectIsoBmffLayout } = require('./exportSourcePreparation')
 const { registerCaptionWhisperHandlers } = require('./captionWhisper')
 const {
+  cancelRtxVideoUpscale,
+  checkRtxRuntime,
+  installRtxRuntime,
+  runRtxVideoUpscale,
+} = require('./rtxVideoUpscale')
+const {
   ComfyLauncher,
   detectLaunchersForComfyRoot,
   DEFAULT_CONFIG: DEFAULT_LAUNCHER_CONFIG,
@@ -122,6 +128,9 @@ function resolvePackagedBinaryPath(binaryPath) {
 
 const ffmpegPath = resolvePackagedBinaryPath(ffmpegStaticPath)
 const ffprobePath = resolvePackagedBinaryPath(ffprobeStaticPath)
+const rtxHelperPath = app.isPackaged
+  ? path.join(process.resourcesPath, 'scripts', 'rtx_vsr_stream.py')
+  : path.join(__dirname, '..', 'scripts', 'rtx_vsr_stream.py')
 
 // ffmpeg-static resolves a path whether or not its install script actually
 // downloaded the binary (skipped postinstalls, antivirus quarantine), and
@@ -4746,6 +4755,67 @@ ipcMain.handle('settings:delete', async (event, key) => {
     return { success: false, error: err.message }
   }
 })
+
+// ============================================
+// NVIDIA RTX Video Super Resolution
+// ============================================
+
+async function getRtxRuntimeContext() {
+  const settings = await readSettingsRaw().catch(() => ({}))
+  return {
+    userDataPath: app.getPath('userData'),
+    comfyRootPath: settings?.[COMFY_ROOT_SETTING_KEY] || '',
+    explicitPythonPath: settings?.rtxPythonPath || '',
+  }
+}
+
+ipcMain.handle('rtx:checkRuntime', async () => {
+  try {
+    return await checkRtxRuntime(await getRtxRuntimeContext())
+  } catch (error) {
+    return {
+      ready: false,
+      installAvailable: process.platform === 'win32' && process.arch === 'x64',
+      error: error?.message || String(error),
+    }
+  }
+})
+
+ipcMain.handle('rtx:installRuntime', async (event) => {
+  try {
+    return await installRtxRuntime({
+      userDataPath: app.getPath('userData'),
+      onProgress: (progress) => {
+        if (!event.sender.isDestroyed()) event.sender.send('rtx:setupProgress', progress)
+      },
+    })
+  } catch (error) {
+    return { success: false, error: error?.message || String(error) }
+  }
+})
+
+ipcMain.handle('rtx:run', async (event, payload = {}) => {
+  try {
+    const runtime = await checkRtxRuntime(await getRtxRuntimeContext())
+    if (!runtime.ready) {
+      return { success: false, error: runtime.error || 'The NVIDIA RTX runtime is not ready.' }
+    }
+    return await runRtxVideoUpscale({
+      ...payload,
+      runtime,
+      helperPath: rtxHelperPath,
+      ffmpegPath,
+      ffprobePath,
+      onProgress: (progress) => {
+        if (!event.sender.isDestroyed()) event.sender.send('rtx:progress', progress)
+      },
+    })
+  } catch (error) {
+    return { success: false, error: error?.message || String(error) }
+  }
+})
+
+ipcMain.handle('rtx:cancel', (_event, jobId) => cancelRtxVideoUpscale(jobId))
 
 // ============================================
 // MCP Server IPC

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -147,6 +147,23 @@ contextBridge.exposeInMainWorld('electronAPI', {
    */
   checkNvenc: () => ipcRenderer.invoke('export:checkNvenc'),
 
+  // Direct NVIDIA RTX Video Super Resolution. The optional runtime is
+  // managed by Velorn and does not require a running ComfyUI server.
+  checkRtxVideoUpscaleRuntime: () => ipcRenderer.invoke('rtx:checkRuntime'),
+  installRtxVideoUpscaleRuntime: () => ipcRenderer.invoke('rtx:installRuntime'),
+  runRtxVideoUpscale: (options) => ipcRenderer.invoke('rtx:run', options),
+  cancelRtxVideoUpscale: (jobId) => ipcRenderer.invoke('rtx:cancel', jobId),
+  onRtxVideoUpscaleProgress: (callback) => {
+    const handler = (_event, data) => callback(data)
+    ipcRenderer.on('rtx:progress', handler)
+    return () => ipcRenderer.removeListener('rtx:progress', handler)
+  },
+  onRtxVideoUpscaleSetupProgress: (callback) => {
+    const handler = (_event, data) => callback(data)
+    ipcRenderer.on('rtx:setupProgress', handler)
+    return () => ipcRenderer.removeListener('rtx:setupProgress', handler)
+  },
+
   /**
    * Make a local source safe for the renderer's decoders. mode 'remux'
    * (default): already-fast-start files are reused, other containers are

--- a/electron/rtxVideoUpscale.js
+++ b/electron/rtxVideoUpscale.js
@@ -1,0 +1,706 @@
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const http = require('http')
+const https = require('https')
+const { spawn } = require('child_process')
+
+const PYTHON_VERSION = '3.13.15'
+const PYTHON_ARCHIVE_URL = `https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-embed-amd64.zip`
+const PYTHON_ARCHIVE_SHA256 = 'd1f04d990aee1253d8569e8e5104e30fa9f5fa830899f14843448872d936a2cf'
+const MANAGED_RUNTIME_DIR = 'rtx-runtime-v1'
+const RUNTIME_PACKAGES = Object.freeze([
+  'numpy==2.2.6',
+  'fastrlock==0.8.3',
+  'cupy-cuda12x==13.6.0',
+  'nvidia-vfx==0.1.0.1',
+])
+const RUNTIME_WHEELS = Object.freeze([
+  Object.freeze({
+    package: 'pip',
+    filename: 'pip-bootstrap.zip',
+    url: 'https://files.pythonhosted.org/packages/44/3c/d717024885424591d5376220b5e836c2d5293ce2011523c9de23ff7bf068/pip-25.3-py3-none-any.whl',
+    sha256: '9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd',
+    size: 1778622,
+    bootstrap: true,
+  }),
+  Object.freeze({
+    package: 'numpy',
+    filename: 'numpy-2.2.6-cp313-cp313-win_amd64.whl',
+    url: 'https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl',
+    sha256: 'b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c',
+    size: 12610885,
+  }),
+  Object.freeze({
+    package: 'fastrlock',
+    filename: 'fastrlock-0.8.3-cp313-cp313-win_amd64.whl',
+    url: 'https://files.pythonhosted.org/packages/28/a3/2ad0a0a69662fd4cf556ab8074f0de978ee9b56bff6ddb4e656df4aa9e8e/fastrlock-0.8.3-cp313-cp313-win_amd64.whl',
+    sha256: '8d1d6a28291b4ace2a66bd7b49a9ed9c762467617febdd9ab356b867ed901af8',
+    size: 30472,
+  }),
+  Object.freeze({
+    package: 'cupy-cuda12x',
+    filename: 'cupy_cuda12x-13.6.0-cp313-cp313-win_amd64.whl',
+    url: 'https://files.pythonhosted.org/packages/72/36/c9e24acb19f039f814faea880b3704a3661edaa6739456b73b27540663e3/cupy_cuda12x-13.6.0-cp313-cp313-win_amd64.whl',
+    sha256: '297b4268f839de67ef7865c2202d3f5a0fb8d20bd43360bc51b6e60cb4406447',
+    size: 89750580,
+  }),
+  Object.freeze({
+    package: 'nvidia-vfx',
+    filename: 'nvidia_vfx-0.1.0.1-cp312-abi3-win_amd64.whl',
+    url: 'https://pypi.nvidia.com/nvidia-vfx/nvidia_vfx-0.1.0.1-cp312-abi3-win_amd64.whl',
+    sha256: 'b6cfaff5f435ad18329a1e1c1ac3ceb36f2aa6cfb0774d271c0bcc3aeaf31c53',
+    size: 490396952,
+  }),
+])
+const QUALITY_LEVELS = new Set(['LOW', 'MEDIUM', 'HIGH', 'ULTRA'])
+const activeJobs = new Map()
+let activeInstall = null
+
+function createCancelledError(message = 'RTX operation cancelled') {
+  const error = new Error(message)
+  error.name = 'AbortError'
+  return error
+}
+
+function normalizeQuality(value = '') {
+  const normalized = String(value || '').trim().toUpperCase()
+  return QUALITY_LEVELS.has(normalized) ? normalized : 'HIGH'
+}
+
+function getManagedRuntimePaths(userDataPath) {
+  const root = path.join(path.resolve(userDataPath), MANAGED_RUNTIME_DIR)
+  return {
+    root,
+    pythonDir: path.join(root, 'python'),
+    pythonPath: path.join(root, 'python', 'python.exe'),
+    manifestPath: path.join(root, 'runtime.json'),
+  }
+}
+
+function getComfyPythonCandidates(comfyRootPath = '') {
+  const rootText = String(comfyRootPath || '').trim()
+  if (!rootText) return []
+  const root = path.resolve(rootText)
+  const parent = path.dirname(root)
+  const grandparent = path.dirname(parent)
+  return [
+    path.join(root, 'python_embeded', 'python.exe'),
+    path.join(root, 'python_embedded', 'python.exe'),
+    path.join(parent, 'python_embeded', 'python.exe'),
+    path.join(parent, 'python_embedded', 'python.exe'),
+    path.join(grandparent, 'python_embeded', 'python.exe'),
+    path.join(grandparent, 'python_embedded', 'python.exe'),
+  ]
+}
+
+function getRuntimeCandidates({ userDataPath, comfyRootPath = '', explicitPythonPath = '' }) {
+  const managed = getManagedRuntimePaths(userDataPath)
+  const candidates = [
+    { pythonPath: managed.pythonPath, kind: 'managed', label: 'Velorn RTX runtime' },
+  ]
+  if (String(explicitPythonPath || '').trim()) {
+    candidates.push({
+      pythonPath: path.resolve(String(explicitPythonPath).trim()),
+      kind: 'custom',
+      label: 'Custom RTX Python runtime',
+    })
+  }
+  for (const pythonPath of getComfyPythonCandidates(comfyRootPath)) {
+    candidates.push({ pythonPath, kind: 'compatible-local', label: 'Compatible local RTX runtime' })
+  }
+
+  const seen = new Set()
+  return candidates.filter((candidate) => {
+    const key = path.normalize(candidate.pythonPath).toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function tailLines(text = '', count = 16) {
+  return String(text || '').split(/\r?\n/).filter(Boolean).slice(-count).join('\n')
+}
+
+function killProcessTree(child) {
+  if (!child || child.exitCode !== null || child.killed) return
+  if (process.platform === 'win32' && child.pid) {
+    const killer = spawn('taskkill.exe', ['/pid', String(child.pid), '/t', '/f'], {
+      windowsHide: true,
+      stdio: 'ignore',
+    })
+    killer.unref()
+    return
+  }
+  child.kill('SIGTERM')
+}
+
+function runProcess(command, args = [], options = {}) {
+  const {
+    cwd = undefined,
+    env = process.env,
+    signal = null,
+    timeoutMs = 0,
+    onStdoutLine = null,
+    onStderrLine = null,
+  } = options
+
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createCancelledError())
+      return
+    }
+
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    let stdoutPending = ''
+    let stderrPending = ''
+    let settled = false
+    let timeout = null
+
+    const flushLines = (chunk, pending, callback) => {
+      const combined = pending + chunk
+      const lines = combined.split(/\r?\n/)
+      const nextPending = lines.pop() || ''
+      for (const line of lines) callback?.(line)
+      return nextPending
+    }
+    const cleanup = () => {
+      signal?.removeEventListener?.('abort', abort)
+      if (timeout) clearTimeout(timeout)
+    }
+    const finish = (error, value) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      if (error) reject(error)
+      else resolve(value)
+    }
+    const abort = () => {
+      killProcessTree(child)
+      finish(createCancelledError())
+    }
+
+    signal?.addEventListener?.('abort', abort, { once: true })
+    if (timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        killProcessTree(child)
+        finish(new Error(`Process timed out after ${Math.round(timeoutMs / 1000)} seconds.`))
+      }, timeoutMs)
+    }
+
+    child.stdout.on('data', (data) => {
+      const text = data.toString('utf8')
+      stdout += text
+      if (stdout.length > 512 * 1024) stdout = stdout.slice(-512 * 1024)
+      stdoutPending = flushLines(text, stdoutPending, onStdoutLine)
+    })
+    child.stderr.on('data', (data) => {
+      const text = data.toString('utf8')
+      stderr += text
+      if (stderr.length > 512 * 1024) stderr = stderr.slice(-512 * 1024)
+      stderrPending = flushLines(text, stderrPending, onStderrLine)
+    })
+    child.on('error', (error) => finish(error))
+    child.on('close', (code, processSignal) => {
+      if (stdoutPending) onStdoutLine?.(stdoutPending)
+      if (stderrPending) onStderrLine?.(stderrPending)
+      finish(null, { code, signal: processSignal, stdout, stderr, child })
+    })
+  })
+}
+
+async function probePythonRuntime(pythonPath) {
+  const code = [
+    'import json',
+    'import importlib.metadata as metadata',
+    'import cupy as cp',
+    'import nvvfx',
+    'props = cp.cuda.runtime.getDeviceProperties(0)',
+    'name = props.get("name", "NVIDIA GPU")',
+    'name = name.decode("utf-8", errors="replace") if isinstance(name, bytes) else str(name)',
+    'print(json.dumps({"gpu": name, "cupy": cp.__version__, "nvidiaVfx": metadata.version("nvidia-vfx")}))',
+  ].join('; ')
+  const result = await runProcess(pythonPath, ['-c', code], { timeoutMs: 45000 })
+  if (result.code !== 0) {
+    throw new Error(tailLines(result.stderr || result.stdout) || `Python exited with code ${result.code}.`)
+  }
+  const payloadLine = result.stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).pop()
+  try {
+    return JSON.parse(payloadLine)
+  } catch {
+    throw new Error('The RTX runtime returned an invalid readiness response.')
+  }
+}
+
+async function checkRtxRuntime(options = {}) {
+  if (process.platform !== 'win32' || process.arch !== 'x64') {
+    return {
+      ready: false,
+      installAvailable: false,
+      error: 'NVIDIA RTX Video Super Resolution is currently available on 64-bit Windows only.',
+    }
+  }
+
+  const candidates = getRuntimeCandidates(options)
+  const failures = []
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate.pythonPath)) continue
+    try {
+      const details = await probePythonRuntime(candidate.pythonPath)
+      return {
+        ready: true,
+        installAvailable: true,
+        ...candidate,
+        ...details,
+      }
+    } catch (error) {
+      failures.push(`${candidate.label}: ${error?.message || error}`)
+    }
+  }
+
+  return {
+    ready: false,
+    installAvailable: true,
+    error: failures.length > 0
+      ? `A local Python runtime was found, but NVIDIA RTX support is incomplete. ${failures[0]}`
+      : 'Install the optional Velorn RTX runtime to enable direct 4K upscaling. ComfyUI is not required.',
+  }
+}
+
+function downloadFile(urlText, outputPath, options = {}, redirectsRemaining = 5) {
+  const { signal = null, onProgress = () => {} } = options
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createCancelledError())
+      return
+    }
+    const url = new URL(urlText)
+    const transport = url.protocol === 'https:' ? https : http
+    const partialPath = `${outputPath}.part`
+    let request = null
+    let output = null
+    let settled = false
+
+    const cleanup = () => signal?.removeEventListener?.('abort', abort)
+    const finish = async (error, value) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      if (error) {
+        try { await fs.promises.rm(partialPath, { force: true }) } catch { /* ignore */ }
+        reject(error)
+      } else {
+        resolve(value)
+      }
+    }
+    const abort = () => {
+      const error = createCancelledError('RTX runtime installation cancelled')
+      output?.destroy(error)
+      request?.destroy(error)
+      void finish(error)
+    }
+
+    signal?.addEventListener?.('abort', abort, { once: true })
+    request = transport.get(url, { headers: { 'User-Agent': 'Velorn RTX Runtime Installer' } }, (response) => {
+      if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+        response.resume()
+        cleanup()
+        settled = true
+        if (redirectsRemaining <= 0) {
+          reject(new Error('Too many redirects while downloading the RTX runtime.'))
+          return
+        }
+        const redirected = new URL(response.headers.location, url).toString()
+        downloadFile(redirected, outputPath, options, redirectsRemaining - 1).then(resolve, reject)
+        return
+      }
+      if (response.statusCode !== 200) {
+        response.resume()
+        void finish(new Error(`Download failed with HTTP ${response.statusCode}.`))
+        return
+      }
+
+      const totalBytes = Number(response.headers['content-length']) || null
+      let transferredBytes = 0
+      let lastProgressAt = 0
+      output = fs.createWriteStream(partialPath)
+      response.on('data', (chunk) => {
+        transferredBytes += chunk.length
+        const now = Date.now()
+        if (now - lastProgressAt >= 200 || (totalBytes && transferredBytes >= totalBytes)) {
+          lastProgressAt = now
+          onProgress({ transferredBytes, totalBytes })
+        }
+      })
+      response.on('error', (error) => void finish(error))
+      output.on('error', (error) => void finish(error))
+      output.on('close', async () => {
+        if (settled) return
+        try {
+          await fs.promises.rm(outputPath, { force: true })
+          await fs.promises.rename(partialPath, outputPath)
+          onProgress({ transferredBytes, totalBytes: totalBytes || transferredBytes })
+          await finish(null, { outputPath, transferredBytes, totalBytes })
+        } catch (error) {
+          await finish(error)
+        }
+      })
+      response.pipe(output)
+    })
+    request.on('error', (error) => void finish(error))
+  })
+}
+
+async function sha256File(filePath) {
+  return await new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256')
+    const input = fs.createReadStream(filePath)
+    input.on('error', reject)
+    input.on('data', (chunk) => hash.update(chunk))
+    input.on('end', () => resolve(hash.digest('hex')))
+  })
+}
+
+async function expandZip(archivePath, destinationPath, signal = null) {
+  await fs.promises.mkdir(destinationPath, { recursive: true })
+  const script = '& { param($archive, $destination) Expand-Archive -LiteralPath $archive -DestinationPath $destination -Force }'
+  const result = await runProcess('powershell.exe', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy', 'Bypass',
+    '-Command', script,
+    archivePath,
+    destinationPath,
+  ], { signal, timeoutMs: 120000 })
+  if (result.code !== 0) {
+    throw new Error(tailLines(result.stderr || result.stdout) || 'Could not extract the Python runtime.')
+  }
+}
+
+async function enableEmbeddedPythonSitePackages(pythonDir) {
+  const entries = await fs.promises.readdir(pythonDir)
+  const pthName = entries.find((name) => /^python\d+\._pth$/i.test(name))
+  if (!pthName) throw new Error('The embedded Python path configuration was not found.')
+  const pthPath = path.join(pythonDir, pthName)
+  const original = await fs.promises.readFile(pthPath, 'utf8')
+  const lines = original.split(/\r?\n/)
+  const next = []
+  let hasSitePackages = false
+  let hasImportSite = false
+  for (const line of lines) {
+    if (/^\s*#?\s*import\s+site\s*$/i.test(line)) {
+      if (!hasImportSite) next.push('import site')
+      hasImportSite = true
+      continue
+    }
+    if (/^\s*Lib[\\/]site-packages\s*$/i.test(line)) hasSitePackages = true
+    next.push(line)
+  }
+  if (!hasSitePackages) next.push('Lib\\site-packages')
+  if (!hasImportSite) next.push('import site')
+  await fs.promises.writeFile(pthPath, `${next.filter((line, index, all) => index < all.length - 1 || line).join('\r\n')}\r\n`, 'utf8')
+}
+
+function emitInstallProgress(onProgress, payload) {
+  try { onProgress({ scope: 'rtx-runtime', ...payload }) } catch { /* renderer closed */ }
+}
+
+async function installRtxRuntime(options = {}) {
+  if (activeInstall) return await activeInstall
+  if (process.platform !== 'win32' || process.arch !== 'x64') {
+    return { success: false, error: 'The standalone RTX runtime is currently available on 64-bit Windows only.' }
+  }
+
+  const { userDataPath, signal = null, onProgress = () => {} } = options
+  const managed = getManagedRuntimePaths(userDataPath)
+  const temporaryRoot = path.join(path.dirname(managed.root), `.rtx-runtime-install-${crypto.randomUUID()}`)
+  const pythonDir = path.join(temporaryRoot, 'python')
+  const downloadsDir = path.join(temporaryRoot, 'downloads')
+  const pythonArchive = path.join(downloadsDir, `python-${PYTHON_VERSION}.zip`)
+
+  activeInstall = (async () => {
+    try {
+      await fs.promises.mkdir(downloadsDir, { recursive: true })
+      emitInstallProgress(onProgress, {
+        stage: 'python-download',
+        percent: 1,
+        message: 'Downloading the small Python runtime...',
+      })
+      await downloadFile(PYTHON_ARCHIVE_URL, pythonArchive, {
+        signal,
+        onProgress: ({ transferredBytes, totalBytes }) => {
+          const ratio = totalBytes ? transferredBytes / totalBytes : 0
+          emitInstallProgress(onProgress, {
+            stage: 'python-download',
+            percent: 1 + (ratio * 9),
+            transferredBytes,
+            totalBytes,
+            message: totalBytes
+              ? `Downloading Python runtime... ${Math.round(ratio * 100)}%`
+              : 'Downloading Python runtime...',
+          })
+        },
+      })
+      const archiveHash = await sha256File(pythonArchive)
+      if (archiveHash.toLowerCase() !== PYTHON_ARCHIVE_SHA256) {
+        throw new Error('The downloaded Python runtime failed its integrity check.')
+      }
+
+      emitInstallProgress(onProgress, { stage: 'python-extract', percent: 11, message: 'Preparing the Python runtime...' })
+      await expandZip(pythonArchive, pythonDir, signal)
+      await enableEmbeddedPythonSitePackages(pythonDir)
+      const pythonPath = path.join(pythonDir, 'python.exe')
+
+      const wheelBytes = RUNTIME_WHEELS.reduce((total, wheel) => total + wheel.size, 0)
+      let completedWheelBytes = 0
+      for (const wheel of RUNTIME_WHEELS) {
+        const wheelPath = path.join(downloadsDir, wheel.filename)
+        emitInstallProgress(onProgress, {
+          stage: 'packages-download',
+          percent: 14 + ((completedWheelBytes / wheelBytes) * 68),
+          message: wheel.package === 'nvidia-vfx'
+            ? 'Downloading NVIDIA RTX Video Super Resolution...'
+            : `Downloading ${wheel.package}...`,
+        })
+        await downloadFile(wheel.url, wheelPath, {
+          signal,
+          onProgress: ({ transferredBytes }) => {
+            const currentBytes = Math.min(wheel.size, transferredBytes)
+            emitInstallProgress(onProgress, {
+              stage: 'packages-download',
+              percent: 14 + (((completedWheelBytes + currentBytes) / wheelBytes) * 68),
+              transferredBytes: completedWheelBytes + currentBytes,
+              totalBytes: wheelBytes,
+              message: wheel.package === 'nvidia-vfx'
+                ? 'Downloading NVIDIA RTX Video Super Resolution...'
+                : `Downloading ${wheel.package}...`,
+            })
+          },
+        })
+        const wheelHash = await sha256File(wheelPath)
+        if (wheelHash.toLowerCase() !== wheel.sha256) {
+          throw new Error(`The downloaded ${wheel.package} package failed its integrity check.`)
+        }
+        completedWheelBytes += wheel.size
+      }
+
+      emitInstallProgress(onProgress, {
+        stage: 'pip-setup',
+        percent: 83,
+        message: 'Preparing the local package installer...',
+      })
+      const pipWheel = RUNTIME_WHEELS.find((wheel) => wheel.bootstrap)
+      const sitePackagesPath = path.join(pythonDir, 'Lib', 'site-packages')
+      await expandZip(path.join(downloadsDir, pipWheel.filename), sitePackagesPath, signal)
+
+      emitInstallProgress(onProgress, {
+        stage: 'packages-install',
+        percent: 85,
+        message: 'Installing NVIDIA RTX libraries (about 1 GB)...',
+      })
+      let packageProgress = 85
+      const packageResult = await runProcess(pythonPath, [
+        '-m', 'pip', 'install',
+        '--disable-pip-version-check',
+        '--no-input',
+        '--no-cache-dir',
+        '--no-index',
+        '--find-links', downloadsDir,
+        '--only-binary=:all:',
+        '--upgrade',
+        ...RUNTIME_PACKAGES,
+      ], {
+        signal,
+        timeoutMs: 45 * 60 * 1000,
+        onStdoutLine: (line) => {
+          if (/^Processing\s+/i.test(line) || /^Installing collected packages/i.test(line)) {
+            packageProgress = Math.min(94, packageProgress + 2)
+            emitInstallProgress(onProgress, {
+              stage: 'packages-install',
+              percent: packageProgress,
+              message: 'Installing NVIDIA RTX libraries...',
+            })
+          }
+        },
+      })
+      if (packageResult.code !== 0) {
+        throw new Error(tailLines(packageResult.stderr || packageResult.stdout) || 'Could not install NVIDIA RTX libraries.')
+      }
+
+      emitInstallProgress(onProgress, { stage: 'verify', percent: 96, message: 'Checking the GPU and RTX runtime...' })
+      const details = await probePythonRuntime(pythonPath)
+      await fs.promises.rm(downloadsDir, { recursive: true, force: true })
+      await fs.promises.writeFile(path.join(temporaryRoot, 'runtime.json'), JSON.stringify({
+        runtimeVersion: 1,
+        pythonVersion: PYTHON_VERSION,
+        packages: RUNTIME_PACKAGES,
+        installedAt: new Date().toISOString(),
+        ...details,
+      }, null, 2), 'utf8')
+
+      await fs.promises.rm(managed.root, { recursive: true, force: true })
+      await fs.promises.rename(temporaryRoot, managed.root)
+      emitInstallProgress(onProgress, { stage: 'complete', percent: 100, message: 'NVIDIA RTX runtime is ready.' })
+      return {
+        success: true,
+        ready: true,
+        pythonPath: managed.pythonPath,
+        kind: 'managed',
+        label: 'Velorn RTX runtime',
+        ...details,
+      }
+    } catch (error) {
+      await fs.promises.rm(temporaryRoot, { recursive: true, force: true }).catch(() => {})
+      if (signal?.aborted || error?.name === 'AbortError') {
+        return { success: false, cancelled: true, error: 'RTX runtime installation cancelled.' }
+      }
+      return { success: false, error: error?.message || String(error) }
+    } finally {
+      activeInstall = null
+    }
+  })()
+
+  return await activeInstall
+}
+
+function buildRtxHelperArgs(options = {}) {
+  const width = Math.max(8, Math.round(Number(options.width) || 3840))
+  const height = Math.max(8, Math.round(Number(options.height) || 2160))
+  if (width > 8192 || height > 8192) throw new Error('RTX output dimensions cannot exceed 8192 pixels.')
+  return [
+    options.helperPath,
+    '--input', path.resolve(options.inputPath),
+    '--output', path.resolve(options.outputPath),
+    '--width', String(width),
+    '--height', String(height),
+    '--quality', normalizeQuality(options.quality),
+    '--ffmpeg', path.resolve(options.ffmpegPath),
+    '--ffprobe', path.resolve(options.ffprobePath),
+    '--encoder', String(options.encoder || 'h264_nvenc'),
+    '--cq', String(Math.max(0, Math.min(51, Math.round(Number(options.cq) || 18)))),
+  ]
+}
+
+async function runRtxVideoUpscale(options = {}) {
+  const {
+    jobId = `rtx-${crypto.randomUUID()}`,
+    runtime,
+    inputPath,
+    outputPath,
+    helperPath,
+    ffmpegPath,
+    ffprobePath,
+    onProgress = () => {},
+  } = options
+  if (!runtime?.pythonPath || !fs.existsSync(runtime.pythonPath)) throw new Error('The NVIDIA RTX runtime is not ready.')
+  if (!inputPath || !fs.existsSync(path.resolve(inputPath))) throw new Error('The RTX source video does not exist.')
+  if (!outputPath) throw new Error('No RTX output path was provided.')
+  if (!helperPath || !fs.existsSync(helperPath)) throw new Error('The Velorn RTX helper is missing.')
+  if (!ffmpegPath || !fs.existsSync(ffmpegPath) || !ffprobePath || !fs.existsSync(ffprobePath)) {
+    throw new Error('Velorn could not find its FFmpeg tools.')
+  }
+  if (path.resolve(inputPath).toLowerCase() === path.resolve(outputPath).toLowerCase()) {
+    throw new Error('The RTX output must use a different path from the source render.')
+  }
+  if (activeJobs.has(jobId)) throw new Error(`RTX job ${jobId} is already running.`)
+
+  await fs.promises.mkdir(path.dirname(path.resolve(outputPath)), { recursive: true })
+  const args = buildRtxHelperArgs({ ...options, helperPath, ffmpegPath, ffprobePath })
+  let helperError = null
+  let completion = null
+  let stdoutPending = ''
+  let stderr = ''
+  let cancelled = false
+
+  const child = spawn(runtime.pythonPath, args, {
+    windowsHide: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  activeJobs.set(jobId, { child, outputPath: path.resolve(outputPath), cancel: () => { cancelled = true; killProcessTree(child) } })
+
+  const consumeLine = (line) => {
+    const trimmed = String(line || '').trim()
+    if (!trimmed) return
+    let event
+    try { event = JSON.parse(trimmed) } catch { return }
+    if (event.event === 'error') helperError = event
+    if (event.event === 'complete') completion = event
+    try { onProgress({ jobId, ...event }) } catch { /* renderer closed */ }
+  }
+
+  try {
+    const result = await new Promise((resolve, reject) => {
+      child.stdout.on('data', (data) => {
+        const combined = stdoutPending + data.toString('utf8')
+        const lines = combined.split(/\r?\n/)
+        stdoutPending = lines.pop() || ''
+        lines.forEach(consumeLine)
+      })
+      child.stderr.on('data', (data) => {
+        stderr += data.toString('utf8')
+        if (stderr.length > 256 * 1024) stderr = stderr.slice(-256 * 1024)
+      })
+      child.on('error', reject)
+      child.on('close', (code, processSignal) => {
+        if (stdoutPending) consumeLine(stdoutPending)
+        resolve({ code, signal: processSignal })
+      })
+    })
+
+    if (cancelled) throw createCancelledError('RTX upscale cancelled')
+    if (result.code !== 0 || !completion) {
+      throw new Error(helperError?.message || tailLines(stderr) || `RTX helper exited with code ${result.code}.`)
+    }
+    if (!fs.existsSync(path.resolve(outputPath))) throw new Error('RTX upscale completed without creating an output video.')
+    return {
+      success: true,
+      jobId,
+      outputPath: path.resolve(outputPath),
+      runtimeKind: runtime.kind,
+      runtimeLabel: runtime.label,
+      ...completion,
+    }
+  } catch (error) {
+    await fs.promises.rm(path.resolve(outputPath), { force: true }).catch(() => {})
+    if (cancelled || error?.name === 'AbortError') {
+      return { success: false, cancelled: true, jobId, error: 'RTX upscale cancelled.' }
+    }
+    return { success: false, jobId, error: error?.message || String(error) }
+  } finally {
+    activeJobs.delete(jobId)
+  }
+}
+
+function cancelRtxVideoUpscale(jobId = '') {
+  const job = activeJobs.get(String(jobId || '').trim())
+  if (!job) return { success: false, error: 'RTX job is not running.' }
+  job.cancel()
+  return { success: true, cancelled: true, jobId }
+}
+
+module.exports = {
+  MANAGED_RUNTIME_DIR,
+  PYTHON_ARCHIVE_SHA256,
+  PYTHON_ARCHIVE_URL,
+  PYTHON_VERSION,
+  RUNTIME_PACKAGES,
+  RUNTIME_WHEELS,
+  buildRtxHelperArgs,
+  cancelRtxVideoUpscale,
+  checkRtxRuntime,
+  getComfyPythonCandidates,
+  getManagedRuntimePaths,
+  getRuntimeCandidates,
+  installRtxRuntime,
+  normalizeQuality,
+  probePythonRuntime,
+  runRtxVideoUpscale,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "velorn",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "velorn",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@xyflow/react": "^12.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velorn",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "AI-native video editing built around real creative timelines, generative workflows, and local agent control.",
   "main": "electron/main.js",
   "scripts": {
@@ -117,6 +117,10 @@
         "filter": [
           "**/*"
         ]
+      },
+      {
+        "from": "scripts/rtx_vsr_stream.py",
+        "to": "scripts/rtx_vsr_stream.py"
       }
     ],
     "win": {

--- a/scripts/rtx_vsr_stream.py
+++ b/scripts/rtx_vsr_stream.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Stream a video through NVIDIA Video Super Resolution one frame at a time."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import threading
+import time
+from fractions import Fraction
+from pathlib import Path
+
+import cupy as cp
+import numpy as np
+
+from nvvfx import VideoSuperRes
+from nvvfx.effects import QualityLevel
+
+
+QUALITY_LEVELS = {
+    "LOW": QualityLevel.LOW,
+    "MEDIUM": QualityLevel.MEDIUM,
+    "HIGH": QualityLevel.HIGH,
+    "ULTRA": QualityLevel.ULTRA,
+}
+
+
+def emit(event: str, **payload: object) -> None:
+    print(json.dumps({"event": event, **payload}, separators=(",", ":")), flush=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--width", required=True, type=int)
+    parser.add_argument("--height", required=True, type=int)
+    parser.add_argument("--quality", default="HIGH", choices=tuple(QUALITY_LEVELS))
+    parser.add_argument("--ffmpeg", required=True, type=Path)
+    parser.add_argument("--ffprobe", required=True, type=Path)
+    parser.add_argument("--encoder", default="h264_nvenc")
+    parser.add_argument("--cq", default=18, type=int)
+    parser.add_argument(
+        "--max-frames",
+        default=0,
+        type=int,
+        help="Limit processing for diagnostics; zero processes the entire video.",
+    )
+    return parser.parse_args()
+
+
+def run_json(command: list[str]) -> dict:
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return json.loads(completed.stdout)
+
+
+def probe_video(ffprobe: Path, input_path: Path) -> dict:
+    data = run_json([
+        str(ffprobe),
+        "-v", "error",
+        "-show_entries", "stream=index,codec_type,codec_name,width,height,avg_frame_rate,nb_frames,duration",
+        "-show_entries", "format=duration",
+        "-of", "json",
+        str(input_path),
+    ])
+    streams = data.get("streams") or []
+    video = next((stream for stream in streams if stream.get("codec_type") == "video"), None)
+    if not video:
+        raise RuntimeError("Input has no video stream.")
+
+    width = int(video.get("width") or 0)
+    height = int(video.get("height") or 0)
+    if width <= 0 or height <= 0:
+        raise RuntimeError("Could not determine the source dimensions.")
+
+    frame_rate_text = str(video.get("avg_frame_rate") or "0/1")
+    frame_rate = Fraction(frame_rate_text)
+    if frame_rate <= 0:
+        raise RuntimeError("Could not determine the source frame rate.")
+
+    duration = float(video.get("duration") or (data.get("format") or {}).get("duration") or 0)
+    frame_count = int(video.get("nb_frames") or 0)
+    if frame_count <= 0 and duration > 0:
+        frame_count = round(duration * float(frame_rate))
+
+    audio = next((stream for stream in streams if stream.get("codec_type") == "audio"), None)
+    return {
+        "width": width,
+        "height": height,
+        "fps": frame_rate,
+        "duration": duration,
+        "frame_count": frame_count,
+        "audio_codec": str((audio or {}).get("codec_name") or ""),
+        "has_audio": audio is not None,
+    }
+
+
+def collect_stderr(pipe, sink: list[str]) -> None:
+    try:
+        for raw_line in iter(pipe.readline, b""):
+            sink.append(raw_line.decode("utf-8", errors="replace").rstrip())
+            if len(sink) > 80:
+                del sink[:-80]
+    finally:
+        pipe.close()
+
+
+def read_exact(stream, target: memoryview) -> int:
+    offset = 0
+    while offset < len(target):
+        count = stream.readinto(target[offset:])
+        if not count:
+            break
+        offset += count
+    return offset
+
+
+def terminate_process(process: subprocess.Popen | None) -> None:
+    if not process or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def build_encoder_command(
+    args: argparse.Namespace,
+    info: dict,
+    fps_text: str,
+) -> list[str]:
+    command = [
+        str(args.ffmpeg),
+        "-hide_banner",
+        "-loglevel", "warning",
+        "-nostdin",
+        "-y",
+        "-f", "rawvideo",
+        "-pixel_format", "rgb24",
+        "-video_size", f"{args.width}x{args.height}",
+        "-framerate", fps_text,
+        "-i", "pipe:0",
+        "-i", str(args.input),
+        "-map", "0:v:0",
+    ]
+    if info["has_audio"]:
+        command.extend(["-map", "1:a:0?"])
+    command.extend([
+        "-map_metadata", "1",
+        "-c:v", args.encoder,
+        "-preset", "p6",
+        "-tune", "hq",
+        "-rc", "vbr",
+        "-cq", str(args.cq),
+        "-b:v", "0",
+        "-pix_fmt", "yuv420p",
+    ])
+    if info["has_audio"]:
+        if info["audio_codec"] == "aac":
+            command.extend(["-c:a", "copy"])
+        else:
+            command.extend(["-c:a", "aac", "-b:a", "192k"])
+    target_frames = info["frame_count"]
+    if args.max_frames > 0:
+        target_frames = min(target_frames, args.max_frames) if target_frames else args.max_frames
+    target_duration = (
+        target_frames / float(info["fps"])
+        if target_frames
+        else info["duration"]
+    )
+    if target_duration > 0:
+        command.extend(["-t", f"{target_duration:.9f}"])
+    command.extend(["-movflags", "+faststart", str(args.output)])
+    return command
+
+
+def main() -> int:
+    args = parse_args()
+    args.input = args.input.resolve()
+    args.output = args.output.resolve()
+    args.ffmpeg = args.ffmpeg.resolve()
+    args.ffprobe = args.ffprobe.resolve()
+
+    if not args.input.is_file():
+        raise RuntimeError(f"Input does not exist: {args.input}")
+    if not args.ffmpeg.is_file() or not args.ffprobe.is_file():
+        raise RuntimeError("FFmpeg or FFprobe was not found.")
+    if args.width < 8 or args.height < 8:
+        raise RuntimeError("Output dimensions must be at least 8x8.")
+    try:
+        gpu_properties = cp.cuda.runtime.getDeviceProperties(0)
+        gpu_name = gpu_properties.get("name", "NVIDIA GPU")
+        if isinstance(gpu_name, bytes):
+            gpu_name = gpu_name.decode("utf-8", errors="replace")
+    except Exception as error:
+        raise RuntimeError(f"CUDA is not available in this Python environment: {error}") from error
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    info = probe_video(args.ffprobe, args.input)
+    fps: Fraction = info["fps"]
+    fps_text = f"{fps.numerator}/{fps.denominator}"
+    total_frames = info["frame_count"]
+    if args.max_frames > 0:
+        total_frames = min(total_frames, args.max_frames) if total_frames else args.max_frames
+    frame_size = info["width"] * info["height"] * 3
+    raw_frame = bytearray(frame_size)
+    raw_view = memoryview(raw_frame)
+    source_frame = np.frombuffer(raw_frame, dtype=np.uint8).reshape(
+        info["height"], info["width"], 3
+    )
+
+    emit(
+        "start",
+        input=str(args.input),
+        output=str(args.output),
+        sourceWidth=info["width"],
+        sourceHeight=info["height"],
+        outputWidth=args.width,
+        outputHeight=args.height,
+        fps=fps_text,
+        totalFrames=total_frames,
+        durationSeconds=info["duration"],
+        quality=args.quality,
+        gpu=str(gpu_name),
+    )
+
+    decoder_stderr: list[str] = []
+    encoder_stderr: list[str] = []
+    decoder = None
+    encoder = None
+    started_at = time.perf_counter()
+    processed = 0
+
+    try:
+        decoder_command = [
+            str(args.ffmpeg),
+            "-hide_banner",
+            "-loglevel", "warning",
+            "-nostdin",
+            "-i", str(args.input),
+            "-map", "0:v:0",
+            "-an",
+            "-sn",
+            "-dn",
+            "-fps_mode", "passthrough",
+        ]
+        if args.max_frames > 0:
+            decoder_command.extend(["-frames:v", str(args.max_frames)])
+        decoder_command.extend([
+            "-f", "rawvideo",
+            "-pix_fmt", "rgb24",
+            "pipe:1",
+        ])
+        decoder = subprocess.Popen(
+            decoder_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=frame_size * 2,
+        )
+        encoder = subprocess.Popen(
+            build_encoder_command(args, info, fps_text),
+            stdin=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
+        if not decoder.stdout or not decoder.stderr or not encoder.stdin or not encoder.stderr:
+            raise RuntimeError("Could not create FFmpeg pipes.")
+
+        threading.Thread(target=collect_stderr, args=(decoder.stderr, decoder_stderr), daemon=True).start()
+        threading.Thread(target=collect_stderr, args=(encoder.stderr, encoder_stderr), daemon=True).start()
+
+        with VideoSuperRes(QUALITY_LEVELS[args.quality]) as super_res:
+            super_res.output_width = args.width
+            super_res.output_height = args.height
+            super_res.load()
+
+            while True:
+                bytes_read = read_exact(decoder.stdout, raw_view)
+                if bytes_read == 0:
+                    break
+                if bytes_read != frame_size:
+                    raise RuntimeError(
+                        f"Decoder returned a partial frame ({bytes_read}/{frame_size} bytes)."
+                    )
+
+                input_cuda = cp.ascontiguousarray(
+                    cp.asarray(source_frame).transpose(2, 0, 1),
+                    dtype=cp.float32,
+                )
+                input_cuda *= 1.0 / 255.0
+                result = super_res.run(input_cuda)
+                output_cuda = cp.from_dlpack(result.image)
+                output_u8 = cp.rint(cp.clip(output_cuda, 0.0, 1.0) * 255.0).astype(cp.uint8)
+                output_cpu = cp.asnumpy(output_u8.transpose(1, 2, 0))
+                encoder.stdin.write(memoryview(output_cpu))
+                processed += 1
+
+                del input_cuda, output_cuda, output_u8, output_cpu, result
+                elapsed = time.perf_counter() - started_at
+                if processed == 1 or processed % 5 == 0:
+                    rate = processed / elapsed if elapsed > 0 else 0.0
+                    remaining = max(0, total_frames - processed)
+                    emit(
+                        "progress",
+                        frame=processed,
+                        totalFrames=total_frames,
+                        percent=(processed / total_frames * 100.0) if total_frames else None,
+                        fps=rate,
+                        etaSeconds=(remaining / rate) if rate > 0 and total_frames else None,
+                    )
+
+        decoder.stdout.close()
+        encoder.stdin.close()
+        decoder_code = decoder.wait(timeout=30)
+        encoder_code = encoder.wait(timeout=120)
+        if decoder_code != 0:
+            raise RuntimeError("FFmpeg decode failed: " + "\n".join(decoder_stderr[-12:]))
+        if encoder_code != 0:
+            raise RuntimeError("FFmpeg encode failed: " + "\n".join(encoder_stderr[-12:]))
+        if processed <= 0:
+            raise RuntimeError("No video frames were processed.")
+        if not args.output.is_file() or args.output.stat().st_size <= 0:
+            raise RuntimeError("The output video was not created.")
+
+        elapsed = time.perf_counter() - started_at
+        emit(
+            "complete",
+            frames=processed,
+            elapsedSeconds=elapsed,
+            averageFps=processed / elapsed if elapsed > 0 else 0.0,
+            cupyPoolBytes=cp.get_default_memory_pool().total_bytes(),
+            outputBytes=args.output.stat().st_size,
+        )
+        return 0
+    except KeyboardInterrupt:
+        emit("cancelled", frame=processed)
+        return 130
+    except Exception as error:
+        emit(
+            "error",
+            message=str(error),
+            frame=processed,
+            decoderLog=decoder_stderr[-12:],
+            encoderLog=encoder_stderr[-12:],
+        )
+        return 1
+    finally:
+        if decoder and decoder.stdout and not decoder.stdout.closed:
+            decoder.stdout.close()
+        if encoder and encoder.stdin and not encoder.stdin.closed:
+            try:
+                encoder.stdin.close()
+            except BrokenPipeError:
+                pass
+        terminate_process(decoder)
+        terminate_process(encoder)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as error:
+        emit("error", message=str(error), frame=0)
+        raise SystemExit(1)

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Download, Plus, Trash2, Play, Settings, Film, Clock, RotateCcw, Square } from 'lucide-react'
+import { Download, Plus, Trash2, Play, Settings, Film, Clock, RotateCcw, Sparkles, Square } from 'lucide-react'
 import useProjectStore, { RESOLUTION_PRESETS, FPS_PRESETS } from '../stores/projectStore'
 import useTimelineStore from '../stores/timelineStore'
 import useAssetsStore from '../stores/assetsStore'
@@ -8,6 +8,15 @@ import buildFcpXml from '../services/fcpxmlExporter'
 import buildPremiereXml from '../services/premiereXmlExporter'
 import { mixTimelineAudioToWav } from '../services/timelineAudioMix'
 import { analyzeAudioBuffer } from '../services/audioAnalysis'
+import {
+  checkRtxVideoUpscaleReadiness,
+  installRtxVideoUpscaleRuntime,
+} from '../services/rtxVideoUpscale'
+import {
+  RTX_VIDEO_UPSCALE_DEFAULTS,
+  RTX_VIDEO_UPSCALE_QUALITY_OPTIONS,
+  resolveRtx4kDimensions,
+} from '../config/rtxVideoUpscaleConfig'
 
 const EXPORT_SETTINGS_STORAGE_PREFIX = 'comfystudio-export-settings-v1'
 
@@ -163,6 +172,8 @@ const createDefaultExportSettings = (filename) => ({
   loudnessTarget: -14,
   useProxyMedia: false,
   useDirectFramePipe: true,
+  postProcessUpscale: 'none',
+  rtxUpscaleQuality: RTX_VIDEO_UPSCALE_DEFAULTS.quality,
 })
 
 const EXPORT_PRESETS = [
@@ -378,6 +389,13 @@ function ExportPanel() {
   const [exportResult, setExportResult] = useState(null)
   const [etaSeconds, setEtaSeconds] = useState(null)
   const [renderFps, setRenderFps] = useState(null)
+  const [rtxReadiness, setRtxReadiness] = useState({
+    status: 'idle',
+    ready: false,
+    installAvailable: false,
+    error: '',
+  })
+  const [rtxInstallProgress, setRtxInstallProgress] = useState(null)
 
   // Pre-flight loudness check: render the timeline's program audio (the same
   // mixer captions use) and measure it with the shared analysis engine.
@@ -481,6 +499,52 @@ function ExportPanel() {
     }
   }, [])
 
+  const handleCheckRtxSetup = async () => {
+    setRtxReadiness((current) => ({ ...current, status: 'checking', ready: false, error: '' }))
+    try {
+      const result = await checkRtxVideoUpscaleReadiness()
+      setRtxReadiness({
+        ...result,
+        status: result.ready ? 'ready' : 'error',
+        ready: Boolean(result.ready),
+        installAvailable: Boolean(result.installAvailable),
+        error: result.error || '',
+      })
+      return result
+    } catch (error) {
+      const result = {
+        ready: false,
+        installAvailable: false,
+        error: error?.message || 'Could not check the NVIDIA RTX runtime.',
+      }
+      setRtxReadiness({ ...result, status: 'error' })
+      return result
+    }
+  }
+
+  const handleInstallRtxRuntime = async () => {
+    setRtxInstallProgress({ percent: 0, message: 'Preparing the NVIDIA RTX runtime installer...' })
+    setRtxReadiness((current) => ({ ...current, status: 'installing', error: '' }))
+    try {
+      await installRtxVideoUpscaleRuntime({
+        onStatus: (status) => setRtxInstallProgress(status),
+      })
+      setRtxInstallProgress({ percent: 100, message: 'NVIDIA RTX runtime is ready.' })
+      return await handleCheckRtxSetup()
+    } catch (error) {
+      const message = error?.message || 'Could not install the NVIDIA RTX runtime.'
+      setRtxReadiness((current) => ({ ...current, status: 'error', ready: false, error: message }))
+      setRtxInstallProgress(null)
+      return { ready: false, error: message }
+    }
+  }
+
+  const handleToggleRtxUpscale = () => {
+    const enabling = settings.postProcessUpscale !== 'rtx-4k'
+    handleSettingChange('postProcessUpscale', enabling ? 'rtx-4k' : 'none')
+    if (enabling) void handleCheckRtxSetup()
+  }
+
   useEffect(() => {
     if (typeof window === 'undefined' || !window.electronAPI?.onExportProgress) return
     const onProgress = (data) => {
@@ -556,6 +620,7 @@ function ExportPanel() {
         }
         if (value === 'webm' || value === 'prores' || value === 'audio') {
           next.useHardwareEncoder = false
+          next.postProcessUpscale = 'none'
         }
         if (value === 'audio') {
           // The whole export IS the audio — the include toggle is moot.
@@ -570,6 +635,7 @@ function ExportPanel() {
         if (value === 'vp9') {
           next.format = 'webm'
           next.useHardwareEncoder = false
+          next.postProcessUpscale = 'none'
         } else {
           next.format = 'mp4'
         }
@@ -599,6 +665,7 @@ function ExportPanel() {
     setSettings((prev) => {
       const next = {
         ...prev,
+        postProcessUpscale: 'none',
         ...exportPreset.settings,
       }
       const requestedCodec = next.videoCodec
@@ -632,6 +699,7 @@ function ExportPanel() {
   }
 
   const activeExportPresetId = useMemo(() => {
+    if (settings.postProcessUpscale === 'rtx-4k') return null
     const isEqual = (a, b) => String(a) === String(b)
     return EXPORT_PRESETS.find((exportPreset) => (
       Object.entries(exportPreset.settings).every(([key, value]) => isEqual(settings[key], value))
@@ -822,6 +890,27 @@ function ExportPanel() {
     return Number(settings.fps) || 24
   }
 
+  const rtxUpscaleEnabled = settings.postProcessUpscale === 'rtx-4k'
+  const rtxSourceResolution = resolveResolution()
+  const rtxTargetResolution = resolveRtx4kDimensions(rtxSourceResolution.width, rtxSourceResolution.height)
+  const rtxToggleDisabledReason = !window.electronAPI?.checkRtxVideoUpscaleRuntime
+    ? 'RTX upscale is available only in the Velorn desktop app.'
+    : window.electronAPI.platform !== 'win32'
+      ? 'NVIDIA RTX Video Super Resolution is currently available on Windows only.'
+      : settings.format !== 'mp4'
+        ? 'NVIDIA RTX Video Super Resolution currently requires an MP4 export.'
+        : null
+
+  const rtxReadinessText = rtxReadiness.status === 'checking'
+    ? 'Checking the direct NVIDIA RTX runtime...'
+    : rtxReadiness.status === 'installing'
+      ? (rtxInstallProgress?.message || 'Installing the optional NVIDIA RTX runtime...')
+      : rtxReadiness.status === 'ready'
+        ? `Direct RTX engine ready${rtxReadiness.gpu ? ` on ${rtxReadiness.gpu}` : ''}.`
+        : rtxReadiness.status === 'error'
+          ? rtxReadiness.error
+          : 'Runs directly on NVIDIA RTX. ComfyUI is not required. Optional runtime is about 1 GB.'
+
   const resolveRange = () => {
     if (settings.range === 'inout' && inPoint !== null && outPoint !== null) {
       return { start: Math.min(inPoint, outPoint), end: Math.max(inPoint, outPoint) }
@@ -864,6 +953,9 @@ function ExportPanel() {
     if (pixelCount >= 3840 * 2160) {
       hints.push('4K exports are heavy. Consider proxies or lower resolution for previews.')
     }
+    if (settings.postProcessUpscale === 'rtx-4k') {
+      hints.push('RTX 4K runs after the normal render and streams one frame at a time to keep memory bounded.')
+    }
     if (settings.useProxyMedia && proxyCoverage.ready > 0) {
       hints.push(`Proxy export will use ${proxyCoverage.ready}/${proxyCoverage.total} ready video prox${proxyCoverage.ready === 1 ? 'y' : 'ies'}.`)
     } else if (settings.useProxyMedia && proxyCoverage.total > 0) {
@@ -905,8 +997,15 @@ function ExportPanel() {
   }, [clips, transitions, tracks, settings, getCurrentTimelineSettings, nvencStatus, proxyCoverage])
 
   const runExportJob = async (jobSettings, labelOverride = null) => {
+    const shouldRunRtxUpscale = jobSettings.postProcessUpscale === 'rtx-4k'
     if (jobSettings.format === 'gif' || jobSettings.format === 'png-seq') {
       throw new Error('GIF and PNG sequence export are not wired yet.')
+    }
+    if (shouldRunRtxUpscale && jobSettings.format !== 'mp4') {
+      throw new Error('NVIDIA RTX Video Super Resolution currently requires an MP4 export.')
+    }
+    if (shouldRunRtxUpscale && window.electronAPI?.platform !== 'win32') {
+      throw new Error('NVIDIA RTX Video Super Resolution is currently available on Windows only.')
     }
     if (jobSettings.useHardwareEncoder && nvencStatus.checked) {
       const codecSupported = jobSettings.videoCodec === 'h265'
@@ -924,6 +1023,15 @@ function ExportPanel() {
     setExportError(null)
     setExportResult(null)
     setIsExporting(true)
+
+    if (shouldRunRtxUpscale) {
+      setExportStatus('Checking the direct NVIDIA RTX runtime...')
+      const readiness = await handleCheckRtxSetup()
+      if (!readiness.ready) {
+        setIsExporting(false)
+        throw new Error(readiness.error || 'The NVIDIA RTX runtime is not ready.')
+      }
+    }
 
     const { width, height } = resolveResolution()
     const fps = resolveFps()
@@ -968,16 +1076,30 @@ function ExportPanel() {
           : (jobSettings.format === 'webm' ? 'webm' : (jobSettings.format === 'prores' ? 'mov' : 'mp4'))
         const outputFolder = await window.electronAPI.pathJoin(currentProjectHandle, 'renders')
         await window.electronAPI.createDirectory(outputFolder)
-        const defaultPath = await window.electronAPI.pathJoin(outputFolder, `${options.filename}.${outputExtension}`)
-        const outputPath = await window.electronAPI.saveFileDialog({
-          title: 'Export Timeline',
+        const outputBaseName = shouldRunRtxUpscale ? `${options.filename}_rtx4k` : options.filename
+        const defaultPath = await window.electronAPI.pathJoin(outputFolder, `${outputBaseName}.${outputExtension}`)
+        const finalOutputPath = await window.electronAPI.saveFileDialog({
+          title: shouldRunRtxUpscale ? 'Export Timeline with NVIDIA RTX 4K Upscale' : 'Export Timeline',
           defaultPath,
           filters: [{ name: outputExtension.toUpperCase(), extensions: [outputExtension] }],
         })
-        if (!outputPath) {
+        if (!finalOutputPath) {
           setIsExporting(false)
           throw new Error('Export cancelled')
         }
+        const sourceOutputPath = shouldRunRtxUpscale
+          ? await window.electronAPI.pathJoin(outputFolder, `.velorn-rtx-source-${Date.now()}.mp4`)
+          : finalOutputPath
+        const postProcess = shouldRunRtxUpscale
+          ? {
+              type: 'rtx-4k',
+              outputPath: finalOutputPath,
+              sourceWidth: width,
+              sourceHeight: height,
+              videoCodec: jobSettings.videoCodec,
+              quality: jobSettings.rtxUpscaleQuality || RTX_VIDEO_UPSCALE_DEFAULTS.quality,
+            }
+          : null
         const state = {
           timeline: { clips, tracks, transitions },
           assets: assets.map((a) => ({
@@ -993,12 +1115,16 @@ function ExportPanel() {
             maskFrames: a.maskFrames?.map((f) => ({ ...f, url: undefined })),
           })),
         }
-        await window.electronAPI.runExportInWorker({
+        const workerStart = await window.electronAPI.runExportInWorker({
           projectPath: currentProjectHandle,
-          outputPath,
-          options: { ...options, outputPath },
+          outputPath: sourceOutputPath,
+          options: { ...options, outputPath: sourceOutputPath },
+          postProcess,
           state,
         })
+        if (workerStart?.success === false) {
+          throw new Error(workerStart.error || 'Could not start the export worker.')
+        }
         return
       } catch (err) {
         setExportError(err?.message || 'Export failed')
@@ -1365,6 +1491,90 @@ function ExportPanel() {
                     <span className="text-[10px] text-sf-text-muted">
                       Skips PNG frame files during export
                     </span>
+                  </div>
+
+                  <div className="mt-3 border-t border-sf-dark-700 pt-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <div className="flex min-w-0 items-center gap-1.5 text-xs font-medium text-sf-text-primary">
+                        <Sparkles className="h-3.5 w-3.5 shrink-0 text-sf-accent" />
+                        <span>NVIDIA RTX 4K upscale</span>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-label="NVIDIA RTX 4K upscale"
+                        aria-checked={rtxUpscaleEnabled}
+                        disabled={Boolean(rtxToggleDisabledReason) || isExporting || rtxReadiness.status === 'installing'}
+                        onClick={handleToggleRtxUpscale}
+                        title={rtxToggleDisabledReason || 'Upscale the finished MP4 directly with NVIDIA RTX Video Super Resolution'}
+                        className={`relative h-5 w-9 shrink-0 rounded-full border transition-colors ${
+                          rtxUpscaleEnabled
+                            ? 'border-sf-accent bg-sf-accent'
+                            : 'border-sf-dark-600 bg-sf-dark-800'
+                        } ${(rtxToggleDisabledReason || isExporting || rtxReadiness.status === 'installing') ? 'cursor-not-allowed opacity-50' : ''}`}
+                      >
+                        <span className={`absolute left-0.5 top-0.5 h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                          rtxUpscaleEnabled ? 'translate-x-4' : 'translate-x-0'
+                        }`} />
+                      </button>
+                    </div>
+                    <div className="mt-0.5 text-[10px] text-sf-text-muted">
+                      Runs after the normal render. Target: {rtxTargetResolution.width}x{rtxTargetResolution.height}.
+                    </div>
+
+                    {rtxUpscaleEnabled && (
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <label className="text-[10px] uppercase tracking-wider text-sf-text-muted" htmlFor="rtx-upscale-quality">
+                          Quality
+                        </label>
+                        <select
+                          id="rtx-upscale-quality"
+                          value={settings.rtxUpscaleQuality || RTX_VIDEO_UPSCALE_DEFAULTS.quality}
+                          onChange={(event) => handleSettingChange('rtxUpscaleQuality', event.target.value)}
+                          disabled={rtxReadiness.status === 'installing'}
+                          className="rounded border border-sf-dark-600 bg-sf-dark-800 px-2 py-1 text-xs text-sf-text-primary focus:border-sf-accent focus:outline-none disabled:opacity-50"
+                        >
+                          {RTX_VIDEO_UPSCALE_QUALITY_OPTIONS.map((option) => (
+                            <option key={option.id} value={option.id}>{option.label}</option>
+                          ))}
+                        </select>
+                        <button
+                          type="button"
+                          onClick={() => void handleCheckRtxSetup()}
+                          disabled={rtxReadiness.status === 'checking' || rtxReadiness.status === 'installing'}
+                          className="text-[10px] text-sf-accent hover:text-sf-accent-hover disabled:opacity-50"
+                        >
+                          Check setup
+                        </button>
+                        {rtxReadiness.status === 'error' && rtxReadiness.installAvailable && (
+                          <button
+                            type="button"
+                            onClick={() => void handleInstallRtxRuntime()}
+                            className="rounded border border-sf-accent/50 bg-sf-accent/10 px-2 py-1 text-[10px] font-medium text-sf-accent hover:bg-sf-accent/20"
+                          >
+                            Install RTX runtime
+                          </button>
+                        )}
+                      </div>
+                    )}
+
+                    {rtxReadiness.status === 'installing' && (
+                      <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-sf-dark-800">
+                        <div
+                          className="h-full bg-sf-accent transition-[width]"
+                          style={{ width: `${Math.max(2, Math.min(100, Number(rtxInstallProgress?.percent) || 2))}%` }}
+                        />
+                      </div>
+                    )}
+                    <div className={`mt-1 text-[10px] ${
+                      rtxReadiness.status === 'error'
+                        ? 'text-sf-warning'
+                        : rtxReadiness.status === 'ready'
+                          ? 'text-sf-accent'
+                          : 'text-sf-text-muted'
+                    }`}>
+                      {rtxToggleDisabledReason || rtxReadinessText}
+                    </div>
                   </div>
                 </div>
                 

--- a/src/components/ExportWorker.jsx
+++ b/src/components/ExportWorker.jsx
@@ -3,6 +3,7 @@ import useTimelineStore from '../stores/timelineStore'
 import useAssetsStore from '../stores/assetsStore'
 import useProjectStore from '../stores/projectStore'
 import exportTimeline from '../services/exporter'
+import { runRtxVideoUpscale } from '../services/rtxVideoUpscale'
 
 const isElectron = () => typeof window !== 'undefined' && window.electronAPI != null
 
@@ -14,7 +15,7 @@ export default function ExportWorker() {
     started.current = true
 
     window.electronAPI.onExportJob(async (job) => {
-      const { projectPath, outputPath, options, state: jobState } = job
+      const { projectPath, outputPath, options, postProcess, state: jobState } = job
       console.log('[ExportWorker] Job received', { projectPath: !!projectPath, outputPath: !!outputPath, assetsCount: jobState?.assets?.length, clipsCount: jobState?.timeline?.clips?.length })
       if (!projectPath || !outputPath || !jobState) {
         window.electronAPI.sendExportError?.('Invalid export job')
@@ -59,13 +60,68 @@ export default function ExportWorker() {
           { ...options, outputPath, signal: abortController.signal },
           (progress) => {
             if (progress?.progress % 20 < 5) console.log('[ExportWorker] Progress', progress?.progress, progress?.status)
-            window.electronAPI.sendExportProgress?.(progress)
+            if (postProcess?.type === 'rtx-4k') {
+              window.electronAPI.sendExportProgress?.({
+                ...progress,
+                progress: typeof progress?.progress === 'number' ? progress.progress * 0.6 : progress?.progress,
+                status: `Source render - ${progress?.status || 'Rendering timeline'}`,
+              })
+            } else {
+              window.electronAPI.sendExportProgress?.(progress)
+            }
           }
         )
+        let finalResult = result
+        if (postProcess?.type === 'rtx-4k') {
+          let upscaleComplete = false
+          try {
+            console.log('[ExportWorker] Starting direct RTX 4K post-process', {
+              sourcePath: outputPath,
+              finalPath: postProcess.outputPath,
+              quality: postProcess.quality,
+            })
+            const upscaleResult = await runRtxVideoUpscale({
+              inputPath: outputPath,
+              outputPath: postProcess.outputPath,
+              sourceWidth: postProcess.sourceWidth || options?.width,
+              sourceHeight: postProcess.sourceHeight || options?.height,
+              videoCodec: postProcess.videoCodec || options?.videoCodec,
+              quality: postProcess.quality,
+              signal: abortController.signal,
+              onStatus: (status) => {
+                window.electronAPI.sendExportProgress?.({
+                  frame: status?.frame,
+                  totalFrames: status?.totalFrames,
+                  etaSeconds: status?.etaSeconds,
+                  progress: 60 + ((Number(status?.progress) || 0) * 0.4),
+                  status: status?.statusMessage || 'Running direct NVIDIA RTX 4K upscale...',
+                })
+              },
+            })
+            upscaleComplete = true
+            finalResult = {
+              ...result,
+              ...upscaleResult,
+              outputPath: postProcess.outputPath,
+              sourceExport: result,
+              encoderUsed: `${result?.encoderUsed || 'timeline export'} + NVIDIA RTX Video Super Resolution`,
+            }
+          } catch (error) {
+            if (abortController.signal.aborted || error?.name === 'AbortError') throw error
+            throw new Error(`${error?.message || 'RTX upscale failed'} The normal source render was kept at ${outputPath}.`)
+          } finally {
+            if ((upscaleComplete || abortController.signal.aborted) && window.electronAPI?.deleteFile) {
+              const cleanup = await window.electronAPI.deleteFile(outputPath).catch(() => null)
+              if (cleanup?.success === false) {
+                console.warn('[ExportWorker] Could not delete RTX source render', cleanup.error)
+              }
+            }
+          }
+        }
         // Stringify: the worker's console reaches export-worker.log via the
         // console-message event, which flattens objects to "[object Object]".
-        console.log('[ExportWorker] Export complete', JSON.stringify(result))
-        window.electronAPI.sendExportComplete?.(result)
+        console.log('[ExportWorker] Export complete', JSON.stringify(finalResult))
+        window.electronAPI.sendExportComplete?.(finalResult)
       } catch (err) {
         const errMsg = err && typeof err === 'object' && err instanceof Event
           ? `Export error (${err.type}): ${err.target?.error?.message || err.target?.statusText || 'see console'}`

--- a/src/config/rtxVideoUpscaleConfig.js
+++ b/src/config/rtxVideoUpscaleConfig.js
@@ -1,0 +1,35 @@
+export const RTX_VIDEO_UPSCALE_QUALITY_OPTIONS = Object.freeze([
+  { id: 'LOW', label: 'Low' },
+  { id: 'MEDIUM', label: 'Medium' },
+  { id: 'HIGH', label: 'High' },
+  { id: 'ULTRA', label: 'Ultra' },
+])
+
+export const RTX_VIDEO_UPSCALE_DEFAULTS = Object.freeze({
+  quality: 'HIGH',
+  longSide: 3840,
+})
+
+export function normalizeRtxUpscaleQuality(value = '') {
+  const normalized = String(value || '').trim().toUpperCase()
+  return RTX_VIDEO_UPSCALE_QUALITY_OPTIONS.some((option) => option.id === normalized)
+    ? normalized
+    : RTX_VIDEO_UPSCALE_DEFAULTS.quality
+}
+
+export function resolveRtxNvencEncoder(videoCodec = 'h264') {
+  return String(videoCodec || '').trim().toLowerCase() === 'h265'
+    ? 'hevc_nvenc'
+    : 'h264_nvenc'
+}
+
+export function resolveRtx4kDimensions(width = 1920, height = 1080) {
+  const sourceWidth = Math.max(2, Number(width) || 1920)
+  const sourceHeight = Math.max(2, Number(height) || 1080)
+  const scale = Math.max(1, RTX_VIDEO_UPSCALE_DEFAULTS.longSide / Math.max(sourceWidth, sourceHeight))
+  const makeMultipleOfEight = (value) => Math.max(8, Math.round(value / 8) * 8)
+  return {
+    width: makeMultipleOfEight(sourceWidth * scale),
+    height: makeMultipleOfEight(sourceHeight * scale),
+  }
+}

--- a/src/services/rtxVideoUpscale.js
+++ b/src/services/rtxVideoUpscale.js
@@ -1,0 +1,126 @@
+import {
+  RTX_VIDEO_UPSCALE_DEFAULTS,
+  normalizeRtxUpscaleQuality,
+  resolveRtx4kDimensions,
+  resolveRtxNvencEncoder,
+} from '../config/rtxVideoUpscaleConfig'
+
+function createAbortError() {
+  const error = new Error('RTX upscale cancelled')
+  error.name = 'AbortError'
+  return error
+}
+
+function createJobId() {
+  const token = globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  return `rtx-${token}`
+}
+
+export async function checkRtxVideoUpscaleReadiness() {
+  if (!window.electronAPI?.checkRtxVideoUpscaleRuntime) {
+    return {
+      ready: false,
+      installAvailable: false,
+      error: 'RTX upscale is available only in the Velorn desktop app.',
+    }
+  }
+  return await window.electronAPI.checkRtxVideoUpscaleRuntime()
+}
+
+export async function installRtxVideoUpscaleRuntime(options = {}) {
+  const { onStatus = () => {} } = options
+  if (!window.electronAPI?.installRtxVideoUpscaleRuntime) {
+    throw new Error('The RTX runtime installer is unavailable. Restart Velorn and try again.')
+  }
+  const unsubscribe = window.electronAPI.onRtxVideoUpscaleSetupProgress?.((status) => onStatus(status))
+  try {
+    const result = await window.electronAPI.installRtxVideoUpscaleRuntime()
+    if (!result?.success) throw new Error(result?.error || 'Could not install the NVIDIA RTX runtime.')
+    return result
+  } finally {
+    unsubscribe?.()
+  }
+}
+
+export async function runRtxVideoUpscale(options = {}) {
+  const {
+    inputPath = '',
+    outputPath = '',
+    sourceWidth = 1920,
+    sourceHeight = 1080,
+    videoCodec = 'h264',
+    quality = RTX_VIDEO_UPSCALE_DEFAULTS.quality,
+    signal = null,
+    onStatus = () => {},
+  } = options
+  if (!window.electronAPI?.runRtxVideoUpscale) {
+    throw new Error('Direct RTX upscaling is unavailable. Restart Velorn and try again.')
+  }
+  if (!inputPath) throw new Error('RTX upscale requires a source export path.')
+  if (!outputPath) throw new Error('RTX upscale requires a final output path.')
+  if (signal?.aborted) throw createAbortError()
+
+  const target = resolveRtx4kDimensions(sourceWidth, sourceHeight)
+  const jobId = createJobId()
+  const unsubscribe = window.electronAPI.onRtxVideoUpscaleProgress?.((status) => {
+    if (status?.jobId !== jobId) return
+    if (status.event === 'progress') {
+      onStatus({
+        status: 'running',
+        progress: Number(status.percent) || 0,
+        frame: status.frame,
+        totalFrames: status.totalFrames,
+        fps: status.fps,
+        etaSeconds: status.etaSeconds,
+        statusMessage: `Upscaling to ${target.width}x${target.height} with NVIDIA RTX... ${Math.round(Number(status.percent) || 0)}%`,
+      })
+      return
+    }
+    if (status.event === 'start') {
+      onStatus({
+        status: 'running',
+        progress: 0,
+        frame: 0,
+        totalFrames: status.totalFrames,
+        statusMessage: `Starting direct NVIDIA RTX upscale to ${target.width}x${target.height}...`,
+      })
+    }
+  })
+  const abort = () => {
+    window.electronAPI.cancelRtxVideoUpscale?.(jobId).catch(() => {})
+  }
+
+  try {
+    signal?.addEventListener?.('abort', abort, { once: true })
+    const result = await window.electronAPI.runRtxVideoUpscale({
+      jobId,
+      inputPath,
+      outputPath,
+      width: target.width,
+      height: target.height,
+      quality: normalizeRtxUpscaleQuality(quality),
+      encoder: resolveRtxNvencEncoder(videoCodec),
+      cq: 18,
+    })
+    if (signal?.aborted || result?.cancelled) throw createAbortError()
+    if (!result?.success) throw new Error(result?.error || 'NVIDIA RTX upscale failed.')
+    onStatus({
+      status: 'complete',
+      progress: 100,
+      statusMessage: 'NVIDIA RTX 4K upscale complete.',
+    })
+    return {
+      ...result,
+      outputPath,
+      sourcePath: inputPath,
+      width: target.width,
+      height: target.height,
+      quality: normalizeRtxUpscaleQuality(quality),
+      videoCodec: String(videoCodec || '').toLowerCase() === 'h265' ? 'h265' : 'h264',
+      encoderUsed: 'NVIDIA RTX Video Super Resolution',
+    }
+  } finally {
+    signal?.removeEventListener?.('abort', abort)
+    unsubscribe?.()
+  }
+}

--- a/tests/rtxVideoUpscale.test.js
+++ b/tests/rtxVideoUpscale.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+const path = require('node:path')
+
+const {
+  RUNTIME_PACKAGES,
+  RUNTIME_WHEELS,
+  buildRtxHelperArgs,
+  getComfyPythonCandidates,
+  getManagedRuntimePaths,
+  getRuntimeCandidates,
+  normalizeQuality,
+} = require('../electron/rtxVideoUpscale')
+
+test('pins and verifies every standalone RTX runtime wheel', () => {
+  assert.deepEqual(RUNTIME_PACKAGES, [
+    'numpy==2.2.6',
+    'fastrlock==0.8.3',
+    'cupy-cuda12x==13.6.0',
+    'nvidia-vfx==0.1.0.1',
+  ])
+  assert.equal(RUNTIME_WHEELS.filter((wheel) => wheel.bootstrap).length, 1)
+  assert.ok(RUNTIME_WHEELS.some((wheel) => wheel.package === 'nvidia-vfx'))
+  for (const wheel of RUNTIME_WHEELS) {
+    assert.match(wheel.url, /^https:\/\//)
+    assert.match(wheel.sha256, /^[a-f0-9]{64}$/)
+    assert.ok(wheel.size > 0)
+  }
+})
+
+test('normalizes supported RTX quality values', () => {
+  assert.equal(normalizeQuality('ultra'), 'ULTRA')
+  assert.equal(normalizeQuality('unexpected'), 'HIGH')
+})
+
+test('keeps the standalone runtime ahead of compatible local fallbacks', () => {
+  const candidates = getRuntimeCandidates({
+    userDataPath: 'C:\\VelornData',
+    comfyRootPath: 'D:\\ComfyUI_windows_portable\\ComfyUI',
+  })
+  assert.equal(candidates[0].kind, 'managed')
+  assert.equal(candidates[0].pythonPath, path.join('C:\\VelornData', 'rtx-runtime-v1', 'python', 'python.exe'))
+  assert.ok(candidates.some((entry) => (
+    entry.pythonPath === path.join('D:\\ComfyUI_windows_portable', 'python_embeded', 'python.exe')
+  )))
+})
+
+test('finds common portable ComfyUI Python layouts as compatibility fallbacks', () => {
+  const candidates = getComfyPythonCandidates('D:\\Apps\\ComfyUI_windows_portable\\ComfyUI')
+  assert.ok(candidates.includes(path.join('D:\\Apps\\ComfyUI_windows_portable', 'python_embeded', 'python.exe')))
+  assert.ok(candidates.includes(path.join('D:\\Apps\\ComfyUI_windows_portable', 'python_embedded', 'python.exe')))
+})
+
+test('builds a bounded direct helper command', () => {
+  const args = buildRtxHelperArgs({
+    helperPath: 'C:\\Velorn\\rtx_vsr_stream.py',
+    inputPath: 'C:\\Renders\\source.mp4',
+    outputPath: 'C:\\Renders\\final.mp4',
+    width: 2160,
+    height: 3840,
+    quality: 'medium',
+    ffmpegPath: 'C:\\Velorn\\ffmpeg.exe',
+    ffprobePath: 'C:\\Velorn\\ffprobe.exe',
+  })
+  assert.deepEqual(args.slice(0, 11), [
+    'C:\\Velorn\\rtx_vsr_stream.py',
+    '--input', 'C:\\Renders\\source.mp4',
+    '--output', 'C:\\Renders\\final.mp4',
+    '--width', '2160',
+    '--height', '3840',
+    '--quality', 'MEDIUM',
+  ])
+})
+
+test('returns stable managed runtime paths', () => {
+  const runtime = getManagedRuntimePaths('C:\\Users\\Editor\\AppData\\Roaming\\Velorn')
+  assert.equal(runtime.pythonPath, path.join(runtime.root, 'python', 'python.exe'))
+  assert.equal(runtime.manifestPath, path.join(runtime.root, 'runtime.json'))
+})

--- a/tests/rtxVideoUpscaleConfig.test.js
+++ b/tests/rtxVideoUpscaleConfig.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  normalizeRtxUpscaleQuality,
+  resolveRtx4kDimensions,
+  resolveRtxNvencEncoder,
+} from '../src/config/rtxVideoUpscaleConfig.js'
+
+test('preserves landscape and vertical aspect ratios at a 4K long side', () => {
+  assert.deepEqual(resolveRtx4kDimensions(1920, 1080), { width: 3840, height: 2160 })
+  assert.deepEqual(resolveRtx4kDimensions(1080, 1920), { width: 2160, height: 3840 })
+})
+
+test('rounds unusual aspect ratios to dimensions accepted by the RTX runtime', () => {
+  const result = resolveRtx4kDimensions(1000, 777)
+  assert.equal(result.width, 3840)
+  assert.equal(result.height % 8, 0)
+})
+
+test('falls back to high quality for unknown values', () => {
+  assert.equal(normalizeRtxUpscaleQuality('low'), 'LOW')
+  assert.equal(normalizeRtxUpscaleQuality('not-a-quality'), 'HIGH')
+})
+
+test('maps the selected delivery codec to the matching NVENC encoder', () => {
+  assert.equal(resolveRtxNvencEncoder('h264'), 'h264_nvenc')
+  assert.equal(resolveRtxNvencEncoder('h265'), 'hevc_nvenc')
+  assert.equal(resolveRtxNvencEncoder('unexpected'), 'h264_nvenc')
+})


### PR DESCRIPTION
## Summary

- add a standalone NVIDIA RTX Video Super Resolution export path that does not require a running ComfyUI process
- stream frames through the GPU one at a time to keep system and GPU memory bounded
- preserve landscape and vertical aspect ratios, audio, and the selected H.264 or H.265 delivery codec
- add managed runtime installation, integrity verification, progress, cancellation, failure recovery, and export controls
- prepare Velorn v0.3.24 release notes and package metadata

## Validation

- 10 focused RTX unit tests pass
- production Vite build passes
- Windows unpacked Electron package builds successfully and contains the helper plus FFmpeg tools
- packaged UI recognizes the standalone runtime on an RTX 5090
- 1080p to 4K, vertical 4K, H.264, H.265, audio preservation, exact frame count, and cancellation were exercised locally

- [x] I have read and agree to the Contributor License Agreement
