### PR TITLE
Recover tested local fixes onto clean main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,11 @@
 
 - The product/app is called Velorn. Do not refer to it as ComfyStudio in user-facing text, MCP metadata, docs, or chat.
 - `comfystudio` may still appear as a legacy package name, protocol/file-extension namespace, bridge identifier, repository URL, or backward-compatible MCP alias. Treat those as internal compatibility identifiers only.
+- Read `docs/AI_PROJECT_CONTEXT.md` before substantial implementation work.
+- Read `docs/AI_CURRENT_HANDOFF.md` for the current branch, migration, and verification state.
+- Read `docs/AI_RELEASE_HANDOFF.md` before commits, tags, releases, or GitHub Actions work.
+- Velorn is a creator-facing desktop video editor. Preserve simple guided workflows; do not turn routine product surfaces into ComfyUI-style node configuration.
+- Keep project files portable. Store project-owned media paths relative to the project when possible and preserve legacy project compatibility.
+- Treat generation and editing as separate layers: editing, captions, and export must not require ComfyUI unless the specific feature is explicitly a ComfyUI workflow.
+- Agent write actions should inspect first, preview when supported, and use Velorn's existing undo/checkpoint paths.
+- Keep changes narrowly scoped and test risky behavior at the renderer, Electron IPC, and packaged-platform boundaries it touches.

--- a/docs/AI_CURRENT_HANDOFF.md
+++ b/docs/AI_CURRENT_HANDOFF.md
@@ -1,0 +1,76 @@
+# Current AI Handoff
+
+Last updated: 2026-08-12
+
+This is the live state for moving Velorn development from the old Windows checkout to a clean repository state that can be cloned on Ubuntu.
+
+## Clean Migration Branch
+
+- Worktree: `C:\Users\papa\Documents\coding_projects\general\velorn-migration-cleanup`
+- Branch: `codex/migration-cleanup`
+- Base: `origin/main` at `0ca5db5` (`v0.3.25`)
+- This branch is intentionally separate from the old dirty `main` checkout.
+
+Recovered, tested, and committed changes:
+
+1. `592cf30` - Add a Settings toggle that hides the Comfy.org credit balance and stops its polling while hidden.
+2. `fb09ce6` - Refresh paused text/shape/caption rasters when timeline or asset state changes.
+3. `bcea1de` - Recognize namespaced `model.prompt` inputs in imported workflows, with MiniMax H3 regression coverage.
+
+The production renderer build passed after every feature. Electron main/preload syntax checks pass. All ten existing `package.json` test scripts plus the two recovered-feature suites pass: 82 tests total, 0 failures.
+
+## Preserved Windows Checkout
+
+The original checkout remains untouched at:
+
+`C:\Users\papa\Documents\coding_projects\general\comfyui_editing`
+
+At migration start it was on local `main` at `6b450ce` (`v0.3.23`), three commits behind `origin/main`, with 20 modified tracked files and many untracked files. It contains useful fixes mixed with obsolete experiments, generated review media, drafts, and screenshots.
+
+A safety inventory exists at:
+
+`C:\Users\papa\Documents\coding_projects\general\velorn-migration-backup-2026-08-12`
+
+It contains:
+
+- `tracked-changes.patch`
+- `git-status.txt`
+- `untracked-files.txt`
+- `recent-history.txt`
+
+Do not reset, pull, delete, or repurpose the old checkout until the maintainer has verified the clean branch and explicitly approves cleanup.
+
+## Deliberate Decisions
+
+- The old ComfyUI-based RTX upscale implementation was not migrated. Standalone NVIDIA RTX 4K export already shipped upstream in v0.3.24.
+- My Workflows MCP support was not recopied because it already shipped upstream in v0.3.25.
+- Manual title-bar/window dragging and unload changes were reviewed but not migrated. They are platform-sensitive, mixed with unrelated work, and lack a clear verification record. They remain recoverable in the old checkout and backup patch.
+- Generated timeline contact sheets, output media, mockups, marketing drafts, and old handoff notes were not brought into the clean branch.
+- No old worktree has been deleted.
+
+## Remaining Work
+
+1. Launch `npm run electron:dev` for maintainer UI verification of:
+   - Settings credit-balance toggle.
+   - Immediate paused text-clip preview updates.
+   - A custom imported workflow using `model.prompt` if a suitable graph is available.
+2. Review the final branch diff and commit these context documents.
+3. Push or merge only after the maintainer approves the clean result.
+4. On Ubuntu, clone the repository fresh after the intended branch is merged/pushed; do not copy `node_modules` or the Windows `.codex` directory.
+5. Keep Windows available for Windows packaging, Azure signing behavior, and NVIDIA RTX export testing.
+
+## Ubuntu First Session
+
+After cloning the intended Git branch on Ubuntu:
+
+```bash
+npm ci
+npm run build
+npm run electron:dev
+```
+
+Start a new Codex task with:
+
+> Read AGENTS.md, docs/AI_PROJECT_CONTEXT.md, docs/AI_CURRENT_HANDOFF.md, and docs/AI_RELEASE_HANDOFF.md. Inspect git status and recent history, then summarize the product, architecture, current branch state, and next safe step before changing files.
+
+Local projects, ComfyUI models, credentials, signing secrets, generated media, and machine-specific settings are not repository context and must be migrated separately and deliberately.

--- a/docs/AI_PROJECT_CONTEXT.md
+++ b/docs/AI_PROJECT_CONTEXT.md
@@ -1,0 +1,152 @@
+# Velorn Project Context
+
+This document gives a new coding agent enough durable context to work on Velorn without relying on a previous chat or one developer machine.
+
+## Product
+
+Velorn is an open-source desktop AI video workstation. It combines a real multi-track editor with guided AI generation, project asset management, captions, effects, export, and a local MCP control layer for agents.
+
+The founder's background is VFX and editorial. Product decisions should reflect real production workflows while keeping AI video approachable for people who do not want to operate a node graph.
+
+Core product principles:
+
+- Make the common creative path simple and guided.
+- Keep outputs editable on a real timeline.
+- Let advanced users bring custom workflows without making every user manage nodes.
+- Keep local editing useful without ComfyUI. Only generation features and explicitly ComfyUI-backed utilities should require it.
+- Prefer visible review and iteration over one-shot automation for creative work.
+- Preserve user projects and existing behavior before optimizing architecture.
+
+## Technical Shape
+
+Velorn is an Electron desktop application with a React renderer.
+
+- **Electron main process:** `electron/main.js`
+  Owns native windows, filesystem IPC, dialogs, FFmpeg processes, export workers, ComfyUI launching, workflow installation, and the local MCP server.
+- **Preload bridge:** `electron/preload.js`
+  Exposes a limited `window.electronAPI` surface to the renderer. Renderer code should use this bridge rather than Node APIs directly.
+- **React renderer:** `src/App.jsx` and `src/components/`
+  Owns visible workspaces, editor interaction, preview, Generate, captions, settings, and export UI.
+- **State:** `src/stores/`
+  Zustand stores hold project, timeline, asset, workflow, generation monitor, and transient UI state. Some slices persist to local storage; the project file remains the durable creative document.
+- **Services:** `src/services/`
+  Domain logic for projects, workflows, generation, captions, media preparation, export, MCP actions, and filesystem abstraction.
+- **Configuration:** `src/config/`
+  Built-in workflow registries, setup catalogs, model/node dependencies, and other product configuration.
+
+Electron main and renderer are separate processes. If renderer code needs native filesystem, subprocess, or OS behavior, add a narrow IPC handler in `electron/main.js` and expose only the required method through `electron/preload.js`.
+
+## Project Data
+
+Each Velorn project is a folder with project-owned assets, renders, cache data, autosaves, and a `project.comfystudio` JSON document. The legacy filename is retained for compatibility and should not appear as the product name in user-facing text.
+
+Important rules:
+
+- Prefer project-relative media paths so projects can move between Windows, macOS, and Linux.
+- Keep absolute-path fallback and relinking behavior intact for older projects.
+- Do not put generated test media or personal projects in the repository.
+- Project hydration coordinates `projectStore`, `timelineStore`, and `assetsStore`; changing one contract can affect project opening, autosave, MCP snapshots, and export.
+- Timeline edits should use existing store actions so undo, dirty tracking, autosave, and MCP snapshots stay accurate.
+
+## Editing And Preview
+
+The timeline and editor are driven mainly by `timelineStore` and `assetsStore`. Preview is assembled from timeline clips rather than delegated to a traditional NLE engine.
+
+`CanvasPreviewRenderer.jsx` combines video/image sources, text and shape rasters, masks, compositing, transitions, transforms, and effects. Cache keys and source versions matter: a paused frame may need repainting even when the playhead frame number has not changed.
+
+Export aims to match the editor but has multiple paths:
+
+- Native/FFmpeg paths are used when the edit can be represented safely and efficiently.
+- Canvas/frame-pipe rendering is used for visual states that need the renderer's composition logic.
+- Export runs in a hidden Electron worker window to isolate heavy rendering from the main UI.
+- Hardware encoding and Windows-only NVIDIA RTX upscaling are optional capabilities and must have clear availability/fallback behavior.
+
+Do not assume browser preview behavior, FFmpeg output, and packaged Electron behavior are identical. Test the boundary affected by a change.
+
+## ComfyUI And Generation
+
+Velorn talks to a separately installed local ComfyUI server, normally at `127.0.0.1:8188`. It can launch configured local installations and embeds ComfyUI as an advanced workspace.
+
+Generation supports:
+
+- Curated built-in local and cloud workflows.
+- Guided creators such as Music Video, UGC, Business Ad, and Short Film.
+- Imported API-format workflows and workflows captured through the Velorn Bridge.
+- Custom workflow bindings for prompts, media inputs, seeds, dimensions, duration, FPS, and output nodes.
+- Dependency inspection and approved installation of custom nodes/models when metadata is available.
+
+Custom workflow support is important. Do not restrict imported workflows to the bundled catalog. Detection code must tolerate real-world node naming while avoiding accidental binding to the wrong string or media field.
+
+Cloud workflows may spend credits. Keep costs visible and require explicit approval before an agent queues paid work.
+
+## Agents And MCP
+
+Velorn starts a loopback MCP server at `http://127.0.0.1:19790/mcp`. The main server is implemented in `electron/mcpServer.js`; renderer-side action handling lives in MCP services and application state.
+
+MCP is a control layer over the same visible project, not a separate project model. Agents can inspect media and timelines, review frames, edit, generate, caption, and export.
+
+Safety expectations:
+
+1. Read before writing.
+2. Resolve ambiguous timeline targets before mutation.
+3. Use `previewOnly` where supported.
+4. Ask for approval before file writes, timeline changes, generation, credit spending, model/node installation, or export.
+5. Use project checkpoints for risky multi-step work.
+6. Keep the MCP server loopback-only.
+
+See `docs/MCP.md` for the current tool catalog and recipes.
+
+## Development
+
+Install and run:
+
+```bash
+npm ci
+npm run electron:dev
+```
+
+Production renderer build:
+
+```bash
+npm run build
+```
+
+Tests are currently focused Node test scripts rather than one universal suite. Inspect the `test:*` scripts in `package.json` and run tests covering the changed domain. Direct service tests commonly use:
+
+```bash
+node --experimental-default-type=module --test path/to/test.js
+```
+
+For Electron CommonJS files, a useful first syntax check is:
+
+```bash
+node --check electron/main.js
+node --check electron/preload.js
+```
+
+Build warnings about existing large chunks and mixed dynamic/static imports are known. Do not confuse them with a failed build, but do not add avoidable bundle growth.
+
+## Git And Releases
+
+- Repository: `https://github.com/VelornLabs/velorn`
+- License: GPL-3.0-only.
+- Use focused branches and commits. Do not mix generated media, experiments, and release work into feature commits.
+- Never discard a dirty checkout to update it. Make a clean worktree or fresh clone, then migrate intended changes deliberately.
+- GitHub Actions builds Windows, macOS, and Linux from release tags; development can happen on Ubuntu without changing that release model.
+- Releases are created as drafts and reviewed by the maintainer before publication.
+- Read `docs/AI_RELEASE_HANDOFF.md` and `docs/RELEASE_PROCESS.md` before release work.
+
+## Where To Look First
+
+- Product overview: `README.md`
+- Current agent handoff: `docs/AI_CURRENT_HANDOFF.md`
+- MCP behavior: `docs/MCP.md`
+- Release procedure: `docs/AI_RELEASE_HANDOFF.md`
+- Feature history and demo ideas: `docs/FEATURE_TRACKER.md`
+- App shell: `src/App.jsx`
+- Project persistence: `src/services/fileSystem.js`, `src/stores/projectStore.js`
+- Timeline behavior: `src/stores/timelineStore.js`, `src/components/Timeline.jsx`
+- Preview composition: `src/components/CanvasPreviewRenderer.jsx`
+- Export UI/worker: `src/components/ExportPanel.jsx`, `src/components/ExportWorker.jsx`
+- Electron/native layer: `electron/main.js`, `electron/preload.js`
+- MCP server: `electron/mcpServer.js`

--- a/src/components/CanvasPreviewRenderer.jsx
+++ b/src/components/CanvasPreviewRenderer.jsx
@@ -417,6 +417,13 @@ function CanvasPreviewRenderer({
   const lastPreloadTimeRef = useRef(0)
   const lastDrawTimeRef = useRef(null)
   const loopSeekHoldUntilRef = useRef(0)
+  const rasterSourceRevisionRef = useRef(0)
+  const rasterSourceInputsRef = useRef({
+    clips: null,
+    tracks: null,
+    transitions: null,
+    assets: null,
+  })
   const [, setAssetRevision] = useState(0)
 
   const {
@@ -430,6 +437,17 @@ function CanvasPreviewRenderer({
     glslPreviewQuality,
   } = useTimelineStore()
   const assets = useAssetsStore(state => state.assets)
+
+  const previousRasterInputs = rasterSourceInputsRef.current
+  if (
+    previousRasterInputs.clips !== clips
+    || previousRasterInputs.tracks !== tracks
+    || previousRasterInputs.transitions !== transitions
+    || previousRasterInputs.assets !== assets
+  ) {
+    rasterSourceRevisionRef.current += 1
+    rasterSourceInputsRef.current = { clips, tracks, transitions, assets }
+  }
 
   const safeWidth = Math.max(1, Math.round(Number(timelineWidth) || 1920))
   const safeHeight = Math.max(1, Math.round(Number(timelineHeight) || 1080))
@@ -515,6 +533,7 @@ function CanvasPreviewRenderer({
     playbackRate,
     useProxyPlaybackForAssets,
     glslPreviewQuality,
+    rasterSourceRevision: rasterSourceRevisionRef.current,
     width: safeWidth,
     height: safeHeight,
     fps: safeFps,
@@ -1141,7 +1160,10 @@ function CanvasPreviewRenderer({
         samples: [{
           source: buffers.offCanvas,
           sourceKey: `${clip.id}:2d`,
-          sourceVersion: frameIndex,
+          // The same timeline frame can be repainted after a paused edit.
+          // Include the visual-state revision so the GPU uploads the fresh
+          // text/shape/caption raster instead of reusing the old texture.
+          sourceVersion: `${frameIndex}:${state.rasterSourceRevision || 0}`,
           corners: [
             { x: 0, y: 0, u: 0, v: 0, w: 1 },
             { x: width, y: 0, u: 1, v: 0, w: 1 },

--- a/src/components/CreditsChip.jsx
+++ b/src/components/CreditsChip.jsx
@@ -6,6 +6,10 @@ import {
   COMFY_PARTNER_CREDITS_LOW_EVENT,
 } from '../services/comfyPartnerAuth'
 import { comfyui } from '../services/comfyui'
+import {
+  CLOUD_CREDIT_DISPLAY_CHANGED_EVENT,
+  getShowCloudCreditBalance,
+} from '../services/cloudCreditDisplaySettings'
 
 /**
  * CreditsChip
@@ -23,6 +27,7 @@ import { comfyui } from '../services/comfyui'
  *     "Out of credits" state immediately.
  */
 function CreditsChip({ className = '', size = 'sm' }) {
+  const [showCreditBalance, setShowCreditBalance] = useState(() => getShowCloudCreditBalance())
   const [hasKey, setHasKey] = useState(false)
   const [balance, setBalance] = useState({
     status: 'idle', // 'idle' | 'loading' | 'ok' | 'unknown' | 'low'
@@ -34,6 +39,14 @@ function CreditsChip({ className = '', size = 'sm' }) {
   const refreshInFlightRef = useRef(false)
   const hasEmbeddedBalanceSupport = typeof window !== 'undefined'
     && typeof window?.electronAPI?.getComfyCloudCreditBalance === 'function'
+
+  useEffect(() => {
+    const onDisplayChanged = (event) => {
+      setShowCreditBalance(event?.detail?.show !== false)
+    }
+    window.addEventListener(CLOUD_CREDIT_DISPLAY_CHANGED_EVENT, onDisplayChanged)
+    return () => window.removeEventListener(CLOUD_CREDIT_DISPLAY_CHANGED_EVENT, onDisplayChanged)
+  }, [])
 
   const refreshBalance = useCallback(async () => {
     if (refreshInFlightRef.current) return
@@ -121,7 +134,7 @@ function CreditsChip({ className = '', size = 'sm' }) {
   // Poll when either balance source is available. The embedded ComfyUI source
   // gracefully returns "not-authenticated" until the user logs in.
   useEffect(() => {
-    const canQueryBalance = hasKey || hasEmbeddedBalanceSupport
+    const canQueryBalance = showCreditBalance && (hasKey || hasEmbeddedBalanceSupport)
 
     if (!canQueryBalance) {
       setBalance({ status: 'idle', credits: null })
@@ -140,7 +153,7 @@ function CreditsChip({ className = '', size = 'sm' }) {
         pollTimerRef.current = null
       }
     }
-  }, [hasKey, hasEmbeddedBalanceSupport, refreshBalance])
+  }, [hasKey, hasEmbeddedBalanceSupport, refreshBalance, showCreditBalance])
 
   // Flip into "low" state the moment any surface dispatches the event.
   useEffect(() => {
@@ -178,7 +191,7 @@ function CreditsChip({ className = '', size = 'sm' }) {
     }
   }, [balance, isRefreshing])
 
-  if (!hasKey && !hasEmbeddedBalanceSupport) return null
+  if (!showCreditBalance || (!hasKey && !hasEmbeddedBalanceSupport)) return null
 
   const isLow = balance.status === 'low'
   const isLive = balance.status === 'ok'

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -52,6 +52,10 @@ import {
   playGenerationCompletionSound,
   setGenerationCompletionSoundSettings,
 } from '../services/generationCompletionSoundSettings'
+import {
+  getShowCloudCreditBalance,
+  setShowCloudCreditBalance,
+} from '../services/cloudCreditDisplaySettings'
 
 const AUTO_IMPORT_KEY = 'comfystudio-auto-import-comfy-outputs'
 const OUTPUT_DIRECTORY_SETTING_KEY = 'outputDirectory'
@@ -183,6 +187,7 @@ function GeneralTab({ initialSection = null }) {
   const [generationCompletionSoundSettings, setGenerationCompletionSoundSettingsState] = useState(() => (
     getGenerationCompletionSoundSettings()
   ))
+  const [showCloudCreditBalance, setShowCloudCreditBalanceState] = useState(() => getShowCloudCreditBalance())
   const [pexelsApiKey, setPexelsApiKeyLocal] = useState('')
   const [comfyOrgApiKey, setComfyOrgApiKey] = useState('')
   const [apiKeyDialogOpen, setApiKeyDialogOpen] = useState(false)
@@ -398,6 +403,11 @@ function GeneralTab({ initialSection = null }) {
       ...updates,
     })
     setGenerationCompletionSoundSettingsState(next)
+  }
+
+  const handleToggleCloudCreditBalance = () => {
+    const next = setShowCloudCreditBalance(!showCloudCreditBalance)
+    setShowCloudCreditBalanceState(next)
   }
 
   const handleCopyMcpText = async (id, text) => {
@@ -732,6 +742,28 @@ function GeneralTab({ initialSection = null }) {
             {playbackCacheMessage && !playbackCacheBusy && (
               <p className="mt-3 text-[10px] text-sf-text-muted">{playbackCacheMessage}</p>
             )}
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-sf-dark-700 bg-sf-dark-900/60 px-3 py-3">
+            <div className="pr-4">
+              <label className="text-sm text-sf-text-primary">Show cloud credit balance</label>
+              <p className="text-[10px] text-sf-text-muted">
+                Display Comfy.org credits in the app header. Turning this off does not disable cloud workflows.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showCloudCreditBalance}
+              onClick={handleToggleCloudCreditBalance}
+              className={`relative h-5 w-10 flex-shrink-0 rounded-full transition-colors ${showCloudCreditBalance ? 'bg-sf-accent' : 'bg-sf-dark-600'}`}
+              title={showCloudCreditBalance ? 'Hide cloud credit balance' : 'Show cloud credit balance'}
+            >
+              <span
+                className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-all ${showCloudCreditBalance ? 'left-[calc(100%-1.25rem)]' : 'left-0.5'}`}
+                aria-hidden
+              />
+            </button>
           </div>
 
           <div className="flex items-center justify-between rounded-lg border border-sf-dark-700 bg-sf-dark-900/60 px-3 py-3">

--- a/src/services/cloudCreditDisplaySettings.js
+++ b/src/services/cloudCreditDisplaySettings.js
@@ -1,0 +1,27 @@
+const CLOUD_CREDIT_DISPLAY_STORAGE_KEY = 'velorn-show-cloud-credit-balance'
+
+export const CLOUD_CREDIT_DISPLAY_CHANGED_EVENT = 'velorn-cloud-credit-display-changed'
+
+export function getShowCloudCreditBalance() {
+  if (typeof localStorage === 'undefined') return true
+  try {
+    return localStorage.getItem(CLOUD_CREDIT_DISPLAY_STORAGE_KEY) !== 'false'
+  } catch {
+    return true
+  }
+}
+
+export function setShowCloudCreditBalance(show) {
+  const next = Boolean(show)
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.setItem(CLOUD_CREDIT_DISPLAY_STORAGE_KEY, String(next))
+    } catch (_) {}
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(CLOUD_CREDIT_DISPLAY_CHANGED_EVENT, {
+      detail: { show: next },
+    }))
+  }
+  return next
+}

--- a/src/services/cloudCreditDisplaySettings.test.js
+++ b/src/services/cloudCreditDisplaySettings.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  CLOUD_CREDIT_DISPLAY_CHANGED_EVENT,
+  getShowCloudCreditBalance,
+  setShowCloudCreditBalance,
+} from './cloudCreditDisplaySettings.js'
+
+function installBrowserMocks(initialValue = null) {
+  const values = new Map()
+  if (initialValue !== null) {
+    values.set('velorn-show-cloud-credit-balance', initialValue)
+  }
+
+  const events = []
+  globalThis.localStorage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  }
+  globalThis.window = {
+    dispatchEvent: (event) => events.push(event),
+  }
+
+  return { events, values }
+}
+
+test.afterEach(() => {
+  delete globalThis.localStorage
+  delete globalThis.window
+})
+
+test('shows the cloud credit balance by default', () => {
+  installBrowserMocks()
+  assert.equal(getShowCloudCreditBalance(), true)
+})
+
+test('reads a disabled preference from local storage', () => {
+  installBrowserMocks('false')
+  assert.equal(getShowCloudCreditBalance(), false)
+})
+
+test('persists and announces visibility changes', () => {
+  const { events, values } = installBrowserMocks()
+
+  assert.equal(setShowCloudCreditBalance(false), false)
+  assert.equal(values.get('velorn-show-cloud-credit-balance'), 'false')
+  assert.equal(events.length, 1)
+  assert.equal(events[0].type, CLOUD_CREDIT_DISPLAY_CHANGED_EVENT)
+  assert.deepEqual(events[0].detail, { show: false })
+})

--- a/src/services/importedWorkflowBindings.js
+++ b/src/services/importedWorkflowBindings.js
@@ -5,7 +5,11 @@
 // input nodes; those ids survive conversion because only subgraph-internal
 // nodes get composite ids.
 
-const TEXT_INPUT_KEYS = ['text', 'prompt', 'positive_prompt', 'caption', 'text_g']
+// Partner/API nodes can expose namespaced widget keys instead of the usual
+// ComfyUI `prompt` input. MiniMax H3, for example, stores its positive prompt
+// under `model.prompt`. Treat it as a first-class prompt binding so a queue-time
+// prompt actually replaces the template's baked character/scene prompt.
+const TEXT_INPUT_KEYS = ['text', 'prompt', 'model.prompt', 'positive_prompt', 'caption', 'text_g']
 const SEED_INPUT_KEYS = ['seed', 'noise_seed']
 const ASSET_INPUT_KEY_CANDIDATES = {
   image: ['image'],

--- a/src/services/importedWorkflowBindings.test.js
+++ b/src/services/importedWorkflowBindings.test.js
@@ -1,0 +1,45 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  applyImportedWorkflowBindings,
+  detectImportedWorkflowBindings,
+} from './importedWorkflowBindings.js'
+
+test('detects and replaces MiniMax H3 model.prompt without touching the source image', () => {
+  const workflow = {
+    2: {
+      class_type: 'LoadImage',
+      inputs: { image: 'old-reference.png' },
+    },
+    4: {
+      class_type: 'MinimaxHailuo03FirstLastFrameNode',
+      inputs: {
+        first_frame: ['2', 0],
+        'model.prompt': 'Old character-specific prompt',
+        seed: 42,
+      },
+    },
+    5: {
+      class_type: 'SaveVideo',
+      inputs: { video: ['4', 0], filename_prefix: 'video/test' },
+    },
+  }
+
+  const detected = detectImportedWorkflowBindings(workflow, null)
+
+  assert.deepEqual(detected.bindings.prompt, {
+    nodeId: '4',
+    inputKey: 'model.prompt',
+  })
+
+  const bound = applyImportedWorkflowBindings(workflow, detected.bindings, {
+    prompt: 'Clean paper-city motion prompt',
+    inputImage: '01_city_stage.png',
+    seed: 310001,
+  })
+
+  assert.equal(bound['4'].inputs['model.prompt'], 'Clean paper-city motion prompt')
+  assert.equal(bound['2'].inputs.image, '01_city_stage.png')
+  assert.equal(bound['4'].inputs.seed, 310001)
+})


### PR DESCRIPTION
﻿## Summary

- add a Settings preference to hide the Comfy.org credit balance and stop balance polling while hidden
- refresh paused text, shape, and caption rasters when timeline or asset state changes
- recognize namespaced `model.prompt` inputs in imported workflows such as MiniMax H3
- add durable project and migration context for coding agents moving between Windows and Ubuntu

## Why

These three tested fixes existed only in an older dirty Windows checkout and were never included in `main` or a release. This PR migrates only the approved changes onto a clean v0.3.25 base. It deliberately excludes the obsolete ComfyUI-based RTX implementation, already-shipped My Workflows MCP work, generated media, drafts, and unverified title-bar experiments.

## Validation

- maintainer manually verified all three user-facing fixes in Electron
- `npm run build`
- `node --check electron/main.js`
- `node --check electron/preload.js`
- all ten existing `package.json` test scripts
- focused cloud-credit preference and imported-workflow binding tests
- 82 tests passed, 0 failed



## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement

