### PR TITLE
Prepare Velorn v0.3.26

### DIFF
--- a/docs/RELEASE_NOTES_0.3.26.md
+++ b/docs/RELEASE_NOTES_0.3.26.md
@@ -1,0 +1,31 @@
+# Velorn v0.3.26
+
+Velorn v0.3.26 improves audio reliability across preview, editing, and export, and lets Linux creators use a compatible system FFmpeg build for NVIDIA hardware encoding while retaining Velorn's bundled software fallback.
+
+## Highlights
+
+- **Smoother timeline audio playback.** Velorn now prepares nearby audio clips ahead of playback, keeps active layers stable across edits, and performs a bounded start alignment when playback begins in the middle of a clip. This reduces crackling, catch-up behavior, and gaps around short or multilayer cuts.
+- **Short audio clips survive export.** Export now recognizes legacy video-backed clips placed on audio tracks and preserves fractional timeline delays, preventing very short fragments and frame-aligned cut boundaries from being dropped or shifted.
+- **Safer audio splits.** Audio razor edits preserve clip gain, fades, timing, retiming, reverse state, and source ranges. Older projects with video-typed audio-track fragments are repaired when loaded.
+- **Configurable FFmpeg for hardware export.** In **Settings > File Paths**, Linux users can select and test an external FFmpeg build that supports NVIDIA NVENC. The `VELORN_FFMPEG_PATH` environment variable is also supported for advanced setups.
+- **Isolated hardware path with safe fallback.** A custom FFmpeg binary is used only for final H.264/H.265 hardware encoding. Velorn continues to use its bundled FFmpeg for normal media processing and automatically falls back to bundled software encoding when the custom binary or requested encoder is unavailable.
+- **Comfy.org credit display control.** Creators can hide the cloud credit balance when they use local workflows and do not need the Comfy.org balance in the interface.
+- **Immediate paused graphic refresh.** Text, shape, and caption changes now refresh the preview immediately while playback is paused.
+- **Broader imported workflow support.** Imported workflows can bind namespaced prompt fields such as `model.prompt`.
+
+## Downloads
+
+- `Windows Installer`: standard Windows install experience for most users
+- `Windows Portable`: no-install Windows build for quick testing or portable use
+- `Mac (Apple Silicon)`: for M1, M2, M3, M4, and newer Macs
+- `Mac (Intel)`: for older Intel-based Macs
+- `Linux AppImage`: portable Linux build
+- `Linux deb`: Debian/Ubuntu package
+
+Ignore the auto-generated source-code archives unless you plan to build Velorn from source.
+
+## Notes
+
+- Editing, captions, export, MCP control, and local project management do not require ComfyUI. ComfyUI is needed only when running a ComfyUI generation workflow.
+- Velorn's bundled FFmpeg remains the default and the software fallback. Configure an external binary only when you need a hardware encoder that is not included in the bundled build.
+- Standalone NVIDIA RTX 4K upscaling remains Windows-only. The external FFmpeg setting affects H.264/H.265 hardware export, not RTX 4K upscaling.

--- a/electron/audioMixEligibility.mjs
+++ b/electron/audioMixEligibility.mjs
@@ -1,0 +1,39 @@
+/**
+ * Audio export eligibility shared by the renderer and Electron main process.
+ *
+ * Some projects saved by an older split path contain `type: "video"` clips
+ * on audio tracks. Track placement is authoritative for those media clips:
+ * they must remain audible and exportable even before the project is edited
+ * and saved again with corrected clip metadata.
+ */
+export const isAudioMixClip = (clip, track = null) => Boolean(
+  clip
+  && (
+    clip.type === 'audio'
+    || (clip.type === 'video' && track?.type === 'audio')
+  )
+)
+
+export const collectAudioMixClips = (clips = [], tracks = []) => {
+  const trackMap = new Map((tracks || []).map((track) => [track.id, track]))
+  return (clips || []).filter((clip) => (
+    clip?.enabled !== false
+    && isAudioMixClip(clip, trackMap.get(clip?.trackId))
+  ))
+}
+
+export const countExpectedAudioMixClips = (clips, rangeStart, rangeEnd) => (
+  (clips || []).filter((clip) => {
+    if (clip?.reverse) return false // Reverse audio is intentionally silent.
+    const clipStart = Number(clip?.startTime) || 0
+    const clipDuration = Math.max(0, Number(clip?.duration) || 0)
+    return clipDuration > 0 && clipStart < rangeEnd && clipStart + clipDuration > rangeStart
+  }).length
+)
+
+export const getAudioMixDelayMilliseconds = (visibleStart, rangeStart) => {
+  const start = Number(visibleStart)
+  const range = Number(rangeStart)
+  if (!Number.isFinite(start) || !Number.isFinite(range)) return 0
+  return Math.max(0, (start - range) * 1000)
+}

--- a/electron/hardwareExportFfmpeg.js
+++ b/electron/hardwareExportFfmpeg.js
@@ -1,0 +1,196 @@
+const fs = require('fs')
+const path = require('path')
+const { spawn } = require('child_process')
+
+const HARDWARE_EXPORT_FFMPEG_SETTING_KEY = 'hardwareExportFfmpegPath'
+const HARDWARE_EXPORT_FFMPEG_ENV_KEY = 'VELORN_FFMPEG_PATH'
+const DEFAULT_VERSION_PROBE_TIMEOUT_MS = 5000
+const MAX_PROBE_OUTPUT_BYTES = 32 * 1024
+
+function normalizeFfmpegPath(value) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function validateFfmpegPath(binaryPath, options = {}) {
+  const platform = options.platform || process.platform
+  const fsImpl = options.fsImpl || fs
+  const normalizedPath = normalizeFfmpegPath(binaryPath)
+
+  if (!normalizedPath) {
+    return { ok: false, path: '', error: 'Choose an FFmpeg executable first.' }
+  }
+  if (!path.isAbsolute(normalizedPath)) {
+    return { ok: false, path: normalizedPath, error: 'The FFmpeg path must be absolute.' }
+  }
+
+  try {
+    const stat = fsImpl.statSync(normalizedPath)
+    if (!stat.isFile()) {
+      return { ok: false, path: normalizedPath, error: 'The selected FFmpeg path is not a file.' }
+    }
+    if (platform !== 'win32') {
+      fsImpl.accessSync(normalizedPath, fs.constants.X_OK)
+    }
+  } catch (error) {
+    const reason = error?.code === 'EACCES'
+      ? 'The selected FFmpeg file is not executable.'
+      : 'The selected FFmpeg file could not be found or opened.'
+    return { ok: false, path: normalizedPath, error: reason }
+  }
+
+  return { ok: true, path: normalizedPath, error: null }
+}
+
+function resolveHardwareExportFfmpeg(options = {}) {
+  const bundledPath = normalizeFfmpegPath(options.bundledPath)
+  const settingPath = normalizeFfmpegPath(options.settingPath)
+  const environmentPath = normalizeFfmpegPath(options.environmentPath)
+  const platform = options.platform || process.platform
+  const fsImpl = options.fsImpl || fs
+
+  const configured = environmentPath
+    ? { source: 'environment', path: environmentPath }
+    : settingPath
+      ? { source: 'setting', path: settingPath }
+      : null
+
+  if (configured) {
+    const validation = validateFfmpegPath(configured.path, { platform, fsImpl })
+    if (validation.ok) {
+      return {
+        path: validation.path,
+        source: configured.source,
+        settingPath,
+        environmentPath,
+        warning: null,
+      }
+    }
+
+    const sourceLabel = configured.source === 'environment'
+      ? HARDWARE_EXPORT_FFMPEG_ENV_KEY
+      : 'saved hardware-export FFmpeg path'
+    return {
+      path: bundledPath,
+      source: 'bundled',
+      settingPath,
+      environmentPath,
+      warning: `${sourceLabel} is invalid: ${validation.error} Velorn will use its bundled FFmpeg.`,
+    }
+  }
+
+  return {
+    path: bundledPath,
+    source: 'bundled',
+    settingPath,
+    environmentPath,
+    warning: null,
+  }
+}
+
+function appendBoundedOutput(current, chunk) {
+  const next = current + String(chunk || '')
+  return next.length > MAX_PROBE_OUTPUT_BYTES
+    ? next.slice(-MAX_PROBE_OUTPUT_BYTES)
+    : next
+}
+
+function probeFfmpegVersion(binaryPath, options = {}) {
+  const validation = validateFfmpegPath(binaryPath, options)
+  if (!validation.ok) return Promise.resolve(validation)
+
+  const spawnImpl = options.spawnImpl || spawn
+  const timeoutMs = Number.isFinite(Number(options.timeoutMs))
+    ? Math.max(100, Number(options.timeoutMs))
+    : DEFAULT_VERSION_PROBE_TIMEOUT_MS
+
+  return new Promise((resolve) => {
+    let child
+    try {
+      child = spawnImpl(validation.path, ['-hide_banner', '-version'], {
+        windowsHide: true,
+        shell: false,
+      })
+    } catch (error) {
+      resolve({ ok: false, path: validation.path, error: error?.message || String(error) })
+      return
+    }
+
+    let output = ''
+    let settled = false
+    let timer = null
+    const finish = (result) => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      resolve({ path: validation.path, ...result })
+    }
+
+    timer = setTimeout(() => {
+      try { child.kill('SIGKILL') } catch { /* process already exited */ }
+      finish({ ok: false, error: 'Timed out while checking the selected FFmpeg executable.' })
+    }, timeoutMs)
+
+    child.stdout?.on('data', (data) => {
+      output = appendBoundedOutput(output, data)
+    })
+    child.stderr?.on('data', (data) => {
+      output = appendBoundedOutput(output, data)
+    })
+    child.on('error', (error) => {
+      finish({ ok: false, error: error?.message || String(error) })
+    })
+    child.on('close', (code) => {
+      const versionLine = output
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find((line) => /^ffmpeg version\b/i.test(line)) || ''
+      if (code === 0 && versionLine) {
+        finish({ ok: true, version: versionLine, error: null })
+        return
+      }
+      finish({
+        ok: false,
+        error: versionLine
+          ? `FFmpeg exited with code ${code}.`
+          : 'The selected file did not identify itself as FFmpeg.',
+      })
+    })
+  })
+}
+
+function getHardwareEncoderProbeCacheKey(binaryPath, encoderName, options = {}) {
+  const fsImpl = options.fsImpl || fs
+  let canonicalPath = normalizeFfmpegPath(binaryPath)
+  let fileSignature = ''
+  try {
+    canonicalPath = fsImpl.realpathSync(canonicalPath)
+    const stat = fsImpl.statSync(canonicalPath)
+    fileSignature = `${stat.size}:${stat.mtimeMs}`
+  } catch {
+    canonicalPath = path.resolve(canonicalPath || '.')
+  }
+  return `${canonicalPath}\u0000${fileSignature}\u0000${String(encoderName || '').trim()}`
+}
+
+function resolveHardwareExportRoute(options = {}) {
+  const bundledPath = normalizeFfmpegPath(options.bundledPath)
+  const selection = options.selection || {}
+  const hardwareActive = options.hardwareRequested === true && options.useHardwareEncoder === true
+  return {
+    path: hardwareActive ? normalizeFfmpegPath(selection.path) || bundledPath : bundledPath,
+    source: hardwareActive ? selection.source || 'bundled' : 'bundled',
+    warning: selection.warning || null,
+  }
+}
+
+module.exports = {
+  DEFAULT_VERSION_PROBE_TIMEOUT_MS,
+  HARDWARE_EXPORT_FFMPEG_ENV_KEY,
+  HARDWARE_EXPORT_FFMPEG_SETTING_KEY,
+  getHardwareEncoderProbeCacheKey,
+  normalizeFfmpegPath,
+  probeFfmpegVersion,
+  resolveHardwareExportFfmpeg,
+  resolveHardwareExportRoute,
+  validateFfmpegPath,
+}

--- a/electron/main.js
+++ b/electron/main.js
@@ -12,6 +12,14 @@ const yaml = require('js-yaml')
 const ffmpegStaticPath = require('ffmpeg-static')
 const ffprobeStatic = require('ffprobe-static')
 const ffprobeStaticPath = ffprobeStatic?.path || ffprobeStatic
+const {
+  HARDWARE_EXPORT_FFMPEG_ENV_KEY,
+  HARDWARE_EXPORT_FFMPEG_SETTING_KEY,
+  getHardwareEncoderProbeCacheKey,
+  probeFfmpegVersion,
+  resolveHardwareExportFfmpeg,
+  resolveHardwareExportRoute,
+} = require('./hardwareExportFfmpeg')
 const { inspectIsoBmffLayout } = require('./exportSourcePreparation')
 const { registerCaptionWhisperHandlers } = require('./captionWhisper')
 const {
@@ -137,12 +145,63 @@ const rtxHelperPath = app.isPackaged
 // downloaded the binary (skipped postinstalls, antivirus quarantine), and
 // spawning a dangling path dies with a bare ENOENT (-4058 on Windows). Export
 // entry points check existence up front so the failure names the path.
-function getFfmpegUnavailableError() {
-  if (!ffmpegPath) return 'FFmpeg binary not available.'
-  if (!fsSync.existsSync(ffmpegPath)) {
-    return `FFmpeg binary is missing at ${ffmpegPath}. Reinstall Velorn (or run npm install in a dev checkout) to restore it.`
+function getFfmpegUnavailableError(binaryPath = ffmpegPath) {
+  if (!binaryPath) return 'FFmpeg binary not available.'
+  if (!fsSync.existsSync(binaryPath)) {
+    const recovery = binaryPath === ffmpegPath
+      ? 'Reinstall Velorn (or run npm install in a dev checkout) to restore it.'
+      : 'Choose another hardware-export FFmpeg path or restore the selected file.'
+    return `FFmpeg binary is missing at ${binaryPath}. ${recovery}`
   }
   return null
+}
+
+async function resolveHardwareExportFfmpegSelection() {
+  const settings = await readSettingsRaw().catch(() => ({}))
+  const selection = resolveHardwareExportFfmpeg({
+    bundledPath: ffmpegPath,
+    settingPath: settings?.[HARDWARE_EXPORT_FFMPEG_SETTING_KEY],
+    environmentPath: process.env[HARDWARE_EXPORT_FFMPEG_ENV_KEY],
+  })
+  if (selection.source === 'bundled') return selection
+
+  const versionProbe = await probeFfmpegVersion(selection.path)
+  if (versionProbe.ok) {
+    return { ...selection, version: versionProbe.version || null }
+  }
+
+  const sourceLabel = selection.source === 'environment'
+    ? HARDWARE_EXPORT_FFMPEG_ENV_KEY
+    : 'Saved hardware-export FFmpeg'
+  return {
+    ...selection,
+    path: ffmpegPath,
+    source: 'bundled',
+    warning: `${sourceLabel} is not a usable FFmpeg executable: ${versionProbe.error} Velorn will use its bundled FFmpeg.`,
+  }
+}
+
+async function getHardwareExportFfmpegStatus() {
+  const selection = await resolveHardwareExportFfmpegSelection()
+  const versionProbe = selection.version
+    ? { ok: true, version: selection.version }
+    : await probeFfmpegVersion(selection.path)
+  return {
+    source: selection.source,
+    activePath: selection.path,
+    settingPath: selection.settingPath,
+    environmentPath: selection.environmentPath,
+    warning: selection.warning,
+    valid: versionProbe.ok === true,
+    version: versionProbe.version || null,
+    error: versionProbe.ok ? null : versionProbe.error,
+  }
+}
+
+function notifyHardwareExportFfmpegChanged() {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('export:hardwareFfmpegChanged')
+  }
 }
 
 // Session-log helper shared by the export-worker and main-window mirrors:
@@ -5876,6 +5935,7 @@ ipcMain.handle('export:mixAudio', async (event, options = {}) => {
   const trackMap = new Map((tracks || []).map((track) => [track.id, track]))
   const assetMap = new Map((assets || []).map((asset) => [asset.id, asset]))
   const preparedInputs = []
+  const { getAudioMixDelayMilliseconds, isAudioMixClip } = await import('./audioMixEligibility.mjs')
 
   // Skip ledger (the captions mixer's mold): every excluded clip gets a
   // reason. `problem: true` marks exclusions the exporter's strict
@@ -5903,8 +5963,8 @@ ipcMain.handle('export:mixAudio', async (event, options = {}) => {
   }
 
   for (const clip of clips || []) {
-    if (!clip || clip.type !== 'audio') { if (clip) skip(clip, 'not-an-audio-clip'); continue }
-    const track = trackMap.get(clip.trackId)
+    const track = trackMap.get(clip?.trackId)
+    if (!isAudioMixClip(clip, track)) { if (clip) skip(clip, 'not-an-audio-clip'); continue }
     if (!track || track.type !== 'audio' || track.muted || track.visible === false) {
       // The renderer only sends clips on audible audio tracks, so landing
       // here means renderer/main disagree — count it as a problem.
@@ -5953,7 +6013,7 @@ ipcMain.handle('export:mixAudio', async (event, options = {}) => {
     const sourceDurationSec = Math.max(0, timelineVisibleSec * timeScale)
     if (sourceDurationSec <= 0.000001) { skip(clip, 'zero-source-duration', true); continue }
 
-    const delayMs = Math.max(0, Math.round((visibleStart - rangeStartSec) * 1000))
+    const delayMs = getAudioMixDelayMilliseconds(visibleStart, rangeStartSec)
     preparedInputs.push({
       inputPath,
       sourceOffsetSec,
@@ -6025,7 +6085,7 @@ ipcMain.handle('export:mixAudio', async (event, options = {}) => {
         : `pan=stereo|c0=${gl}*c0|c1=c1+${gr}*c0`)
     }
     if (entry.delayMs > 0) {
-      filters.push(`adelay=${entry.delayMs}:all=1`)
+      filters.push(`adelay=${formatFilterNumber(entry.delayMs)}:all=1`)
     }
 
     const label = `mix${index}`
@@ -6570,11 +6630,17 @@ ipcMain.handle('export:prepareVideoSource', async (event, options = {}) => {
 // result (as a promise, so concurrent callers share one probe) per app run.
 const hardwareEncoderProbeCache = new Map()
 
-function probeHardwareEncoder(encoderName) {
-  const cached = hardwareEncoderProbeCache.get(encoderName)
+function clearHardwareEncoderProbeCache() {
+  hardwareEncoderProbeCache.clear()
+}
+
+function probeHardwareEncoder(encoderName, binaryPath = ffmpegPath, options = {}) {
+  const cacheKey = getHardwareEncoderProbeCacheKey(binaryPath, encoderName)
+  if (options.forceRefresh) hardwareEncoderProbeCache.delete(cacheKey)
+  const cached = hardwareEncoderProbeCache.get(cacheKey)
   if (cached) return cached
   const probe = new Promise((resolve) => {
-    if (!ffmpegPath) {
+    if (!binaryPath) {
       resolve({ ok: false, error: 'FFmpeg binary not available.' })
       return
     }
@@ -6585,7 +6651,7 @@ function probeHardwareEncoder(encoderName) {
       '-c:v', encoderName,
       '-f', 'null', '-',
     ]
-    const child = spawn(ffmpegPath, args, { windowsHide: true })
+    const child = spawn(binaryPath, args, { windowsHide: true })
     let stderr = ''
     let settled = false
     const finish = (result) => {
@@ -6611,8 +6677,64 @@ function probeHardwareEncoder(encoderName) {
       }
     })
   })
-  hardwareEncoderProbeCache.set(encoderName, probe)
+  hardwareEncoderProbeCache.set(cacheKey, probe)
   return probe
+}
+
+function listHardwareEncoders(binaryPath, options = {}) {
+  const timeoutMs = Number.isFinite(Number(options.timeoutMs))
+    ? Math.max(1000, Number(options.timeoutMs))
+    : 15000
+
+  return new Promise((resolve) => {
+    if (!binaryPath) {
+      resolve({ h264: false, h265: false, error: 'FFmpeg binary not available.' })
+      return
+    }
+
+    let child
+    try {
+      child = spawn(binaryPath, ['-hide_banner', '-encoders'], { windowsHide: true })
+    } catch (error) {
+      resolve({ h264: false, h265: false, error: error?.message || String(error) })
+      return
+    }
+
+    let output = ''
+    let settled = false
+    let timer = null
+    const finish = (result) => {
+      if (settled) return
+      settled = true
+      if (timer) clearTimeout(timer)
+      resolve(result)
+    }
+    timer = setTimeout(() => {
+      try { child.kill('SIGKILL') } catch { /* process already exited */ }
+      finish({ h264: false, h265: false, error: 'Timed out while listing FFmpeg hardware encoders.' })
+    }, timeoutMs)
+
+    child.stdout.on('data', (data) => {
+      output = appendLimitedStderr(output, data)
+    })
+    child.stderr.on('data', (data) => {
+      output = appendLimitedStderr(output, data)
+    })
+    child.on('error', (error) => {
+      finish({ h264: false, h265: false, error: error?.message || String(error) })
+    })
+    child.on('close', (code) => {
+      if (code !== 0) {
+        finish({ h264: false, h265: false, error: output.trim() || `FFmpeg exited with code ${code}` })
+        return
+      }
+      finish({
+        h264: output.includes(process.platform === 'darwin' ? 'h264_videotoolbox' : 'h264_nvenc'),
+        h265: output.includes(process.platform === 'darwin' ? 'hevc_videotoolbox' : 'hevc_nvenc'),
+        error: null,
+      })
+    })
+  })
 }
 
 // When an export requests hardware encoding, verify the encoder actually
@@ -6623,23 +6745,30 @@ function probeHardwareEncoder(encoderName) {
 // options — both encode handlers pass options straight through to
 // appendExportVideoEncoderArgs. Returns null when hardware is unused,
 // software-only (ProRes/VP9/alpha), or healthy.
-async function resolveHardwareEncoderDowngrade(options = {}) {
-  if (!options.useHardwareEncoder) return null
+function isHardwareVideoEncodingRequested(options = {}) {
+  if (!options.useHardwareEncoder || options.alpha) return false
   const isProRes = options.videoCodec === 'prores' || (options.format === 'mov' && options.proresProfile != null)
   const isVp9 = options.format === 'webm' || options.videoCodec === 'vp9'
-  if (isProRes || isVp9 || options.alpha) return null
+  return !isProRes && !isVp9
+}
+
+async function resolveHardwareEncoderDowngrade(options = {}, selection = null) {
+  if (!isHardwareVideoEncodingRequested(options)) return null
   const isMac = process.platform === 'darwin'
   const isH265 = options.videoCodec === 'h265'
   const encoderName = isMac
     ? (isH265 ? 'hevc_videotoolbox' : 'h264_videotoolbox')
     : (isH265 ? 'hevc_nvenc' : 'h264_nvenc')
-  const probe = await probeHardwareEncoder(encoderName)
+  const activeSelection = selection || { path: ffmpegPath, warning: null }
+  const probe = await probeHardwareEncoder(encoderName, activeSelection.path)
   if (probe.ok) return null
   options.useHardwareEncoder = false
   return {
     requestedEncoder: encoderName,
     fallbackEncoder: isH265 ? 'libx265' : 'libx264',
-    reason: probe.error || 'Hardware encoder failed to initialize.',
+    reason: [activeSelection.warning, probe.error || 'Hardware encoder failed to initialize.']
+      .filter(Boolean)
+      .join(' '),
   }
 }
 
@@ -6656,17 +6785,28 @@ ipcMain.handle('export:encodeVideo', async (event, options = {}) => {
     audioSampleRate = 44100
   } = options
 
-  const encodeFfmpegUnavailable = getFfmpegUnavailableError()
-  if (encodeFfmpegUnavailable) {
-    return { success: false, error: encodeFfmpegUnavailable }
-  }
   if (!framePattern || !outputPath) {
     return { success: false, error: 'Missing export inputs.' }
   }
 
-  const hardwareFallback = await resolveHardwareEncoderDowngrade(options)
+  const hardwareRequested = isHardwareVideoEncodingRequested(options)
+  const hardwareFfmpegSelection = hardwareRequested
+    ? await resolveHardwareExportFfmpegSelection()
+    : { path: ffmpegPath, source: 'bundled', warning: null }
+  const hardwareFallback = await resolveHardwareEncoderDowngrade(options, hardwareFfmpegSelection)
   if (hardwareFallback) {
     console.warn(`[Export] ${hardwareFallback.requestedEncoder} unavailable (${hardwareFallback.reason}); using ${hardwareFallback.fallbackEncoder}.`)
+  }
+  const hardwareFfmpegRoute = resolveHardwareExportRoute({
+    hardwareRequested,
+    useHardwareEncoder: options.useHardwareEncoder,
+    selection: hardwareFfmpegSelection,
+    bundledPath: ffmpegPath,
+  })
+  const encodeFfmpegPath = hardwareFfmpegRoute.path
+  const encodeFfmpegUnavailable = getFfmpegUnavailableError(encodeFfmpegPath)
+  if (encodeFfmpegUnavailable) {
+    return { success: false, error: encodeFfmpegUnavailable, ...(hardwareFallback ? { hardwareFallback } : {}) }
   }
 
   const args = ['-y', '-framerate', String(fps), '-i', framePattern]
@@ -6691,7 +6831,7 @@ ipcMain.handle('export:encodeVideo', async (event, options = {}) => {
   console.log(`[Export] Encoding with ${encoderUsed} (${options.useHardwareEncoder ? 'hardware' : 'software'})`)
 
   return await new Promise((resolve) => {
-    const ffmpeg = spawn(ffmpegPath, args, { windowsHide: true })
+    const ffmpeg = spawn(encodeFfmpegPath, args, { windowsHide: true })
     let stderr = ''
 
     ffmpeg.stderr.on('data', (data) => {
@@ -6704,9 +6844,25 @@ ipcMain.handle('export:encodeVideo', async (event, options = {}) => {
 
     ffmpeg.on('close', (code) => {
       if (code === 0) {
-        resolve({ success: true, encoderUsed, ...(hardwareFallback ? { hardwareFallback } : {}) })
+        resolve({
+          success: true,
+          encoderUsed,
+          ...(hardwareFallback ? { hardwareFallback } : {}),
+          ...(hardwareRequested ? {
+            hardwareFfmpeg: {
+              source: hardwareFfmpegRoute.source,
+              path: encodeFfmpegPath,
+              warning: hardwareFfmpegRoute.warning,
+            },
+          } : {}),
+        })
       } else {
-        resolve({ success: false, error: stderr || `FFmpeg exited with code ${code}`, encoderUsed, ...(hardwareFallback ? { hardwareFallback } : {}) })
+        resolve({
+          success: false,
+          error: stderr || `FFmpeg exited with code ${code}`,
+          encoderUsed,
+          ...(hardwareFallback ? { hardwareFallback } : {}),
+        })
       }
     })
   })
@@ -6722,17 +6878,33 @@ ipcMain.handle('export:startFramePipe', async (event, options = {}) => {
     duration = null,
   } = options
 
-  const pipeFfmpegUnavailable = getFfmpegUnavailableError()
-  if (pipeFfmpegUnavailable) {
-    return { success: false, error: pipeFfmpegUnavailable, code: 'ffmpeg-missing' }
-  }
   if (!width || !height || !outputPath) {
     return { success: false, error: 'Missing frame pipe inputs.' }
   }
 
-  const hardwareFallback = await resolveHardwareEncoderDowngrade(options)
+  const hardwareRequested = isHardwareVideoEncodingRequested(options)
+  const hardwareFfmpegSelection = hardwareRequested
+    ? await resolveHardwareExportFfmpegSelection()
+    : { path: ffmpegPath, source: 'bundled', warning: null }
+  const hardwareFallback = await resolveHardwareEncoderDowngrade(options, hardwareFfmpegSelection)
   if (hardwareFallback) {
     console.warn(`[Export] ${hardwareFallback.requestedEncoder} unavailable (${hardwareFallback.reason}); using ${hardwareFallback.fallbackEncoder}.`)
+  }
+  const hardwareFfmpegRoute = resolveHardwareExportRoute({
+    hardwareRequested,
+    useHardwareEncoder: options.useHardwareEncoder,
+    selection: hardwareFfmpegSelection,
+    bundledPath: ffmpegPath,
+  })
+  const encodeFfmpegPath = hardwareFfmpegRoute.path
+  const pipeFfmpegUnavailable = getFfmpegUnavailableError(encodeFfmpegPath)
+  if (pipeFfmpegUnavailable) {
+    return {
+      success: false,
+      error: pipeFfmpegUnavailable,
+      code: 'ffmpeg-missing',
+      ...(hardwareFallback ? { hardwareFallback } : {}),
+    }
   }
 
   const args = [
@@ -6771,7 +6943,7 @@ ipcMain.handle('export:startFramePipe', async (event, options = {}) => {
   args.push(outputPath)
 
   const sessionId = crypto.randomUUID()
-  const ffmpeg = spawn(ffmpegPath, args, { windowsHide: true, stdio: ['pipe', 'ignore', 'pipe'] })
+  const ffmpeg = spawn(encodeFfmpegPath, args, { windowsHide: true, stdio: ['pipe', 'ignore', 'pipe'] })
   let stderr = ''
   let closed = false
   let closeCode = null
@@ -6808,10 +6980,10 @@ ipcMain.handle('export:startFramePipe', async (event, options = {}) => {
     ffmpeg.once('close', onClose)
   })
   if (!startup.ok) {
-    console.error(`[Export] Frame pipe FFmpeg failed to start (${ffmpegPath}): ${startup.reason}`)
+    console.error(`[Export] Frame pipe FFmpeg failed to start (${encodeFfmpegPath}): ${startup.reason}`)
     return {
       success: false,
-      error: `FFmpeg could not start (${ffmpegPath}): ${startup.reason}`,
+      error: `FFmpeg could not start (${encodeFfmpegPath}): ${startup.reason}`,
       code: 'spawn-failed',
       encoderUsed,
     }
@@ -6828,7 +7000,19 @@ ipcMain.handle('export:startFramePipe', async (event, options = {}) => {
   })
 
   console.log(`[Export] Frame pipe started with ${encoderUsed} (${options.useHardwareEncoder ? 'hardware' : 'software'})`)
-  return { success: true, sessionId, encoderUsed, ...(hardwareFallback ? { hardwareFallback } : {}) }
+  return {
+    success: true,
+    sessionId,
+    encoderUsed,
+    ...(hardwareFallback ? { hardwareFallback } : {}),
+    ...(hardwareRequested ? {
+      hardwareFfmpeg: {
+        source: hardwareFfmpegRoute.source,
+        path: encodeFfmpegPath,
+        warning: hardwareFfmpegRoute.warning,
+      },
+    } : {}),
+  }
 })
 
 ipcMain.handle('export:writeFrameToPipe', async (event, sessionId, frameBuffer) => {
@@ -7190,68 +7374,128 @@ ipcMain.handle('proxy:transcode', async (event, { inputPath, outputPath, targetH
 // Hardware-encoder availability check. Despite the historical channel name
 // this is platform-aware: NVENC on Windows/Linux, VideoToolbox on macOS.
 // The `kind` field tells the renderer which family it is looking at.
-ipcMain.handle('export:checkNvenc', async () => {
+ipcMain.handle('export:getHardwareFfmpegStatus', async () => {
+  return await getHardwareExportFfmpegStatus()
+})
+
+ipcMain.handle('export:setHardwareFfmpegPath', async (event, selectedPath) => {
+  const versionProbe = await probeFfmpegVersion(selectedPath)
+  if (!versionProbe.ok) {
+    return { success: false, error: versionProbe.error || 'The selected FFmpeg executable could not be validated.' }
+  }
+
+  try {
+    await writeSettingsRaw((settings) => ({
+      ...settings,
+      [HARDWARE_EXPORT_FFMPEG_SETTING_KEY]: versionProbe.path,
+    }))
+    clearHardwareEncoderProbeCache()
+    notifyHardwareExportFfmpegChanged()
+    return { success: true, status: await getHardwareExportFfmpegStatus() }
+  } catch (error) {
+    return { success: false, error: error?.message || String(error) }
+  }
+})
+
+ipcMain.handle('export:resetHardwareFfmpegPath', async () => {
+  try {
+    await writeSettingsRaw((settings) => {
+      const next = { ...settings }
+      delete next[HARDWARE_EXPORT_FFMPEG_SETTING_KEY]
+      return next
+    })
+    clearHardwareEncoderProbeCache()
+    notifyHardwareExportFfmpegChanged()
+    return { success: true, status: await getHardwareExportFfmpegStatus() }
+  } catch (error) {
+    return { success: false, error: error?.message || String(error) }
+  }
+})
+
+ipcMain.handle('export:checkNvenc', async (event, options = {}) => {
   const isMac = process.platform === 'darwin'
   const kind = isMac ? 'videotoolbox' : 'nvenc'
   const gpuName = isMac ? null : await detectNvidiaGpuName()
+  const selection = await resolveHardwareExportFfmpegSelection()
+  const metadata = {
+    ffmpegSource: selection.source,
+    ffmpegPath: selection.path,
+    configuredFfmpegPath: selection.settingPath || null,
+    environmentFfmpegPath: selection.environmentPath || null,
+    ffmpegWarning: selection.warning || null,
+  }
 
-  if (!ffmpegPath) {
-    return { available: false, h264: false, h265: false, gpuName, kind, error: 'FFmpeg binary not available.' }
+  if (!selection.path) {
+    return { ...metadata, available: false, h264: false, h265: false, gpuName, kind, error: 'FFmpeg binary not available.' }
   }
 
   // Two-stage check: the -encoders listing says whether the build contains
   // the encoder at all (the Linux ffmpeg-static build doesn't), then a real
   // one-frame probe catches builds where it's listed but can't initialize
   // (driver/API-version mismatches). Only the probe result is authoritative.
-  const listing = await new Promise((resolve) => {
-    const ffmpeg = spawn(ffmpegPath, ['-hide_banner', '-encoders'], { windowsHide: true })
-    let output = ''
+  if (options.forceRefresh) clearHardwareEncoderProbeCache()
+  const versionProbe = selection.version
+    ? { ok: true, version: selection.version }
+    : await probeFfmpegVersion(selection.path)
+  if (!versionProbe.ok) {
+    return {
+      ...metadata,
+      available: false,
+      h264: false,
+      h265: false,
+      gpuName,
+      kind,
+      error: [selection.warning, versionProbe.error].filter(Boolean).join(' '),
+    }
+  }
+  metadata.ffmpegVersion = versionProbe.version || null
 
-    ffmpeg.stdout.on('data', (data) => {
-      output += data.toString()
-    })
-    ffmpeg.stderr.on('data', (data) => {
-      output += data.toString()
-    })
-
-    ffmpeg.on('error', (err) => {
-      resolve({ h264: false, h265: false, error: err.message })
-    })
-
-    ffmpeg.on('close', () => {
-      resolve({
-        h264: isMac ? output.includes('h264_videotoolbox') : output.includes('h264_nvenc'),
-        h265: isMac ? output.includes('hevc_videotoolbox') : output.includes('hevc_nvenc'),
-        error: null,
-      })
-    })
-  })
+  const listing = await listHardwareEncoders(selection.path)
 
   if (listing.error) {
-    return { available: false, h264: false, h265: false, gpuName, kind, error: listing.error }
+    return {
+      ...metadata,
+      available: false,
+      h264: false,
+      h265: false,
+      gpuName,
+      kind,
+      error: [selection.warning, listing.error].filter(Boolean).join(' '),
+    }
   }
 
   let h264 = false
   let h265 = false
   let probeError = null
   if (listing.h264) {
-    const probe = await probeHardwareEncoder(isMac ? 'h264_videotoolbox' : 'h264_nvenc')
+    const probe = await probeHardwareEncoder(
+      isMac ? 'h264_videotoolbox' : 'h264_nvenc',
+      selection.path,
+      { forceRefresh: options.forceRefresh === true }
+    )
     h264 = probe.ok
     if (!probe.ok) probeError = probe.error
   }
   if (listing.h265) {
-    const probe = await probeHardwareEncoder(isMac ? 'hevc_videotoolbox' : 'hevc_nvenc')
+    const probe = await probeHardwareEncoder(
+      isMac ? 'hevc_videotoolbox' : 'hevc_nvenc',
+      selection.path,
+      { forceRefresh: options.forceRefresh === true }
+    )
     h265 = probe.ok
     if (!probe.ok && !probeError) probeError = probe.error
   }
 
   return {
+    ...metadata,
     available: h264 || h265,
     h264,
     h265,
     gpuName,
     kind,
-    ...(probeError && !h264 && !h265 ? { error: probeError } : {}),
+    ...((selection.warning || (probeError && !h264 && !h265))
+      ? { error: [selection.warning, probeError].filter(Boolean).join(' ') }
+      : {}),
   }
 })
 

--- a/electron/mcpServer.js
+++ b/electron/mcpServer.js
@@ -3588,7 +3588,7 @@ function checkExportReadiness(snapshot, args = {}) {
   if (plan.settings.includeAudio && audioTracks.some((track) => track?.muted)) notes.push('One or more audio tracks are muted and will not contribute to export audio.')
   if (plan.settings.includeAudio && audioClips.length === 0) notes.push('Audio export is enabled, but no active audio/video clips with audio were detected.')
   if (visualTracks.some((track) => track?.visible === false)) notes.push('One or more visual tracks are hidden and will not appear in the export.')
-  if (plan.settings.useHardwareEncoder) notes.push('Export requests hardware encoding; the renderer will fail if NVENC is unavailable.')
+  if (plan.settings.useHardwareEncoder) notes.push('Export requests hardware encoding; Velorn probes the active export FFmpeg at runtime and falls back to software encoding if the requested encoder is unavailable.')
   if (plan.settings.deliveryFraming === 'fill') notes.push('Delivery framing is fill/center-crop, so the export will fill the target aspect ratio instead of letterboxing.')
 
   return {
@@ -10392,7 +10392,7 @@ function createToolDefinitions() {
           },
           useHardwareEncoder: {
             type: 'boolean',
-            description: 'Request NVENC hardware encoding. Defaults to false.',
+            description: 'Request platform hardware encoding using the active export FFmpeg. Velorn falls back safely to software encoding if the encoder cannot initialize. Defaults to false.',
           },
           useProxyMedia: {
             type: 'boolean',
@@ -10462,7 +10462,7 @@ function createToolDefinitions() {
           includeAudio: { type: 'boolean', description: 'Shared include-audio setting. Defaults to true.' },
           videoCodec: { type: 'string', enum: ['h264', 'h265'], description: 'Shared video codec. Defaults to h264.' },
           crf: { type: 'number', description: 'Shared CRF quality. Defaults to export_timeline behavior.' },
-          useHardwareEncoder: { type: 'boolean', description: 'Shared hardware encoder setting.' },
+          useHardwareEncoder: { type: 'boolean', description: 'Shared hardware encoder request. Velorn probes the active export FFmpeg and falls back to software if unavailable.' },
           deliveryFraming: { type: 'string', enum: ['fit', 'fill', 'center_crop'], description: 'Shared framing override. Square/vertical targets default to fill.' },
           filenamePrefix: { type: 'string', description: 'Optional filename prefix for every export. Target suffixes are appended automatically.' },
           previewOnly: { type: 'boolean', description: 'When true, returns all export plans without rendering. Defaults to true.' },

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -145,7 +145,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
    * Check if FFmpeg supports NVIDIA NVENC encoders
    * @returns {Promise<{available: boolean, h264: boolean, h265: boolean, gpuName?: string | null, error?: string}>}
    */
-  checkNvenc: () => ipcRenderer.invoke('export:checkNvenc'),
+  checkNvenc: (options) => ipcRenderer.invoke('export:checkNvenc', options),
+  getHardwareExportFfmpegStatus: () => ipcRenderer.invoke('export:getHardwareFfmpegStatus'),
+  setHardwareExportFfmpegPath: (filePath) => ipcRenderer.invoke('export:setHardwareFfmpegPath', filePath),
+  resetHardwareExportFfmpegPath: () => ipcRenderer.invoke('export:resetHardwareFfmpegPath'),
+  onHardwareExportFfmpegChanged: (callback) => {
+    const handler = () => callback()
+    ipcRenderer.on('export:hardwareFfmpegChanged', handler)
+    return () => ipcRenderer.removeListener('export:hardwareFfmpegChanged', handler)
+  },
 
   // Direct NVIDIA RTX Video Super Resolution. The optional runtime is
   // managed by Velorn and does not require a running ComfyUI server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "velorn",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "velorn",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@xyflow/react": "^12.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velorn",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "AI-native video editing built around real creative timelines, generative workflows, and local agent control.",
   "main": "electron/main.js",
   "scripts": {
@@ -26,6 +26,10 @@
     "test:premiere-xml": "node --experimental-default-type=module --test ./src/services/premiereXmlExporter.test.js",
     "test:export-frame-source": "node --experimental-default-type=module --test ./src/services/exportFrameSource.test.js",
     "test:export-source-preparation": "node --test ./tests/exportSourcePreparation.test.js",
+    "test:audio-mix-eligibility": "node --test ./tests/audioMixEligibility.test.mjs",
+    "test:audio-preview": "node --test ./src/utils/audioPreviewScheduling.test.js",
+    "test:audio-clip-split": "node --test ./src/utils/audioClipSplit.test.js",
+    "test:hardware-export-ffmpeg": "node --test ./tests/hardwareExportFfmpeg.test.js",
     "test:mcp-h3": "node --test ./tests/mcpH3ReferenceVideo.test.js",
     "test:mcp-my-workflows": "node --test ./tests/myWorkflowCatalog.test.js"
   },

--- a/src/components/AudioLayerRenderer.jsx
+++ b/src/components/AudioLayerRenderer.jsx
@@ -18,6 +18,125 @@ import {
   removeTrackAnalyser,
   setInsertMeters,
 } from '../services/audioMixerGraph'
+import {
+  AUDIO_PREVIEW_DRIFT_CHECK_INTERVAL_MS,
+  AUDIO_PREVIEW_SEEK_TOLERANCE_SECONDS,
+  getAudioClipTimeScale,
+  getAudioSourceTimeAtTimeline,
+  isAudioTimelineDiscontinuity,
+  resolveAudioPreviewUrl,
+  selectAudioPreviewCandidates,
+  shouldAlignAudioBeforeStart,
+  shouldCorrectAudioDrift,
+} from '../utils/audioPreviewScheduling'
+
+const getNowMs = () => (
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now()
+)
+
+function clearAudioEntryListeners(entry) {
+  entry?.removeSourceListeners?.()
+  if (entry) entry.removeSourceListeners = null
+}
+
+function pauseAudioEntry(entry) {
+  if (!entry) return
+  if (!entry.element.paused) entry.element.pause()
+}
+
+function disposeAudioEntry(entry) {
+  if (!entry || entry.disposed) return
+  entry.disposed = true
+  entry.desiredPlaying = false
+  entry.generation += 1
+  clearAudioEntryListeners(entry)
+  pauseAudioEntry(entry)
+  entry.element.removeAttribute('src')
+  entry.element.load?.()
+  try {
+    entry.sourceNode?.disconnect()
+    entry.gainNode?.disconnect()
+  } catch (_) {}
+}
+
+function refreshAudioEntrySeekState(entry, nowMs) {
+  if (!entry?.seekInFlight) return
+  const elapsed = Math.max(0, nowMs - (entry.seekStartedAtMs || 0))
+  // Some Chromium/container combinations omit `seeked` for tiny seeks. Do
+  // not leave the clip permanently blocked if the element is already stable.
+  if ((!entry.element.seeking && elapsed > 100) || elapsed > 1500) {
+    entry.seekInFlight = false
+    entry.seekTarget = null
+  }
+}
+
+function requestAudioEntrySeek(entry, targetTime, nowMs = getNowMs()) {
+  if (!entry || entry.disposed || !Number.isFinite(targetTime)) return false
+  entry.pendingSeekTarget = targetTime
+  if (entry.element.readyState < 1) return false
+  refreshAudioEntrySeekState(entry, nowMs)
+  if (entry.seekInFlight || entry.element.seeking) return false
+
+  if (Math.abs((entry.element.currentTime || 0) - targetTime) <= AUDIO_PREVIEW_SEEK_TOLERANCE_SECONDS) {
+    entry.pendingSeekTarget = null
+    entry.positionPrepared = true
+    return false
+  }
+
+  try {
+    entry.pendingSeekTarget = null
+    entry.seekInFlight = true
+    entry.seekTarget = targetTime
+    entry.seekStartedAtMs = nowMs
+    entry.lastSeekAtMs = nowMs
+    entry.positionPrepared = false
+    entry.element.currentTime = targetTime
+    return true
+  } catch (err) {
+    entry.seekInFlight = false
+    entry.seekTarget = null
+    console.warn('Failed to seek preview audio clip:', err)
+    return false
+  }
+}
+
+function requestAudioEntryPlay(entry) {
+  if (
+    !entry
+    || entry.disposed
+    || !entry.desiredPlaying
+    || entry.seekInFlight
+    || entry.element.seeking
+    || entry.element.readyState < 2
+    || !entry.element.paused
+    || entry.playPromise
+  ) return
+
+  const generation = entry.generation
+  const playPromise = entry.element.play()
+  if (!playPromise || typeof playPromise.then !== 'function') return
+
+  entry.playPromise = playPromise
+  playPromise.then(() => {
+    if (entry.generation !== generation) return
+    if (entry.disposed || !entry.desiredPlaying) {
+      pauseAudioEntry(entry)
+    }
+  }).catch((err) => {
+    if (
+      entry.disposed
+      || entry.generation !== generation
+      || err?.name === 'AbortError'
+    ) return
+    console.warn('Failed to play audio clip:', err)
+  }).finally(() => {
+    if (entry.generation === generation && entry.playPromise === playPromise) {
+      entry.playPromise = null
+    }
+  })
+}
 
 /**
  * AudioLayerRenderer - Manages audio playback for audio clips on the timeline
@@ -46,7 +165,9 @@ import {
 function AudioLayerRenderer() {
   const audioElementsRef = useRef(new Map()) // clipId -> { element, currentSrc, sourceNode, gainNode, trackId }
   const trackBusesRef = useRef(new Map()) // trackId -> { input, chain, chainSignature, fader, analyser }
-  const isPlayingRef = useRef(false)
+  const latestPlaybackRef = useRef(null)
+  const previousTimelineSampleRef = useRef(null)
+  const entryEventHandlerRef = useRef(null)
   const audioContextRef = useRef(null)
   const masterBusInputRef = useRef(null)
   const masterChainRef = useRef(null)
@@ -62,16 +183,11 @@ function AudioLayerRenderer() {
     playbackRate,
     masterAudioVolume,
     masterAudioInserts,
-    getActiveClipsAtTime,
   } = useTimelineStore()
 
-  const getAssetById = useAssetsStore(state => state.getAssetById)
+  const assets = useAssetsStore(state => state.assets)
+  const getAssetUrl = useAssetsStore(state => state.getAssetUrl)
   const volume = useAssetsStore(state => state.volume) // Monitor volume from assets store
-
-  // Keep isPlayingRef in sync so event handlers always have current value
-  useEffect(() => {
-    isPlayingRef.current = isPlaying
-  }, [isPlaying])
 
   useEffect(() => {
     let audioContext = null
@@ -118,6 +234,97 @@ function AudioLayerRenderer() {
       masterBusInputRef.current = null
       programGainRef.current = null
       monitorGainRef.current = null
+    }
+  }, [])
+
+  // Media readiness events must consult the latest timeline/entry state. A
+  // single ref-backed handler prevents old loaded/seeked callbacks from
+  // reviving an evicted clip or playing it after the playhead moved away.
+  useEffect(() => {
+    entryEventHandlerRef.current = (entry, eventType = '') => {
+      if (!entry || entry.disposed || audioElementsRef.current.get(entry.clipId) !== entry) return
+
+      const nowMs = getNowMs()
+      const latest = latestPlaybackRef.current
+      const clip = entry.clip
+      if (!latest || !clip) return
+      const clipStart = Number(clip.startTime) || 0
+      const clipEnd = clipStart + Math.max(0, Number(clip.duration) || 0)
+      const active = latest.playheadPosition >= clipStart && latest.playheadPosition < clipEnd
+      entry.active = active
+      entry.desiredPlaying = Boolean(latest.isPlaying && active && !clip.reverse)
+
+      if (eventType === 'error') {
+        const failedUrl = entry.currentSrc
+        entry.failedUrl = failedUrl
+        entry.failedUrls.add(failedUrl)
+        if (failedUrl && failedUrl === entry.cacheUrl) {
+          useAssetsStore.getState().markPlaybackCacheBroken?.(clip.assetId, 'audio-preview-error')
+        }
+        const fallbackUrl = [entry.preferredUrl, entry.sourceUrl]
+          .find((url) => url && !entry.failedUrls.has(url)) || null
+        if (fallbackUrl) {
+          pauseAudioEntry(entry)
+          entry.seekInFlight = false
+          entry.seekTarget = null
+          entry.pendingSeekTarget = null
+          entry.positionPrepared = false
+          entry.startAlignmentAttempts = 0
+          entry.currentSrc = fallbackUrl
+          entry.element.src = fallbackUrl
+          entry.element.load?.()
+        } else if (!entry.errorReported) {
+          entry.errorReported = true
+          console.warn('Failed to load preview audio clip:', clip?.name || clip?.id || entry.clipId)
+        }
+        return
+      }
+
+      if (entry.element.seeking) return
+      if (entry.seekInFlight) {
+        entry.seekInFlight = false
+        entry.seekTarget = null
+      }
+      if (eventType === 'seeked') entry.positionPrepared = true
+
+      const latestTarget = active
+        ? getAudioSourceTimeAtTimeline(clip, latest.playheadPosition)
+        : null
+      if (shouldAlignAudioBeforeStart({
+        active,
+        isPlaying: entry.desiredPlaying,
+        positionPrepared: entry.positionPrepared,
+        attempts: entry.startAlignmentAttempts,
+        currentTime: entry.element.currentTime,
+        expectedTime: latestTarget,
+      })) {
+        entry.startAlignmentAttempts += 1
+        entry.positionPrepared = false
+        entry.pendingSeekTarget = latestTarget
+      }
+
+      // A cold load may finish hundreds of milliseconds after playback began.
+      // Replace its original target with the current playhead so it never
+      // starts behind and enters the audible catch-up/drift-correction cycle.
+      // Once a seek completes, start from that prepared position instead of
+      // chasing the moving playhead with a second in-flight seek.
+      if (active && !entry.positionPrepared) {
+        entry.pendingSeekTarget = Number.isFinite(entry.pendingSeekTarget)
+          ? entry.pendingSeekTarget
+          : latestTarget
+      }
+      const pendingTarget = entry.pendingSeekTarget
+      if (Number.isFinite(pendingTarget)) {
+        requestAudioEntrySeek(entry, pendingTarget, nowMs)
+        if (entry.seekInFlight) return
+      }
+
+      if (entry.desiredPlaying) requestAudioEntryPlay(entry)
+      else pauseAudioEntry(entry)
+    }
+
+    return () => {
+      entryEventHandlerRef.current = null
     }
   }, [])
 
@@ -250,27 +457,45 @@ function AudioLayerRenderer() {
     }
   }, [tracks])
 
-  // Get active audio clips at current playhead position (solo-aware)
-  const activeAudioClips = useMemo(() => {
+  // Keep active clips plus a bounded forward/backward warm window. Upcoming
+  // short clips get a loaded, pre-seeked element before their first sample;
+  // recently-ended entries survive briefly so ordinary cut crossings do not
+  // churn decoder instances.
+  const audioPreviewCandidates = useMemo(() => {
     const anySolo = hasAudioSolo(tracks)
-    const allActive = getActiveClipsAtTime(playheadPosition)
-    return allActive
-      .filter(({ track }) => track.type === 'audio' && isAudioTrackAudible(track, anySolo))
-      .map(({ clip, track }) => ({ clip, track }))
-  }, [playheadPosition, getActiveClipsAtTime, tracks])
+    return selectAudioPreviewCandidates({
+      clips,
+      tracks,
+      playheadPosition,
+      playbackRate,
+      isTrackAudible: (track) => isAudioTrackAudible(track, anySolo),
+    })
+  }, [clips, tracks, playheadPosition, playbackRate])
 
-  // Create/update audio elements for active clips
+  // Create/update audio elements for active and soon-to-be-active clips.
   useEffect(() => {
     const audioEntries = audioElementsRef.current
+    const nowMs = getNowMs()
+    const nextTimelineSample = {
+      playheadPosition,
+      playbackRate,
+      isPlaying,
+      sampledAtMs: nowMs,
+    }
+    const timelineDiscontinuity = isAudioTimelineDiscontinuity(
+      previousTimelineSampleRef.current,
+      nextTimelineSample,
+      nowMs
+    )
+    previousTimelineSampleRef.current = nextTimelineSample
+    latestPlaybackRef.current = nextTimelineSample
 
-    // Remove audio elements for clips that are no longer active
-    const activeClipIds = new Set(activeAudioClips.map(({ clip }) => clip.id))
+    // Evict only clips outside the warm/retention window. This set is stable
+    // during ordinary playback and avoids cold-starting a decoder at each cut.
+    const retainedClipIds = new Set(audioPreviewCandidates.map(({ clip }) => clip.id))
     for (const [clipId, entry] of audioEntries.entries()) {
-      if (!activeClipIds.has(clipId)) {
-        entry.element.pause()
-        entry.element.src = ''
-        entry.sourceNode?.disconnect()
-        entry.gainNode?.disconnect()
+      if (!retainedClipIds.has(clipId)) {
+        disposeAudioEntry(entry)
         audioEntries.delete(clipId)
       }
     }
@@ -298,12 +523,20 @@ function AudioLayerRenderer() {
       monitorGainRef.current.gain.value = Math.max(0, volume)
     }
 
-    // Create/update audio elements for active clips
-    activeAudioClips.forEach(({ clip, track }) => {
-      const asset = getAssetById(clip.assetId)
-      if (!asset?.url) return
-
+    audioPreviewCandidates.forEach(({ clip, track, active, upcoming, prepareTimelineTime }) => {
+      const asset = assets.find(item => item.id === clip.assetId)
       let entry = audioEntries.get(clip.id)
+      const sourceUrl = asset?.url || clip.url || null
+      const preferredUrl = getAssetUrl(clip.assetId) || sourceUrl
+      const resolvedUrl = resolveAudioPreviewUrl({
+        preferredUrl,
+        sourceUrl,
+        currentUrl: entry?.currentSrc,
+        playing: Boolean(isPlaying && active && !clip.reverse),
+        failedUrl: entry?.failedUrl,
+        failedUrls: entry?.failedUrls,
+      })
+      if (!resolvedUrl) return
 
       if (!entry) {
         const audioEl = new Audio()
@@ -312,9 +545,32 @@ function AudioLayerRenderer() {
         entry = {
           element: audioEl,
           currentSrc: null,
+          sourceUrl: null,
+          preferredUrl: null,
+          cacheUrl: null,
+          failedUrl: null,
+          failedUrls: new Set(),
+          errorReported: false,
           sourceNode: null,
           gainNode: null,
           trackId: null,
+          clipId: clip.id,
+          clip: null,
+          track: null,
+          active: false,
+          desiredPlaying: false,
+          disposed: false,
+          generation: 0,
+          seekInFlight: false,
+          seekTarget: null,
+          pendingSeekTarget: null,
+          seekStartedAtMs: 0,
+          lastSeekAtMs: 0,
+          lastDriftCheckAtMs: 0,
+          startAlignmentAttempts: 0,
+          positionPrepared: false,
+          playPromise: null,
+          removeSourceListeners: null,
         }
 
         const audioContext = audioContextRef.current
@@ -351,84 +607,55 @@ function AudioLayerRenderer() {
       }
 
       const audioEl = entry.element
+      entry.clip = clip
+      entry.track = track
+      entry.sourceUrl = sourceUrl
+      entry.preferredUrl = preferredUrl
+      entry.cacheUrl = asset?.playbackCacheUrl || null
+      entry.active = active
+      entry.desiredPlaying = Boolean(isPlaying && active && !clip.reverse)
+      if (!active) entry.startAlignmentAttempts = 0
+      entry.disposed = false
 
       // Check if src actually changed (compare against our tracked src, not browser-resolved URL)
-      const srcChanged = entry.currentSrc !== asset.url
+      const srcChanged = entry.currentSrc !== resolvedUrl
       if (srcChanged) {
-        audioEl.src = asset.url
-        entry.currentSrc = asset.url
+        clearAudioEntryListeners(entry)
+        pauseAudioEntry(entry)
+        entry.generation += 1
+        entry.playPromise = null
+        entry.seekInFlight = false
+        entry.seekTarget = null
+        entry.pendingSeekTarget = null
+        entry.positionPrepared = false
+        entry.startAlignmentAttempts = 0
+        entry.errorReported = false
+        const sourceGeneration = entry.generation
+        const handleMediaState = (event) => {
+          if (entry.generation !== sourceGeneration) return
+          entryEventHandlerRef.current?.(entry, event?.type)
+        }
+        audioEl.addEventListener('loadedmetadata', handleMediaState)
+        audioEl.addEventListener('canplay', handleMediaState)
+        audioEl.addEventListener('seeked', handleMediaState)
+        audioEl.addEventListener('error', handleMediaState)
+        entry.removeSourceListeners = () => {
+          audioEl.removeEventListener('loadedmetadata', handleMediaState)
+          audioEl.removeEventListener('canplay', handleMediaState)
+          audioEl.removeEventListener('seeked', handleMediaState)
+          audioEl.removeEventListener('error', handleMediaState)
+        }
+        audioEl.src = resolvedUrl
+        entry.currentSrc = resolvedUrl
+        audioEl.load?.()
       }
 
-      // Calculate source time within the audio file (with speed/reverse)
       const clipTime = playheadPosition - clip.startTime
-      const speed = Number(clip.speed)
-      const speedScale = Number.isFinite(speed) && speed > 0 ? speed : 1
       const reverse = !!clip.reverse
-      const trimStart = clip.trimStart || 0
-      const rawTrimEnd = clip.trimEnd ?? clip.sourceDuration ?? trimStart
-      const trimEnd = Number.isFinite(rawTrimEnd) ? rawTrimEnd : trimStart
-      const minTime = Math.min(trimStart, trimEnd)
-      const maxTime = Math.max(trimStart, trimEnd)
-      const sourceTime = reverse
-        ? trimEnd - clipTime * speedScale
-        : trimStart + clipTime * speedScale
-      const clampedTime = Math.max(minTime, Math.min(sourceTime, maxTime - 0.01))
+      const clampedTime = getAudioSourceTimeAtTimeline(clip, playheadPosition)
 
-      // Check if we're within the clip's active range
-      const clipEnd = clip.startTime + clip.duration
-      const isWithinClip = playheadPosition >= clip.startTime && playheadPosition < clipEnd
-
-      // Reverse audio not supported with HTMLAudioElement; keep silent
-      if (reverse) {
-        audioEl.pause()
-        return
-      }
-
-      const effectiveRate = Math.abs(playbackRate) * speedScale
-
-      if (srcChanged) {
-        // Remove any prior loadeddata handlers to avoid stale closures
-        const onLoadedData = () => {
-          // Read from ref to get current isPlaying state (not stale closure)
-          const currentlyPlaying = isPlayingRef.current
-          if (isWithinClip && currentlyPlaying) {
-            audioEl.currentTime = clampedTime
-            audioEl.playbackRate = effectiveRate
-            audioEl.play().catch(err => {
-              console.warn('Failed to play audio clip:', err)
-            })
-          }
-        }
-        // Use { once: true } to auto-remove the listener
-        audioEl.addEventListener('loadeddata', onLoadedData, { once: true })
-      } else if (audioEl.readyState >= 2) {
-        // Audio is loaded - sync position
-        const timeDiff = Math.abs(audioEl.currentTime - clampedTime)
-        if (timeDiff > 0.1) {
-          audioEl.currentTime = clampedTime
-        }
-
-        // Set playback rate
-        if (Math.abs(audioEl.playbackRate - effectiveRate) > 0.01) {
-          audioEl.playbackRate = effectiveRate
-        }
-
-        // Play/pause based on timeline state and clip boundaries
-        if (isPlaying && isWithinClip) {
-          if (audioEl.paused) {
-            audioEl.play().catch(err => {
-              console.warn('Failed to play audio clip:', err)
-            })
-          }
-        } else {
-          if (!audioEl.paused) {
-            audioEl.pause()
-          }
-        }
-      }
-
-      const fadeGain = getAudioClipFadeGain(clip, clipTime)
-      const clipGain = getAudioClipLinearGain(clip) * fadeGain
+      const fadeGain = active ? getAudioClipFadeGain(clip, clipTime) : 0
+      const clipGain = active ? getAudioClipLinearGain(clip) * fadeGain : 0
 
       if (entry.gainNode) {
         entry.gainNode.gain.value = Math.max(0, clipGain)
@@ -441,18 +668,62 @@ function AudioLayerRenderer() {
         const fallbackVolume = Math.max(0, Math.min(1, volume * clipGain * trackGain * masterGain))
         audioEl.volume = fallbackVolume
       }
+
+      // Reverse audio not supported with HTMLAudioElement; keep silent
+      if (reverse) {
+        pauseAudioEntry(entry)
+        return
+      }
+
+      const effectiveRate = Math.max(0.01, Math.abs(playbackRate) * getAudioClipTimeScale(clip))
+      if (Math.abs(audioEl.playbackRate - effectiveRate) > 0.01) {
+        audioEl.playbackRate = effectiveRate
+      }
+
+      refreshAudioEntrySeekState(entry, nowMs)
+
+      // Warm upcoming clips at their source in-point. Active clips only seek
+      // on initial preparation, explicit timeline jumps, or bounded drift
+      // checks — never on every RAF update.
+      if (upcoming && Number.isFinite(prepareTimelineTime)) {
+        requestAudioEntrySeek(entry, getAudioSourceTimeAtTimeline(clip, prepareTimelineTime), nowMs)
+      } else if (active && (srcChanged || timelineDiscontinuity)) {
+        entry.startAlignmentAttempts = 0
+        requestAudioEntrySeek(entry, clampedTime, nowMs)
+      } else if (shouldCorrectAudioDrift({
+        active,
+        isPlaying,
+        isSeeking: entry.seekInFlight || audioEl.seeking,
+        currentTime: audioEl.currentTime,
+        expectedTime: clampedTime,
+        nowMs,
+        lastCheckAtMs: entry.lastDriftCheckAtMs,
+        lastSeekAtMs: entry.lastSeekAtMs,
+      })) {
+        entry.lastDriftCheckAtMs = nowMs
+        requestAudioEntrySeek(entry, clampedTime, nowMs)
+      } else if (
+        active
+        && isPlaying
+        && nowMs - entry.lastDriftCheckAtMs >= AUDIO_PREVIEW_DRIFT_CHECK_INTERVAL_MS
+      ) {
+        entry.lastDriftCheckAtMs = nowMs
+      }
+
+      if (entry.desiredPlaying) {
+        requestAudioEntryPlay(entry)
+      } else {
+        pauseAudioEntry(entry)
+      }
     })
-  }, [activeAudioClips, playheadPosition, isPlaying, playbackRate, getAssetById, clips, tracks, volume, masterAudioVolume, masterAudioInserts])
+  }, [audioPreviewCandidates, playheadPosition, isPlaying, playbackRate, getAssetUrl, assets, tracks, volume, masterAudioVolume, masterAudioInserts])
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       const audioEntries = audioElementsRef.current
       for (const entry of audioEntries.values()) {
-        entry.element.pause()
-        entry.element.src = ''
-        entry.sourceNode?.disconnect()
-        entry.gainNode?.disconnect()
+        disposeAudioEntry(entry)
       }
       audioEntries.clear()
     }

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -428,6 +428,7 @@ function ExportPanel() {
     || XML_EXPORT_FORMATS[0]
   const exportStartRef = useRef(null)
   const renderStartRef = useRef(null)
+  const nvencCheckRequestRef = useRef(0)
   const [nvencStatus, setNvencStatus] = useState({
     checked: false,
     available: false,
@@ -435,6 +436,10 @@ function ExportPanel() {
     h265: false,
     gpuName: null,
     kind: 'nvenc', // 'nvenc' | 'videotoolbox' — set by the platform-aware check
+    ffmpegSource: 'bundled',
+    ffmpegPath: null,
+    ffmpegVersion: null,
+    ffmpegWarning: null,
     error: null,
   })
   const [queueRunning, setQueueRunning] = useState(false)
@@ -462,14 +467,16 @@ function ExportPanel() {
   useEffect(() => {
     let cancelled = false
     
-    const checkNvenc = async () => {
+    const checkNvenc = async (options = undefined) => {
+      const requestId = ++nvencCheckRequestRef.current
       if (!window.electronAPI?.checkNvenc) {
-        setNvencStatus({ checked: true, available: false, h264: false, h265: false, gpuName: null, kind: 'nvenc', error: 'Hardware encoder check unavailable' })
+        if (cancelled || requestId !== nvencCheckRequestRef.current) return
+        setNvencStatus({ checked: true, available: false, h264: false, h265: false, gpuName: null, kind: 'nvenc', ffmpegSource: 'bundled', ffmpegPath: null, ffmpegVersion: null, ffmpegWarning: null, error: 'Hardware encoder check unavailable' })
         return
       }
       try {
-        const result = await window.electronAPI.checkNvenc()
-        if (cancelled) return
+        const result = await window.electronAPI.checkNvenc(options)
+        if (cancelled || requestId !== nvencCheckRequestRef.current) return
         setNvencStatus({
           checked: true,
           available: !!result.available,
@@ -477,10 +484,14 @@ function ExportPanel() {
           h265: !!result.h265,
           gpuName: result.gpuName || null,
           kind: result.kind || 'nvenc',
+          ffmpegSource: result.ffmpegSource || 'bundled',
+          ffmpegPath: result.ffmpegPath || null,
+          ffmpegVersion: result.ffmpegVersion || null,
+          ffmpegWarning: result.ffmpegWarning || null,
           error: result.error || null,
         })
       } catch (err) {
-        if (cancelled) return
+        if (cancelled || requestId !== nvencCheckRequestRef.current) return
         setNvencStatus({
           checked: true,
           available: false,
@@ -488,14 +499,25 @@ function ExportPanel() {
           h265: false,
           gpuName: null,
           kind: 'nvenc',
+          ffmpegSource: 'bundled',
+          ffmpegPath: null,
+          ffmpegVersion: null,
+          ffmpegWarning: null,
           error: err.message,
         })
       }
     }
     
     checkNvenc()
+    const unsubscribe = window.electronAPI?.onHardwareExportFfmpegChanged?.(() => {
+      if (cancelled) return
+      setNvencStatus((current) => ({ ...current, checked: false, error: null }))
+      void checkNvenc({ forceRefresh: true })
+    })
     return () => {
       cancelled = true
+      nvencCheckRequestRef.current += 1
+      unsubscribe?.()
     }
   }, [])
 
@@ -723,13 +745,13 @@ function ExportPanel() {
       return `${hardwareLabel} is not used for ProRes exports.`
     }
     if (nvencStatus.checked && !nvencStatus.available) {
-      return `${hardwareLabel} not available in your FFmpeg build.`
+      return `${hardwareLabel} is not available in the active FFmpeg.`
     }
     if (settings.videoCodec === 'h265' && nvencStatus.checked && !nvencStatus.h265) {
-      return `HEVC ${hardwareLabel} is not available in your FFmpeg build.`
+      return `HEVC ${hardwareLabel} is not available in the active FFmpeg.`
     }
     if (settings.videoCodec === 'h264' && nvencStatus.checked && !nvencStatus.h264) {
-      return `H.264 ${hardwareLabel} is not available in your FFmpeg build.`
+      return `H.264 ${hardwareLabel} is not available in the active FFmpeg.`
     }
     return null
   }, [settings.format, settings.videoCodec, nvencStatus, hardwareLabel])
@@ -741,24 +763,30 @@ function ExportPanel() {
     const gpuPrefix = nvencStatus.gpuName
       ? `Detected GPU: ${nvencStatus.gpuName}. `
       : ''
+    const ffmpegSourcePrefix = nvencStatus.ffmpegSource === 'environment'
+      ? 'Environment FFmpeg. '
+      : nvencStatus.ffmpegSource === 'setting'
+        ? 'Custom FFmpeg. '
+        : 'Bundled FFmpeg. '
+    const warningSuffix = nvencStatus.ffmpegWarning ? ` ${nvencStatus.ffmpegWarning}` : ''
 
     if (!nvencStatus.available) {
-      return gpuPrefix + (nvencStatus.error || `${hardwareLabel} not detected in FFmpeg. Hardware encoding will be unavailable.`)
+      return ffmpegSourcePrefix + gpuPrefix + (nvencStatus.error || `${hardwareLabel} not detected in FFmpeg. Hardware encoding will be unavailable.`)
     }
 
     if (settings.format === 'webm' || settings.videoCodec === 'vp9') {
-      return `${gpuPrefix}${hardwareLabel} is ready for MP4 H.264/H.265 exports. Switch from WebM/VP9 to use it.`
+      return `${ffmpegSourcePrefix}${gpuPrefix}${hardwareLabel} is ready for MP4 H.264/H.265 exports. Switch from WebM/VP9 to use it.${warningSuffix}`
     }
 
     if (settings.format === 'prores') {
-      return `${gpuPrefix}${hardwareLabel} is ready for MP4 H.264/H.265 exports. ProRes always uses software encoding.`
+      return `${ffmpegSourcePrefix}${gpuPrefix}${hardwareLabel} is ready for MP4 H.264/H.265 exports. ProRes always uses software encoding.${warningSuffix}`
     }
 
     if (selectedNvencCodecSupported) {
-      return `${gpuPrefix}${hardwareLabel} is ready for faster ${settings.videoCodec === 'h265' ? 'H.265' : 'H.264'} exports.`
+      return `${ffmpegSourcePrefix}${gpuPrefix}${hardwareLabel} is ready for faster ${settings.videoCodec === 'h265' ? 'H.265' : 'H.264'} exports.${warningSuffix}`
     }
 
-    return `${gpuPrefix}${hardwareLabel} is detected, but the current codec is not available in this FFmpeg build.`
+    return `${ffmpegSourcePrefix}${gpuPrefix}${hardwareLabel} is detected, but the current codec is not available in this FFmpeg build.${warningSuffix}`
   }, [nvencStatus, selectedNvencCodecSupported, settings.format, settings.videoCodec, hardwareLabel])
   const nvencExpectedEncoder = settings.useHardwareEncoder && selectedNvencCodecSupported
     ? (settings.videoCodec === 'h265'

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import {
   X, Server, FolderOpen, Palette, Monitor, Save,
   HardDrive, Film, Keyboard, Wrench, Power,
@@ -183,6 +183,13 @@ function GeneralTab({ initialSection = null }) {
   })
   const [outputPath, setOutputPath] = useState('')
   const [workflowPath, setWorkflowPath] = useState('')
+  const [hardwareExportFfmpegPath, setHardwareExportFfmpegPathState] = useState('')
+  const [hardwareExportFfmpegStatus, setHardwareExportFfmpegStatus] = useState(null)
+  const [hardwareExportFfmpegTest, setHardwareExportFfmpegTest] = useState(null)
+  const [hardwareExportFfmpegBusy, setHardwareExportFfmpegBusy] = useState('')
+  const [hardwareExportFfmpegMessage, setHardwareExportFfmpegMessage] = useState('')
+  const hardwareExportFfmpegInputDirtyRef = useRef(false)
+  const hardwareExportFfmpegStatusGenerationRef = useRef(0)
   const [activeThemeId, setActiveThemeId] = useState(() => getStoredThemeId())
   const [generationCompletionSoundSettings, setGenerationCompletionSoundSettingsState] = useState(() => (
     getGenerationCompletionSoundSettings()
@@ -241,16 +248,30 @@ function GeneralTab({ initialSection = null }) {
   useEffect(() => {
     getPexelsApiKey().then((key) => setPexelsApiKeyLocal(key || ''))
     ;(async () => {
+      const hardwareFfmpegStatusGeneration = hardwareExportFfmpegStatusGenerationRef.current
       try {
-        const [storedOutputPath, storedWorkflowPath] = await Promise.all([
+        const [storedOutputPath, storedWorkflowPath, hardwareFfmpegStatus] = await Promise.all([
           window.electronAPI?.getSetting?.(OUTPUT_DIRECTORY_SETTING_KEY),
           window.electronAPI?.getSetting?.(WORKFLOWS_DIRECTORY_SETTING_KEY),
+          window.electronAPI?.getHardwareExportFfmpegStatus?.(),
         ])
         setOutputPath(String(storedOutputPath || ''))
         setWorkflowPath(String(storedWorkflowPath || ''))
+        if (
+          hardwareFfmpegStatus
+          && hardwareFfmpegStatusGeneration === hardwareExportFfmpegStatusGenerationRef.current
+        ) {
+          if (!hardwareExportFfmpegInputDirtyRef.current) {
+            setHardwareExportFfmpegPathState(String(hardwareFfmpegStatus.settingPath || ''))
+          }
+          setHardwareExportFfmpegStatus(hardwareFfmpegStatus)
+        }
       } catch {
         setOutputPath('')
         setWorkflowPath('')
+        if (hardwareFfmpegStatusGeneration === hardwareExportFfmpegStatusGenerationRef.current) {
+          setHardwareExportFfmpegStatus(null)
+        }
       }
 
       try {
@@ -502,6 +523,114 @@ function GeneralTab({ initialSection = null }) {
       if (selectedPath) onSelect(selectedPath)
     } catch (error) {
       console.error('Could not open directory picker:', error)
+    }
+  }
+
+  const handleChooseHardwareExportFfmpeg = async () => {
+    if (!window.electronAPI?.selectFile) {
+      setHardwareExportFfmpegMessage('File picker is not available in this environment.')
+      return
+    }
+    try {
+      const selectedPath = await window.electronAPI.selectFile({
+        title: 'Select FFmpeg for hardware export',
+        defaultPath: hardwareExportFfmpegPath || hardwareExportFfmpegStatus?.activePath || undefined,
+        filters: [{ name: 'FFmpeg executable', extensions: ['*'] }],
+      })
+      if (selectedPath) {
+        hardwareExportFfmpegInputDirtyRef.current = true
+        setHardwareExportFfmpegPathState(String(selectedPath))
+        setHardwareExportFfmpegTest(null)
+        setHardwareExportFfmpegMessage('Path selected. Save it to validate and activate it.')
+      }
+    } catch (error) {
+      setHardwareExportFfmpegMessage(error?.message || 'Could not choose an FFmpeg executable.')
+    }
+  }
+
+  const handleSaveHardwareExportFfmpeg = async () => {
+    const selectedPath = hardwareExportFfmpegPath.trim()
+    if (!selectedPath) {
+      setHardwareExportFfmpegMessage('Choose an FFmpeg executable or use the bundled default.')
+      return
+    }
+    if (!window.electronAPI?.setHardwareExportFfmpegPath) {
+      setHardwareExportFfmpegMessage('Hardware-export FFmpeg settings are not available in this environment.')
+      return
+    }
+
+    hardwareExportFfmpegStatusGenerationRef.current += 1
+    setHardwareExportFfmpegBusy('saving')
+    setHardwareExportFfmpegTest(null)
+    setHardwareExportFfmpegMessage('Validating FFmpeg...')
+    try {
+      const result = await window.electronAPI.setHardwareExportFfmpegPath(selectedPath)
+      if (!result?.success) {
+        setHardwareExportFfmpegMessage(result?.error || 'The selected FFmpeg executable could not be saved.')
+        return
+      }
+      setHardwareExportFfmpegStatus(result.status || null)
+      setHardwareExportFfmpegPathState(String(result.status?.settingPath || selectedPath))
+      hardwareExportFfmpegInputDirtyRef.current = false
+      setHardwareExportFfmpegMessage(
+        result.status?.source === 'environment'
+          ? 'Saved. VELORN_FFMPEG_PATH still takes priority for this app session.'
+          : 'Hardware-export FFmpeg saved and ready to test.'
+      )
+    } catch (error) {
+      setHardwareExportFfmpegMessage(error?.message || 'Could not save the hardware-export FFmpeg path.')
+    } finally {
+      setHardwareExportFfmpegBusy('')
+    }
+  }
+
+  const handleResetHardwareExportFfmpeg = async () => {
+    if (!window.electronAPI?.resetHardwareExportFfmpegPath) return
+    hardwareExportFfmpegStatusGenerationRef.current += 1
+    setHardwareExportFfmpegBusy('resetting')
+    setHardwareExportFfmpegTest(null)
+    try {
+      const result = await window.electronAPI.resetHardwareExportFfmpegPath()
+      if (!result?.success) {
+        setHardwareExportFfmpegMessage(result?.error || 'Could not restore the bundled FFmpeg setting.')
+        return
+      }
+      setHardwareExportFfmpegPathState('')
+      hardwareExportFfmpegInputDirtyRef.current = false
+      setHardwareExportFfmpegStatus(result.status || null)
+      setHardwareExportFfmpegMessage(
+        result.status?.source === 'environment'
+          ? 'Saved path cleared. VELORN_FFMPEG_PATH remains active.'
+          : 'Velorn will use its bundled FFmpeg for hardware checks and software fallback.'
+      )
+    } catch (error) {
+      setHardwareExportFfmpegMessage(error?.message || 'Could not restore the bundled FFmpeg setting.')
+    } finally {
+      setHardwareExportFfmpegBusy('')
+    }
+  }
+
+  const handleTestHardwareExportFfmpeg = async () => {
+    if (!window.electronAPI?.checkNvenc) return
+    hardwareExportFfmpegStatusGenerationRef.current += 1
+    setHardwareExportFfmpegBusy('testing')
+    setHardwareExportFfmpegMessage('Testing the active FFmpeg and hardware encoder...')
+    try {
+      const result = await window.electronAPI.checkNvenc({ forceRefresh: true })
+      setHardwareExportFfmpegTest(result)
+      const status = await window.electronAPI.getHardwareExportFfmpegStatus?.()
+      if (status) setHardwareExportFfmpegStatus(status)
+      if (result?.available) {
+        const codecs = [result.h264 ? 'H.264' : '', result.h265 ? 'H.265' : ''].filter(Boolean).join(' and ')
+        setHardwareExportFfmpegMessage(`${codecs} hardware encoding is ready.`)
+      } else {
+        setHardwareExportFfmpegMessage(result?.error || 'This FFmpeg does not provide a usable hardware encoder. CPU export remains available.')
+      }
+    } catch (error) {
+      setHardwareExportFfmpegTest(null)
+      setHardwareExportFfmpegMessage(error?.message || 'Could not test the active FFmpeg executable.')
+    } finally {
+      setHardwareExportFfmpegBusy('')
     }
   }
 
@@ -1098,6 +1227,111 @@ function GeneralTab({ initialSection = null }) {
                 ...
               </button>
             </div>
+          </div>
+
+          <div className="rounded-lg border border-sf-dark-700 bg-sf-dark-900/60 px-3 py-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-sm font-medium text-sf-text-primary">Hardware export FFmpeg</div>
+                <p className="mt-1 text-[10px] text-sf-text-muted">
+                  Advanced: choose an FFmpeg build with NVENC on Linux. It is used only for final H.264/H.265 hardware video encoding; Velorn keeps its bundled FFmpeg for media tools and as the safe CPU fallback.
+                </p>
+              </div>
+              <span className="flex-shrink-0 rounded border border-sf-dark-600 bg-sf-dark-800 px-2 py-1 text-[10px] text-sf-text-secondary">
+                {hardwareExportFfmpegStatus?.source === 'environment'
+                  ? 'Environment'
+                  : hardwareExportFfmpegStatus?.source === 'setting'
+                    ? 'Custom'
+                    : 'Bundled'}
+              </span>
+            </div>
+
+            <div className="mt-3 flex gap-2">
+              <input
+                type="text"
+                value={hardwareExportFfmpegPath}
+                onChange={(event) => {
+                  hardwareExportFfmpegInputDirtyRef.current = true
+                  setHardwareExportFfmpegPathState(event.target.value)
+                  setHardwareExportFfmpegTest(null)
+                  setHardwareExportFfmpegMessage('')
+                }}
+                placeholder={window.electronAPI?.platform === 'win32' ? 'C:\\path\\to\\ffmpeg.exe' : '/usr/bin/ffmpeg'}
+                className="flex-1 min-w-0 bg-sf-dark-800 border border-sf-dark-600 rounded px-3 py-2 text-xs text-sf-text-primary focus:outline-none focus:border-sf-accent truncate"
+              />
+              <button
+                type="button"
+                onClick={() => { void handleChooseHardwareExportFfmpeg() }}
+                disabled={Boolean(hardwareExportFfmpegBusy)}
+                className="px-3 py-2 bg-sf-dark-700 hover:bg-sf-dark-600 rounded text-xs text-sf-text-secondary transition-colors flex-shrink-0 disabled:cursor-wait disabled:opacity-50"
+              >
+                Browse
+              </button>
+            </div>
+
+            <div className="mt-2 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => { void handleSaveHardwareExportFfmpeg() }}
+                disabled={Boolean(hardwareExportFfmpegBusy) || !hardwareExportFfmpegPath.trim()}
+                className="rounded bg-sf-accent px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-sf-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {hardwareExportFfmpegBusy === 'saving' ? 'Validating...' : 'Save path'}
+              </button>
+              <button
+                type="button"
+                onClick={() => { void handleTestHardwareExportFfmpeg() }}
+                disabled={Boolean(hardwareExportFfmpegBusy)}
+                className="inline-flex items-center gap-1 rounded bg-sf-dark-700 px-3 py-1.5 text-xs text-sf-text-secondary transition-colors hover:bg-sf-dark-600 disabled:cursor-wait disabled:opacity-50"
+              >
+                <RefreshCcw className={`h-3 w-3 ${hardwareExportFfmpegBusy === 'testing' ? 'animate-spin' : ''}`} />
+                Test active FFmpeg
+              </button>
+              <button
+                type="button"
+                onClick={() => { void handleResetHardwareExportFfmpeg() }}
+                disabled={Boolean(hardwareExportFfmpegBusy) || (!hardwareExportFfmpegPath && hardwareExportFfmpegStatus?.source !== 'setting')}
+                className="rounded bg-sf-dark-700 px-3 py-1.5 text-xs text-sf-text-secondary transition-colors hover:bg-sf-dark-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {hardwareExportFfmpegStatus?.source === 'environment' ? 'Clear saved path' : 'Use bundled FFmpeg'}
+              </button>
+            </div>
+
+            {hardwareExportFfmpegStatus?.activePath && (
+              <div className="mt-3 rounded border border-sf-dark-700 bg-black/20 px-2.5 py-2 text-[10px] text-sf-text-muted">
+                <div className="flex gap-1">
+                  <span className="flex-shrink-0 uppercase tracking-wider">Active:</span>
+                  <code className="min-w-0 break-all text-sf-text-secondary">{hardwareExportFfmpegStatus.activePath}</code>
+                </div>
+                {hardwareExportFfmpegStatus.version && (
+                  <div className="mt-1 break-all">{hardwareExportFfmpegStatus.version}</div>
+                )}
+              </div>
+            )}
+
+            {hardwareExportFfmpegStatus?.environmentPath && (
+              <p className="mt-2 text-[10px] text-yellow-300">
+                VELORN_FFMPEG_PATH is active and takes priority over the saved path until Velorn is restarted without it.
+              </p>
+            )}
+            {hardwareExportFfmpegStatus?.warning && (
+              <p className="mt-2 text-[10px] text-yellow-300">{hardwareExportFfmpegStatus.warning}</p>
+            )}
+            {hardwareExportFfmpegMessage && (
+              <p className={`mt-2 text-[10px] ${hardwareExportFfmpegTest?.available ? 'text-green-300' : 'text-sf-text-muted'}`}>
+                {hardwareExportFfmpegMessage}
+              </p>
+            )}
+            {hardwareExportFfmpegTest && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                <span className={`rounded border px-1.5 py-0.5 text-[10px] ${hardwareExportFfmpegTest.h264 ? 'border-green-500/40 bg-green-500/10 text-green-300' : 'border-sf-dark-600 text-sf-text-muted'}`}>
+                  H.264 {hardwareExportFfmpegTest.kind === 'videotoolbox' ? 'VideoToolbox' : 'NVENC'}
+                </span>
+                <span className={`rounded border px-1.5 py-0.5 text-[10px] ${hardwareExportFfmpegTest.h265 ? 'border-green-500/40 bg-green-500/10 text-green-300' : 'border-sf-dark-600 text-sf-text-muted'}`}>
+                  H.265 {hardwareExportFfmpegTest.kind === 'videotoolbox' ? 'VideoToolbox' : 'NVENC'}
+                </span>
+              </div>
+            )}
           </div>
         </div>
       )

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -21,6 +21,7 @@ import useViewportClampedPosition from '../hooks/useViewportClampedPosition'
 import { getAllKeyframeTimes } from '../utils/keyframes'
 import { TRANSITION_TYPES, TRANSITION_DURATIONS, FRAME_RATE } from '../constants/transitions'
 import { getAudioClipFadeValues } from '../utils/audioClipFades'
+import { buildAudioClipSplitState } from '../utils/audioClipSplit'
 import { getSpriteFramePosition } from '../services/thumbnailSprites'
 import { getEffectTypeDefinition } from '../utils/effects'
 import { isTextEditingElement } from '../utils/keyboardFocus'
@@ -2771,10 +2772,12 @@ function Timeline({ onActiveToolChange, onStatusChange }) {
   }, [])
 
   const splitClipAtTime = useCallback((clip, splitPosition, { saveHistory = false } = {}) => {
-    if (!clip || isSyncLockedClip(clip) || splitPosition <= clip.startTime || splitPosition >= clip.startTime + clip.duration) return null
+    const snappedSplitPosition = quantizeTimeToFrame(splitPosition, getSafeTimelineFps(timelineFps))
+    if (!clip || isSyncLockedClip(clip) || snappedSplitPosition <= clip.startTime || snappedSplitPosition >= clip.startTime + clip.duration) return null
 
-    const splitTime = splitPosition - clip.startTime
+    const splitTime = snappedSplitPosition - clip.startTime
     const remainder = clip.duration - splitTime
+    const track = tracks.find((candidate) => candidate.id === clip.trackId)
 
     let asset = null
     if (clip.type !== 'text' && clip.type !== 'shape' && clip.type !== 'adjustment') {
@@ -2787,6 +2790,19 @@ function Timeline({ onActiveToolChange, onStatusChange }) {
     }
 
     resizeClip(clip.id, splitTime)
+    const audioSplitState = buildAudioClipSplitState(clip, track, asset, {
+      left: splitTime,
+      right: remainder,
+    })
+    if (audioSplitState) {
+      useTimelineStore.setState((state) => ({
+        clips: state.clips.map((candidate) => (
+          candidate.id === clip.id
+            ? { ...candidate, ...audioSplitState.leftClipUpdates }
+            : candidate
+        )),
+      }))
+    }
 
     if (clip.type === 'text') {
       const textOptions = {
@@ -2796,7 +2812,7 @@ function Timeline({ onActiveToolChange, onStatusChange }) {
         effects: clip.effects,
         saveHistory: false,
       }
-      return addTextClip(clip.trackId, textOptions, splitPosition)
+      return addTextClip(clip.trackId, textOptions, snappedSplitPosition)
     }
 
     if (clip.type === 'shape') {
@@ -2808,11 +2824,11 @@ function Timeline({ onActiveToolChange, onStatusChange }) {
         enabled: isClipEnabled(clip),
         effects: clip.effects,
         saveHistory: false,
-      }, splitPosition)
+      }, snappedSplitPosition)
     }
 
     if (clip.type === 'adjustment') {
-      return addAdjustmentClip(clip.trackId, splitPosition, {
+      return addAdjustmentClip(clip.trackId, snappedSplitPosition, {
         duration: remainder,
         name: clip.name,
         adjustments: clip.adjustments || {},
@@ -2827,21 +2843,17 @@ function Timeline({ onActiveToolChange, onStatusChange }) {
     const sourceTimeAtCut = (clip.trimStart || 0) + splitTime * timeScale
     const sourceTrimEnd = sourceTimeAtCut + remainder * timeScale
 
-    return addClip(clip.trackId, asset, splitPosition, timelineFps, {
+    return addClip(clip.trackId, audioSplitState?.asset || asset, snappedSplitPosition, timelineFps, {
       duration: remainder,
       trimStart: sourceTimeAtCut,
       trimEnd: sourceTrimEnd,
       enabled: isClipEnabled(clip),
       transform: clip.transform,
       effects: clip.effects,
-      ...(clip.type === 'audio'
-        ? {
-            gainDb: clip.gainDb,
-          }
-        : {}),
+      ...(audioSplitState?.rightClipOptions || {}),
       saveHistory: false,
     })
-  }, [assets, saveToHistory, resizeClip, addTextClip, addShapeClip, addAdjustmentClip, addClip, timelineFps, isClipEnabled])
+  }, [assets, tracks, saveToHistory, resizeClip, addTextClip, addShapeClip, addAdjustmentClip, addClip, timelineFps, isClipEnabled])
 
   const splitAllTracksAtPlayhead = useCallback(() => {
     const playheadPosition = getLivePlayhead()

--- a/src/services/exporter.js
+++ b/src/services/exporter.js
@@ -18,6 +18,7 @@ import { drawLiveCaptionsFrame } from '../utils/captionRenderer'
 import { getAudioClipFadeGain, getAudioClipFadeValues } from '../utils/audioClipFades'
 import { getAudioClipLinearGain, normalizeAudioClipGainDb } from '../utils/audioClipGain'
 import { clampTrackVolume, hasAudioSolo, isAudioTrackAudible, trackPanToStereoPosition, trackVolumeToLinearGain } from '../utils/audioTrackAudibility'
+import { collectAudioMixClips, countExpectedAudioMixClips } from '../../electron/audioMixEligibility.mjs'
 import { getEnabledAudioInserts, hasEnabledAudioInserts } from '../utils/audioInserts'
 import { buildInsertChain } from './audioInsertChain'
 import {
@@ -1030,7 +1031,9 @@ const serializeAudioClipForMix = (clip) => ({
   id: clip.id,
   assetId: clip.assetId,
   trackId: clip.trackId,
-  type: clip.type,
+  // Audio-track placement is authoritative for legacy split fragments whose
+  // persisted clip type was accidentally changed to "video".
+  type: 'audio',
   startTime: clip.startTime,
   duration: clip.duration,
   trimStart: clip.trimStart || 0,
@@ -1065,15 +1068,8 @@ const serializeAudioTracksForMix = (tracks) => (tracks || [])
     pan: track.pan ?? 0,
   }))
 
-const countExpectedAudioMixClips = (clips, rangeStart, rangeEnd) => clips.filter((clip) => {
-  if (clip.reverse) return false // Reverse audio is intentionally silent.
-  const clipStart = Number(clip.startTime) || 0
-  const clipDuration = Math.max(0, Number(clip.duration) || 0)
-  return clipDuration > 0 && clipStart < rangeEnd && clipStart + clipDuration > rangeStart
-}).length
-
 const collectEligibleAudioMix = (timelineState) => {
-  const audioClips = timelineState.clips.filter(clip => clip.type === 'audio' && clip.enabled !== false)
+  const audioClips = collectAudioMixClips(timelineState.clips, timelineState.tracks)
   const anyAudioSolo = hasAudioSolo(timelineState.tracks)
   const activeTracks = timelineState.tracks.filter(t => t.type === 'audio' && isAudioTrackAudible(t, anyAudioSolo))
   const activeTrackIds = new Set(activeTracks.map(track => track.id))
@@ -1367,6 +1363,7 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
   let framePipeSessionId = null
   let framePipeEncoderUsed = null
   let framePipeHardwareFallback = null
+  let framePipeHardwareFfmpeg = null
   
   onProgress({ status: EXPORT_STATUS.preparing, progress: 2 })
   
@@ -1820,6 +1817,7 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
         console.warn(`[Export] Hardware encoder unavailable (${framePipeHardwareFallback.requestedEncoder}): ${framePipeHardwareFallback.reason} — exporting with ${framePipeHardwareFallback.fallbackEncoder}.`)
         onProgress({ status: `Hardware encoder unavailable — exporting with ${framePipeHardwareFallback.fallbackEncoder}`, progress: 4 })
       }
+      framePipeHardwareFfmpeg = pipeStart.hardwareFfmpeg || null
     } else if (pipeStart?.code === 'ffmpeg-missing' || pipeStart?.code === 'spawn-failed') {
       // The PNG fallback needs the same FFmpeg binary for its encode step,
       // so an unstartable FFmpeg would only fail again after rendering
@@ -3258,9 +3256,7 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
       onProgress({ status: `Mixing audio (${elapsed}s) • ${message}`, progress })
     }
     updateAudioStatus('Preparing audio clips', 80)
-    const audioClips = timelineState.clips.filter(clip => clip.type === 'audio' && clip.enabled !== false)
-    const anyAudioSolo = hasAudioSolo(timelineState.tracks)
-    const activeTracks = timelineState.tracks.filter(t => t.type === 'audio' && isAudioTrackAudible(t, anyAudioSolo))
+    const { audioClips, activeTracks, eligibleAudioClips } = collectEligibleAudioMix(timelineState)
     // Program master gain from the mixer; part of the program, so it must be
     // baked into the export mix (unlike the preview-only monitor volume).
     const masterAudioGain = clampTrackVolume(timelineState.masterAudioVolume) / 100
@@ -3268,8 +3264,6 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
     if (audioClips.length > 0 && activeTracks.length > 0) {
       const sampleRate = audioSampleRate || DEFAULT_SAMPLE_RATE
       const channelCount = audioChannels || 2
-      const activeTrackIds = new Set(activeTracks.map(track => track.id))
-      const eligibleAudioClips = audioClips.filter(clip => activeTrackIds.has(clip.trackId))
 
       // Shared module-level builders (see above exportTimeline) so the
       // pre-render validation, the audio-only export, and this mix can
@@ -3596,7 +3590,9 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
         for (let index = 0; index < eligibleAudioClips.length; index++) {
           const clip = eligibleAudioClips[index]
           const track = timelineState.tracks.find(t => t.id === clip.trackId)
-          if (!track || !isAudioTrackAudible(track, anyAudioSolo)) continue
+          // eligibleAudioClips already applies the shared mute/solo/visibility
+          // predicate; only guard against a concurrently removed track here.
+          if (!track) continue
           const asset = assetsState.getAssetById(clip.assetId)
           if (!asset?.url) continue
           let audioUrl = resolvedAudioUrlCache.get(asset.id)
@@ -3816,6 +3812,7 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
     // export fell back to software ({requestedEncoder, fallbackEncoder,
     // reason}); surfaced in the worker-complete log and MCP export results.
     hardwareFallback: framePipeHardwareFallback || encodeResult.hardwareFallback || null,
+    hardwareFfmpeg: framePipeHardwareFfmpeg || encodeResult.hardwareFfmpeg || null,
     // Surfaced in the main window's '[ExportPanel] Worker export complete'
     // log — the export runs in a hidden worker window whose own console
     // isn't visible in normal devtools captures.

--- a/src/services/mcpActions.js
+++ b/src/services/mcpActions.js
@@ -11,6 +11,7 @@ import { normalizeTrackMatte } from '../utils/trackMatte'
 import { DEFAULT_SHAPE_MASK, DEFAULT_SPLINE_POINTS, SHAPE_MASK_TYPES, normalizeShapeMask, normalizeSplinePoints } from '../utils/shapeMask'
 import { clampTrackPan, clampTrackVolume } from '../utils/audioTrackAudibility'
 import { normalizeAudioInserts } from '../utils/audioInserts'
+import { buildAudioClipSplitState } from '../utils/audioClipSplit'
 import {
   MUSIC_KEY_SCALES,
   MUSIC_TIME_SIGNATURES,
@@ -3147,6 +3148,7 @@ function splitTimelineClipAtTime(clip, splitPosition) {
   const splitTime = splitPosition - clip.startTime
   const remainder = clip.duration - splitTime
   const enabled = clip.enabled !== false
+  const track = (useTimelineStore.getState().tracks || []).find((candidate) => candidate.id === clip.trackId)
 
   let asset = null
   if (clip.type !== 'text' && clip.type !== 'shape' && clip.type !== 'adjustment') {
@@ -3155,6 +3157,19 @@ function splitTimelineClipAtTime(clip, splitPosition) {
   }
 
   useTimelineStore.getState().resizeClip?.(clip.id, splitTime)
+  const audioSplitState = buildAudioClipSplitState(clip, track, asset, {
+    left: splitTime,
+    right: remainder,
+  })
+  if (audioSplitState) {
+    useTimelineStore.setState((state) => ({
+      clips: state.clips.map((candidate) => (
+        candidate.id === clip.id
+          ? { ...candidate, ...audioSplitState.leftClipUpdates }
+          : candidate
+      )),
+    }))
+  }
 
   if (clip.type === 'text') {
     return useTimelineStore.getState().addTextClip?.(clip.trackId, {
@@ -3192,7 +3207,7 @@ function splitTimelineClipAtTime(clip, splitPosition) {
   const sourceTrimEnd = sourceTimeAtCut + remainder * timeScale
   const rightClip = useTimelineStore.getState().addClip?.(
     clip.trackId,
-    asset,
+    audioSplitState?.asset || asset,
     splitPosition,
     Number(useTimelineStore.getState().timelineFps) || 24,
     {
@@ -3204,22 +3219,10 @@ function splitTimelineClipAtTime(clip, splitPosition) {
       // media clips keep their layout and label.
       ...(clip.transform ? { transform: safeClone(clip.transform) } : {}),
       ...(clip.labelColor ? { labelColor: clip.labelColor } : {}),
-      ...(clip.type === 'audio' ? { gainDb: clip.gainDb, fadeIn: clip.fadeIn, fadeOut: clip.fadeOut } : {}),
+      ...(audioSplitState?.rightClipOptions || {}),
       saveHistory: false,
     }
   )
-  // addClip always derives type from the asset (e.g. a video file's audio
-  // track clip has type 'audio' but an asset.type of 'video'); patch it back
-  // so the split piece matches the original instead of silently becoming a
-  // visual clip that tools filtering on clip.type === 'audio' won't find.
-  if (rightClip && clip.type && rightClip.type !== clip.type) {
-    useTimelineStore.setState((state) => ({
-      clips: state.clips.map((candidate) => (
-        candidate.id === rightClip.id ? { ...candidate, type: clip.type } : candidate
-      )),
-    }))
-    rightClip.type = clip.type
-  }
   return rightClip
 }
 

--- a/src/stores/timelineStore.js
+++ b/src/stores/timelineStore.js
@@ -8,6 +8,7 @@ import { normalizeAudioClipGainDb } from '../utils/audioClipGain'
 import { clampTrackPan, clampTrackVolume } from '../utils/audioTrackAudibility'
 import { hasVideoSolo, isVideoTrackVisible } from '../utils/videoTrackVisibility'
 import { normalizeAudioInserts } from '../utils/audioInserts'
+import { normalizeVideoBackedAudioClips } from '../utils/audioClipSplit'
 import { CLIP_COMPOSITE_MODE, normalizeClipCompositeMode } from '../utils/layerCompositing'
 import { getKeyframeTimeTolerance } from '../utils/keyframes'
 import { DEFAULT_SHAPE_MASK, normalizeShapeMask } from '../utils/shapeMask'
@@ -1208,7 +1209,7 @@ export const useTimelineStore = create(
    * @param {object} asset
    * @param {number|null} startTime
    * @param {number|null} timelineFps
-   * @param {object} [options] - Optional overrides for split/second-half: { duration, trimStart, trimEnd }
+   * @param {object} [options] - Optional overrides for split/second-half, including duration, trim, and retime state
    */
   addClip: (trackId, asset, startTime = null, timelineFps = null, options = null) => {
     const state = get()
@@ -1236,6 +1237,10 @@ export const useTimelineStore = create(
     const sourceDuration = isImage ? Infinity : (assetDuration || 5)
     const sourceFps = isVideo ? Number(asset.settings?.fps ?? asset.fps) : null
     const normalizedTimelineFps = Number(timelineFps)
+    const optionSourceFps = Number(options?.sourceFps)
+    const optionTimelineFps = Number(options?.timelineFps)
+    const optionSourceTimeScale = Number(options?.sourceTimeScale)
+    const optionSpeed = Number(options?.speed)
     const assetDefaultTransform = (
       asset?.settings?.defaultTransform
       && typeof asset.settings.defaultTransform === 'object'
@@ -1295,11 +1300,17 @@ export const useTimelineStore = create(
       sourceDuration: sourceDuration, // Original media duration (Infinity for images)
       trimStart: finalTrimStart, // In-point (seconds from source start)
       trimEnd: syncLock ? finalTrimStart + anchoredDuration : finalTrimEnd, // Out-point (for images, this can grow)
-      sourceFps: Number.isFinite(sourceFps) && sourceFps > 0 ? sourceFps : null,
-      timelineFps: Number.isFinite(normalizedTimelineFps) && normalizedTimelineFps > 0 ? normalizedTimelineFps : null,
-      sourceTimeScale: 1,
-      speed: 1,
-      reverse: false,
+      sourceFps: Number.isFinite(optionSourceFps) && optionSourceFps > 0
+        ? optionSourceFps
+        : (Number.isFinite(sourceFps) && sourceFps > 0 ? sourceFps : null),
+      timelineFps: Number.isFinite(optionTimelineFps) && optionTimelineFps > 0
+        ? optionTimelineFps
+        : (Number.isFinite(normalizedTimelineFps) && normalizedTimelineFps > 0 ? normalizedTimelineFps : null),
+      sourceTimeScale: Number.isFinite(optionSourceTimeScale) && optionSourceTimeScale > 0
+        ? optionSourceTimeScale
+        : 1,
+      speed: Number.isFinite(optionSpeed) && optionSpeed > 0 ? optionSpeed : 1,
+      reverse: options?.reverse === true,
       gainDb: asset.type === 'audio' ? normalizeAudioClipGainDb(options?.gainDb) : undefined,
       fadeIn: asset.type === 'audio' ? clampAudioFadeDuration(options?.fadeIn, finalDuration) : undefined,
       fadeOut: asset.type === 'audio' ? clampAudioFadeDuration(options?.fadeOut, finalDuration) : undefined,
@@ -5430,7 +5441,14 @@ export const useTimelineStore = create(
     if (!timelineData) return
     const fps = Number(timelineFps) || 24
     const assetsById = buildAssetByIdMap(assets)
-    const normalizedClips = normalizeClipTimebases(timelineData.clips || [], assets, fps)
+    const projectTracks = timelineData.tracks || [
+      { id: 'video-1', name: 'Video 1', type: 'video', muted: false, locked: false, visible: true },
+      { id: 'audio-1', name: 'Audio 1', type: 'audio', channels: 'stereo', muted: false, locked: false, visible: true },
+    ]
+    const normalizedClips = normalizeVideoBackedAudioClips(
+      normalizeClipTimebases(timelineData.clips || [], assets, fps),
+      projectTracks
+    )
     // Align all clip start times and durations to frame boundaries (no sub-frame)
     const frameAlignedClips = normalizedClips.map((clip) => {
       const startTime = roundToFrame(Math.max(0, clip.startTime || 0), fps)
@@ -5456,6 +5474,13 @@ export const useTimelineStore = create(
         trimEnd,
         sourceDuration,
         adjustments: normalizedAdjustments,
+        ...(clip.type === 'audio'
+          ? {
+              gainDb: normalizeAudioClipGainDb(clip.gainDb),
+              fadeIn: clampAudioFadeDuration(clip.fadeIn, duration),
+              fadeOut: clampAudioFadeDuration(clip.fadeOut, duration),
+            }
+          : {}),
         ...(supportsLowerLayerCompositeMode(clip)
           ? { compositeLowerLayers: normalizeClipCompositeMode(clip.compositeLowerLayers) }
           : {}),
@@ -5471,10 +5496,7 @@ export const useTimelineStore = create(
       zoom: timelineData.zoom || 100,
       masterAudioVolume: clampTrackVolume(timelineData.masterAudioVolume),
       masterAudioInserts: normalizeAudioInserts(timelineData.masterAudioInserts),
-      tracks: timelineData.tracks || [
-        { id: 'video-1', name: 'Video 1', type: 'video', muted: false, locked: false, visible: true },
-        { id: 'audio-1', name: 'Audio 1', type: 'audio', channels: 'stereo', muted: false, locked: false, visible: true },
-      ],
+      tracks: projectTracks,
       clips: frameAlignedClips,
       transitions: timelineData.transitions || [],
       markers: timelineData.markers || [],

--- a/src/utils/audioClipSplit.js
+++ b/src/utils/audioClipSplit.js
@@ -1,0 +1,81 @@
+const isVideoBackedAudioClip = (clip, track) => (
+  clip?.type === 'video' && track?.type === 'audio'
+)
+
+export function isAudioClipRole(clip, track) {
+  return clip?.type === 'audio' || isVideoBackedAudioClip(clip, track)
+}
+
+const clampFadeToPiece = (value, duration) => {
+  const fade = Math.max(0, Number(value) || 0)
+  const pieceDuration = Number(duration)
+  return Number.isFinite(pieceDuration) && pieceDuration >= 0
+    ? Math.min(fade, pieceDuration)
+    : fade
+}
+
+export function buildAudioClipSplitState(clip, track, asset, pieceDurations = {}) {
+  if (!isAudioClipRole(clip, track)) return null
+
+  const sourceScale = Number(clip?.sourceTimeScale)
+  const sourceFps = Number(clip?.sourceFps)
+  const timelineFps = Number(clip?.timelineFps)
+  const fallbackSourceScale = (
+    Number.isFinite(sourceFps) && sourceFps > 0
+    && Number.isFinite(timelineFps) && timelineFps > 0
+  ) ? timelineFps / sourceFps : 1
+  const speed = Number(clip?.speed)
+  const normalizedSourceScale = Number.isFinite(sourceScale) && sourceScale > 0
+    ? sourceScale
+    : fallbackSourceScale
+  const normalizedSpeed = Number.isFinite(speed) && speed > 0 ? speed : 1
+  const trimStart = Number(clip?.trimStart)
+  const trimEnd = Number(clip?.trimEnd ?? clip?.sourceDuration)
+  const leftDuration = Number(pieceDurations.left)
+  const hasReverseSplitRange = Boolean(
+    clip?.reverse === true
+    && Number.isFinite(trimStart)
+    && Number.isFinite(trimEnd)
+    && Number.isFinite(leftDuration)
+    && leftDuration >= 0
+  )
+  const lowerTrim = hasReverseSplitRange ? Math.min(trimStart, trimEnd) : null
+  const upperTrim = hasReverseSplitRange ? Math.max(trimStart, trimEnd) : null
+  const reverseBoundary = hasReverseSplitRange
+    ? Math.max(lowerTrim, Math.min(upperTrim, upperTrim - leftDuration * normalizedSourceScale * normalizedSpeed))
+    : null
+
+  return {
+    asset: asset?.type === 'audio' ? asset : { ...asset, type: 'audio' },
+    leftClipUpdates: {
+      type: 'audio',
+      gainDb: clip?.gainDb,
+      fadeIn: clampFadeToPiece(clip?.fadeIn, pieceDurations.left),
+      fadeOut: 0,
+      ...(hasReverseSplitRange ? { trimStart: reverseBoundary, trimEnd: upperTrim } : {}),
+    },
+    rightClipOptions: {
+      gainDb: clip?.gainDb,
+      fadeIn: 0,
+      fadeOut: clampFadeToPiece(clip?.fadeOut, pieceDurations.right),
+      sourceTimeScale: normalizedSourceScale,
+      speed: normalizedSpeed,
+      reverse: clip?.reverse === true,
+      ...(hasReverseSplitRange ? { trimStart: lowerTrim, trimEnd: reverseBoundary } : {}),
+      ...(Number.isFinite(sourceFps) && sourceFps > 0 ? { sourceFps } : {}),
+      ...(Number.isFinite(timelineFps) && timelineFps > 0 ? { timelineFps } : {}),
+    },
+  }
+}
+
+export function normalizeVideoBackedAudioClips(clips = [], tracks = []) {
+  const audioTrackIds = new Set(
+    tracks.filter((track) => track?.type === 'audio').map((track) => track.id)
+  )
+
+  return clips.map((clip) => (
+    clip?.type === 'video' && audioTrackIds.has(clip.trackId)
+      ? { ...clip, type: 'audio' }
+      : clip
+  ))
+}

--- a/src/utils/audioClipSplit.test.js
+++ b/src/utils/audioClipSplit.test.js
@@ -1,0 +1,115 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildAudioClipSplitState,
+  isAudioClipRole,
+  normalizeVideoBackedAudioClips,
+} from './audioClipSplit.js'
+
+test('treats a video-backed clip on an audio track as audio', () => {
+  const clip = { type: 'video', gainDb: -3, fadeIn: 0.25, fadeOut: 0.5 }
+  const track = { id: 'audio-1', type: 'audio' }
+  const asset = { id: 'asset-1', type: 'video', url: 'file:///podcast.mp4' }
+
+  assert.equal(isAudioClipRole(clip, track), true)
+  assert.deepEqual(buildAudioClipSplitState(clip, track, asset), {
+    asset: { ...asset, type: 'audio' },
+    leftClipUpdates: { type: 'audio', gainDb: -3, fadeIn: 0.25, fadeOut: 0 },
+    rightClipOptions: {
+      gainDb: -3,
+      fadeIn: 0,
+      fadeOut: 0.5,
+      sourceTimeScale: 1,
+      speed: 1,
+      reverse: false,
+    },
+  })
+})
+
+test('does not reinterpret video clips on video tracks as audio', () => {
+  const clip = { type: 'video' }
+  const track = { id: 'video-1', type: 'video' }
+
+  assert.equal(isAudioClipRole(clip, track), false)
+  assert.equal(buildAudioClipSplitState(clip, track, { type: 'video' }), null)
+})
+
+test('keeps only the original outer fades after an audio razor cut', () => {
+  const state = buildAudioClipSplitState(
+    { type: 'audio', gainDb: 2, fadeIn: 0.4, fadeOut: 0.7 },
+    { id: 'audio-1', type: 'audio' },
+    { id: 'asset-1', type: 'audio' }
+  )
+
+  assert.deepEqual(state.leftClipUpdates, {
+    type: 'audio', gainDb: 2, fadeIn: 0.4, fadeOut: 0,
+  })
+  assert.deepEqual(state.rightClipOptions, {
+    gainDb: 2,
+    fadeIn: 0,
+    fadeOut: 0.7,
+    sourceTimeScale: 1,
+    speed: 1,
+    reverse: false,
+  })
+})
+
+test('preserves retime state and exact source ranges for a reverse split', () => {
+  const state = buildAudioClipSplitState(
+    {
+      type: 'audio',
+      sourceTimeScale: 0.5,
+      sourceFps: 60,
+      timelineFps: 30,
+      speed: 2,
+      reverse: true,
+      trimStart: 0,
+      trimEnd: 10,
+    },
+    { id: 'audio-1', type: 'audio' },
+    { id: 'asset-1', type: 'audio' },
+    { left: 4, right: 6 }
+  )
+
+  assert.deepEqual(state.leftClipUpdates, {
+    type: 'audio',
+    gainDb: undefined,
+    fadeIn: 0,
+    fadeOut: 0,
+    trimStart: 6,
+    trimEnd: 10,
+  })
+
+  assert.deepEqual(state.rightClipOptions, {
+    gainDb: undefined,
+    fadeIn: 0,
+    fadeOut: 0,
+    sourceTimeScale: 0.5,
+    speed: 2,
+    reverse: true,
+    trimStart: 0,
+    trimEnd: 6,
+    sourceFps: 60,
+    timelineFps: 30,
+  })
+})
+
+test('repairs only legacy video clips placed on audio tracks', () => {
+  const clips = [
+    { id: 'video-audio', type: 'video', trackId: 'audio-1' },
+    { id: 'video', type: 'video', trackId: 'video-1' },
+    { id: 'image-audio', type: 'image', trackId: 'audio-1' },
+    { id: 'audio', type: 'audio', trackId: 'audio-1' },
+  ]
+  const repaired = normalizeVideoBackedAudioClips(clips, [
+    { id: 'video-1', type: 'video' },
+    { id: 'audio-1', type: 'audio' },
+  ])
+
+  assert.deepEqual(repaired.map((clip) => clip.type), ['audio', 'video', 'image', 'audio'])
+  assert.notEqual(repaired[0], clips[0])
+  assert.equal(repaired[1], clips[1])
+  assert.equal(repaired[2], clips[2])
+  assert.equal(repaired[3], clips[3])
+})

--- a/src/utils/audioPreviewScheduling.js
+++ b/src/utils/audioPreviewScheduling.js
@@ -1,0 +1,214 @@
+export const AUDIO_PREVIEW_LOOKAHEAD_SECONDS = 2.5
+export const AUDIO_PREVIEW_RETENTION_SECONDS = 1
+export const AUDIO_PREVIEW_MAX_ENTRIES = 16
+export const AUDIO_PREVIEW_SEEK_TOLERANCE_SECONDS = 0.04
+export const AUDIO_PREVIEW_START_ALIGNMENT_TOLERANCE_SECONDS = 0.12
+export const AUDIO_PREVIEW_DRIFT_THRESHOLD_SECONDS = 0.45
+export const AUDIO_PREVIEW_DRIFT_CHECK_INTERVAL_MS = 750
+export const AUDIO_PREVIEW_SEEK_COOLDOWN_MS = 900
+
+const finiteNumber = (value, fallback = 0) => {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export function resolveAudioPreviewUrl({
+  preferredUrl = null,
+  sourceUrl = null,
+  currentUrl = null,
+  playing = false,
+  failedUrl = null,
+  failedUrls = null,
+} = {}) {
+  const hasFailed = (url) => Boolean(
+    url
+    && (
+      url === failedUrl
+      || (failedUrls instanceof Set && failedUrls.has(url))
+      || (Array.isArray(failedUrls) && failedUrls.includes(url))
+    )
+  )
+  const preferred = preferredUrl || sourceUrl || null
+  const usablePreferred = preferred && !hasFailed(preferred)
+    ? preferred
+    : (sourceUrl && !hasFailed(sourceUrl) ? sourceUrl : null)
+
+  // A cache may become ready while a clip is already sounding. Swapping the
+  // media source at that moment guarantees a cold-load dropout, so retain the
+  // current playable URL until the entry is no longer sounding. Paused clips
+  // may safely adopt and pre-seek a newly ready cache.
+  if (playing && currentUrl && !hasFailed(currentUrl)) return currentUrl
+  return usablePreferred || (currentUrl && !hasFailed(currentUrl) ? currentUrl : null)
+}
+
+export function getAudioClipTimeScale(clip) {
+  const sourceScale = Number(clip?.sourceTimeScale)
+  const timelineFps = Number(clip?.timelineFps)
+  const sourceFps = Number(clip?.sourceFps)
+  const baseScale = Number.isFinite(sourceScale) && sourceScale > 0
+    ? sourceScale
+    : (
+      Number.isFinite(timelineFps) && timelineFps > 0
+      && Number.isFinite(sourceFps) && sourceFps > 0
+        ? timelineFps / sourceFps
+        : 1
+    )
+  const speed = Number(clip?.speed)
+  const speedScale = Number.isFinite(speed) && speed > 0 ? speed : 1
+  return baseScale * speedScale
+}
+
+export function getAudioSourceTimeAtTimeline(clip, timelineTime) {
+  const startTime = finiteNumber(clip?.startTime)
+  const duration = Math.max(0, finiteNumber(clip?.duration))
+  const timeScale = getAudioClipTimeScale(clip)
+  const trimStart = finiteNumber(clip?.trimStart)
+  const fallbackTrimEnd = trimStart + duration * timeScale
+  const trimEnd = finiteNumber(
+    clip?.trimEnd ?? clip?.sourceDuration,
+    fallbackTrimEnd
+  )
+  const minTime = Math.min(trimStart, trimEnd)
+  const maxTime = Math.max(trimStart, trimEnd)
+  const clipTime = finiteNumber(timelineTime) - startTime
+  const sourceTime = clip?.reverse
+    ? trimEnd - clipTime * timeScale
+    : trimStart + clipTime * timeScale
+  const upperBound = Math.max(minTime, maxTime - 0.01)
+  return Math.max(minTime, Math.min(sourceTime, upperBound))
+}
+
+const getClipWindow = (clip, playheadPosition) => {
+  const start = finiteNumber(clip?.startTime)
+  const duration = Math.max(0, finiteNumber(clip?.duration))
+  const end = start + duration
+  const playhead = finiteNumber(playheadPosition)
+  const active = duration > 0 && playhead >= start && playhead < end
+  const distance = active
+    ? 0
+    : playhead < start
+      ? start - playhead
+      : playhead - end
+  return { start, end, active, distance }
+}
+
+/**
+ * Select a bounded set of audio clips to keep backed by HTMLMediaElements.
+ * Active clips are never dropped by the cap. Upcoming clips are preferred
+ * over recently-ended clips so short cuts have time to load and seek before
+ * their first audible frame.
+ */
+export function selectAudioPreviewCandidates({
+  clips = [],
+  tracks = [],
+  playheadPosition = 0,
+  playbackRate = 1,
+  lookaheadSeconds = AUDIO_PREVIEW_LOOKAHEAD_SECONDS,
+  retentionSeconds = AUDIO_PREVIEW_RETENTION_SECONDS,
+  maxEntries = AUDIO_PREVIEW_MAX_ENTRIES,
+  isTrackAudible = null,
+} = {}) {
+  const playhead = finiteNumber(playheadPosition)
+  const isForward = finiteNumber(playbackRate, 1) >= 0
+  const lookahead = Math.max(0, finiteNumber(lookaheadSeconds, AUDIO_PREVIEW_LOOKAHEAD_SECONDS))
+  const retention = Math.max(0, finiteNumber(retentionSeconds, AUDIO_PREVIEW_RETENTION_SECONDS))
+  const entryCap = Math.max(1, Math.floor(finiteNumber(maxEntries, AUDIO_PREVIEW_MAX_ENTRIES)))
+  const trackMap = new Map((tracks || []).map((track) => [track?.id, track]))
+
+  const candidates = []
+  for (const clip of clips || []) {
+    if (!clip || clip.enabled === false) continue
+    const track = trackMap.get(clip.trackId)
+    if (!track || track.type !== 'audio') continue
+    if (typeof isTrackAudible === 'function' && !isTrackAudible(track)) continue
+
+    const window = getClipWindow(clip, playhead)
+    if (window.end <= window.start) continue
+
+    const upcoming = isForward
+      ? window.start > playhead && window.start - playhead <= lookahead
+      : window.end <= playhead && playhead - window.end <= lookahead
+    const retained = isForward
+      ? window.end <= playhead && playhead - window.end <= retention
+      : window.start > playhead && window.start - playhead <= retention
+
+    if (!window.active && !upcoming && !retained) continue
+    candidates.push({
+      clip,
+      track,
+      active: window.active,
+      upcoming,
+      retained,
+      distance: window.distance,
+      prepareTimelineTime: window.active
+        ? playhead
+        : upcoming
+          ? (isForward ? window.start : Math.max(window.start, window.end - 0.01))
+          : null,
+    })
+  }
+
+  candidates.sort((a, b) => {
+    if (a.active !== b.active) return a.active ? -1 : 1
+    if (a.upcoming !== b.upcoming) return a.upcoming ? -1 : 1
+    if (a.distance !== b.distance) return a.distance - b.distance
+    return finiteNumber(a.clip?.startTime) - finiteNumber(b.clip?.startTime)
+  })
+
+  const activeCount = candidates.reduce((count, candidate) => count + (candidate.active ? 1 : 0), 0)
+  return candidates.slice(0, Math.max(entryCap, activeCount))
+}
+
+/**
+ * Distinguish ordinary RAF advancement from an explicit seek, loop jump, or
+ * playback start. This prevents normal playback from re-seeking every frame.
+ */
+export function isAudioTimelineDiscontinuity(previous, next, nowMs, toleranceSeconds = 0.2) {
+  if (!previous) return true
+  if (Boolean(previous.isPlaying) !== Boolean(next?.isPlaying)) return true
+
+  const previousRate = finiteNumber(previous.playbackRate, 1)
+  const nextRate = finiteNumber(next?.playbackRate, 1)
+  if (Math.abs(previousRate - nextRate) > 0.001) return true
+
+  if (!previous.isPlaying) {
+    return Math.abs(finiteNumber(next?.playheadPosition) - finiteNumber(previous.playheadPosition)) > 0.001
+  }
+
+  const elapsedSeconds = Math.max(0, finiteNumber(nowMs) - finiteNumber(previous.sampledAtMs)) / 1000
+  const expectedPosition = finiteNumber(previous.playheadPosition)
+    + (previous.isPlaying ? elapsedSeconds * previousRate : 0)
+  return Math.abs(finiteNumber(next?.playheadPosition) - expectedPosition) > Math.max(0, toleranceSeconds)
+}
+
+export function shouldCorrectAudioDrift({
+  active,
+  isPlaying,
+  isSeeking,
+  currentTime,
+  expectedTime,
+  nowMs,
+  lastCheckAtMs = 0,
+  lastSeekAtMs = 0,
+  driftThresholdSeconds = AUDIO_PREVIEW_DRIFT_THRESHOLD_SECONDS,
+  checkIntervalMs = AUDIO_PREVIEW_DRIFT_CHECK_INTERVAL_MS,
+  seekCooldownMs = AUDIO_PREVIEW_SEEK_COOLDOWN_MS,
+} = {}) {
+  if (!active || !isPlaying || isSeeking) return false
+  if (finiteNumber(nowMs) - finiteNumber(lastCheckAtMs) < checkIntervalMs) return false
+  if (finiteNumber(nowMs) - finiteNumber(lastSeekAtMs) < seekCooldownMs) return false
+  return Math.abs(finiteNumber(currentTime) - finiteNumber(expectedTime)) > driftThresholdSeconds
+}
+
+export function shouldAlignAudioBeforeStart({
+  active,
+  isPlaying,
+  positionPrepared,
+  attempts = 0,
+  currentTime,
+  expectedTime,
+  toleranceSeconds = AUDIO_PREVIEW_START_ALIGNMENT_TOLERANCE_SECONDS,
+} = {}) {
+  if (!active || !isPlaying || !positionPrepared || attempts >= 1) return false
+  return Math.abs(finiteNumber(currentTime) - finiteNumber(expectedTime)) > Math.max(0, toleranceSeconds)
+}

--- a/src/utils/audioPreviewScheduling.test.js
+++ b/src/utils/audioPreviewScheduling.test.js
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getAudioClipTimeScale,
+  getAudioSourceTimeAtTimeline,
+  isAudioTimelineDiscontinuity,
+  resolveAudioPreviewUrl,
+  selectAudioPreviewCandidates,
+  shouldAlignAudioBeforeStart,
+  shouldCorrectAudioDrift,
+} from './audioPreviewScheduling.js'
+
+const tracks = [
+  { id: 'audio-1', type: 'audio' },
+  { id: 'audio-2', type: 'audio' },
+  { id: 'video-1', type: 'video' },
+]
+
+test('keeps active, short upcoming, and recently-ended audio clips warm', () => {
+  const clips = [
+    { id: 'recent', trackId: 'audio-1', startTime: 8, duration: 1.5 },
+    { id: 'active-a', trackId: 'audio-1', startTime: 9.5, duration: 2 },
+    { id: 'active-b', trackId: 'audio-2', startTime: 10, duration: 1 },
+    { id: 'short-next', trackId: 'audio-1', startTime: 11.5, duration: 0.08 },
+    { id: 'later', trackId: 'audio-1', startTime: 14, duration: 1 },
+    { id: 'picture', trackId: 'video-1', startTime: 10, duration: 5 },
+  ]
+
+  const result = selectAudioPreviewCandidates({
+    clips,
+    tracks,
+    playheadPosition: 10.25,
+    playbackRate: 1,
+  })
+
+  assert.deepEqual(result.map(({ clip }) => clip.id), [
+    'active-a',
+    'active-b',
+    'short-next',
+    'recent',
+  ])
+  assert.equal(result.find(({ clip }) => clip.id === 'short-next').prepareTimelineTime, 11.5)
+})
+
+test('the entry cap never drops simultaneous active audio layers', () => {
+  const clips = Array.from({ length: 5 }, (_, index) => ({
+    id: `active-${index}`,
+    trackId: index % 2 ? 'audio-1' : 'audio-2',
+    startTime: 0,
+    duration: 10,
+  }))
+  clips.push({ id: 'upcoming', trackId: 'audio-1', startTime: 6, duration: 1 })
+
+  const result = selectAudioPreviewCandidates({
+    clips,
+    tracks,
+    playheadPosition: 5,
+    maxEntries: 2,
+  })
+
+  assert.equal(result.length, 5)
+  assert.ok(result.every(({ active }) => active))
+})
+
+test('candidate selection excludes tracks rejected by current audibility state', () => {
+  const result = selectAudioPreviewCandidates({
+    clips: [
+      { id: 'audible', trackId: 'audio-1', startTime: 0, duration: 2 },
+      { id: 'muted', trackId: 'audio-2', startTime: 0, duration: 2 },
+    ],
+    tracks,
+    playheadPosition: 1,
+    isTrackAudible: (track) => track.id === 'audio-1',
+  })
+
+  assert.deepEqual(result.map(({ clip }) => clip.id), ['audible'])
+})
+
+test('calculates source time with trim, source scale, and clip speed', () => {
+  const clip = {
+    startTime: 10,
+    duration: 4,
+    trimStart: 3,
+    trimEnd: 11,
+    sourceTimeScale: 0.5,
+    speed: 2,
+  }
+
+  assert.equal(getAudioClipTimeScale(clip), 1)
+  assert.equal(getAudioSourceTimeAtTimeline(clip, 12), 5)
+})
+
+test('recognizes explicit jumps but not ordinary RAF advancement', () => {
+  const previous = {
+    playheadPosition: 20,
+    playbackRate: 1,
+    isPlaying: true,
+    sampledAtMs: 1000,
+  }
+
+  assert.equal(isAudioTimelineDiscontinuity(previous, {
+    playheadPosition: 20.016,
+    playbackRate: 1,
+    isPlaying: true,
+  }, 1016), false)
+  assert.equal(isAudioTimelineDiscontinuity(previous, {
+    playheadPosition: 31,
+    playbackRate: 1,
+    isPlaying: true,
+  }, 1016), true)
+})
+
+test('drift correction is gated while a seek is in flight and by cooldowns', () => {
+  const base = {
+    active: true,
+    isPlaying: true,
+    currentTime: 5,
+    expectedTime: 6,
+    nowMs: 2000,
+    lastCheckAtMs: 1000,
+    lastSeekAtMs: 0,
+  }
+
+  assert.equal(shouldCorrectAudioDrift(base), true)
+  assert.equal(shouldCorrectAudioDrift({ ...base, isSeeking: true }), false)
+  assert.equal(shouldCorrectAudioDrift({ ...base, lastCheckAtMs: 1600 }), false)
+  assert.equal(shouldCorrectAudioDrift({ ...base, lastSeekAtMs: 1500 }), false)
+  assert.equal(shouldCorrectAudioDrift({ ...base, currentTime: 5.8 }), false)
+})
+
+test('pins a playing source across cache changes and adopts it while inactive', () => {
+  const sourceUrl = 'file:///source.mp4'
+  const cacheUrl = 'file:///cache.mp4'
+
+  assert.equal(resolveAudioPreviewUrl({
+    preferredUrl: cacheUrl,
+    sourceUrl,
+    currentUrl: sourceUrl,
+    playing: true,
+  }), sourceUrl)
+  assert.equal(resolveAudioPreviewUrl({
+    preferredUrl: cacheUrl,
+    sourceUrl,
+    currentUrl: sourceUrl,
+    playing: false,
+  }), cacheUrl)
+  assert.equal(resolveAudioPreviewUrl({
+    preferredUrl: cacheUrl,
+    sourceUrl,
+    currentUrl: cacheUrl,
+    playing: false,
+    failedUrl: cacheUrl,
+  }), sourceUrl)
+  assert.equal(resolveAudioPreviewUrl({
+    preferredUrl: cacheUrl,
+    sourceUrl,
+    currentUrl: sourceUrl,
+    playing: true,
+    failedUrls: new Set([sourceUrl]),
+  }), cacheUrl)
+  assert.equal(resolveAudioPreviewUrl({
+    preferredUrl: cacheUrl,
+    sourceUrl,
+    currentUrl: sourceUrl,
+    playing: true,
+    failedUrls: new Set([sourceUrl, cacheUrl]),
+  }), null)
+})
+
+test('allows one bounded catch-up seek before a cold clip starts', () => {
+  const coldStart = {
+    active: true,
+    isPlaying: true,
+    positionPrepared: true,
+    attempts: 0,
+    currentTime: 5,
+    expectedTime: 5.3,
+  }
+
+  assert.equal(shouldAlignAudioBeforeStart(coldStart), true)
+  assert.equal(shouldAlignAudioBeforeStart({ ...coldStart, attempts: 1 }), false)
+  assert.equal(shouldAlignAudioBeforeStart({ ...coldStart, currentTime: 5.25 }), false)
+  assert.equal(shouldAlignAudioBeforeStart({ ...coldStart, isPlaying: false }), false)
+})

--- a/tests/audioMixEligibility.test.mjs
+++ b/tests/audioMixEligibility.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  collectAudioMixClips,
+  countExpectedAudioMixClips,
+  getAudioMixDelayMilliseconds,
+  isAudioMixClip,
+} from '../electron/audioMixEligibility.mjs'
+
+const tracks = [
+  { id: 'audio-1', type: 'audio' },
+  { id: 'video-1', type: 'video' },
+]
+
+test('recovers a video-backed legacy split fragment placed on an audio track', () => {
+  const legacyFragment = {
+    id: 'legacy-short-fragment',
+    type: 'video',
+    trackId: 'audio-1',
+    startTime: 1,
+    duration: 1 / 60,
+  }
+
+  assert.equal(isAudioMixClip(legacyFragment, tracks[0]), true)
+  assert.equal(isAudioMixClip(legacyFragment, tracks[1]), false)
+})
+
+test('collects normal audio and short recovered fragments without including visual video clips', () => {
+  const clips = [
+    { id: 'normal-audio', type: 'audio', trackId: 'audio-1', startTime: 0, duration: 1 },
+    { id: 'legacy-short-fragment', type: 'video', trackId: 'audio-1', startTime: 1, duration: 1 / 60 },
+    { id: 'visual-video', type: 'video', trackId: 'video-1', startTime: 0, duration: 2 },
+    { id: 'disabled-audio', type: 'audio', trackId: 'audio-1', startTime: 0, duration: 2, enabled: false },
+  ]
+
+  const collected = collectAudioMixClips(clips, tracks)
+
+  assert.deepEqual(collected.map((clip) => clip.id), [
+    'normal-audio',
+    'legacy-short-fragment',
+  ])
+  assert.equal(countExpectedAudioMixClips(collected, 0, 2), 2)
+})
+
+test('expected clip count includes a short recovered fragment that overlaps the export range', () => {
+  const shortFragment = {
+    id: 'legacy-short-fragment',
+    type: 'video',
+    trackId: 'audio-1',
+    startTime: 10,
+    duration: 0.005,
+  }
+
+  const collected = collectAudioMixClips([shortFragment], tracks)
+
+  assert.equal(countExpectedAudioMixClips(collected, 9.5, 10.5), 1)
+  assert.equal(countExpectedAudioMixClips(collected, 10.005, 11), 0)
+})
+
+test('preserves fractional-millisecond delay at frame-aligned cut seams', () => {
+  assert.equal(getAudioMixDelayMilliseconds(1 / 24, 0), 1000 / 24)
+  assert.equal(getAudioMixDelayMilliseconds(1001 / 30000, 0), 1001 / 30)
+})

--- a/tests/hardwareExportFfmpeg.test.js
+++ b/tests/hardwareExportFfmpeg.test.js
@@ -1,0 +1,165 @@
+const assert = require('node:assert/strict')
+const fsp = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+const { EventEmitter } = require('node:events')
+const { PassThrough } = require('node:stream')
+
+const bundledFfmpegPath = require('ffmpeg-static')
+const {
+  HARDWARE_EXPORT_FFMPEG_ENV_KEY,
+  getHardwareEncoderProbeCacheKey,
+  probeFfmpegVersion,
+  resolveHardwareExportFfmpeg,
+  resolveHardwareExportRoute,
+  validateFfmpegPath,
+} = require('../electron/hardwareExportFfmpeg')
+
+test('uses the bundled FFmpeg when no override is configured', () => {
+  const result = resolveHardwareExportFfmpeg({ bundledPath: bundledFfmpegPath })
+  assert.equal(result.path, bundledFfmpegPath)
+  assert.equal(result.source, 'bundled')
+  assert.equal(result.warning, null)
+})
+
+test('uses a valid saved path for hardware export', () => {
+  const result = resolveHardwareExportFfmpeg({
+    bundledPath: process.execPath,
+    settingPath: bundledFfmpegPath,
+  })
+  assert.equal(result.path, bundledFfmpegPath)
+  assert.equal(result.source, 'setting')
+  assert.equal(result.warning, null)
+})
+
+test('gives the environment override priority over the saved path', () => {
+  const result = resolveHardwareExportFfmpeg({
+    bundledPath: bundledFfmpegPath,
+    settingPath: bundledFfmpegPath,
+    environmentPath: process.execPath,
+  })
+  assert.equal(result.path, process.execPath)
+  assert.equal(result.source, 'environment')
+})
+
+test('falls back to bundled FFmpeg and warns when the selected override is invalid', () => {
+  const result = resolveHardwareExportFfmpeg({
+    bundledPath: bundledFfmpegPath,
+    settingPath: 'relative/ffmpeg',
+  })
+  assert.equal(result.path, bundledFfmpegPath)
+  assert.equal(result.source, 'bundled')
+  assert.match(result.warning, /saved hardware-export FFmpeg path is invalid/i)
+  assert.match(result.warning, /must be absolute/i)
+})
+
+test('an invalid environment override does not silently select the saved path', () => {
+  const result = resolveHardwareExportFfmpeg({
+    bundledPath: bundledFfmpegPath,
+    settingPath: bundledFfmpegPath,
+    environmentPath: path.join(os.tmpdir(), 'velorn-missing-ffmpeg'),
+  })
+  assert.equal(result.path, bundledFfmpegPath)
+  assert.equal(result.source, 'bundled')
+  assert.match(result.warning, new RegExp(HARDWARE_EXPORT_FFMPEG_ENV_KEY))
+})
+
+test('rejects directories and missing paths', async () => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'velorn-ffmpeg-path-'))
+  try {
+    const directoryResult = validateFfmpegPath(directory)
+    assert.equal(directoryResult.ok, false)
+    assert.match(directoryResult.error, /not a file/i)
+
+    const missingResult = validateFfmpegPath(path.join(directory, 'missing-ffmpeg'))
+    assert.equal(missingResult.ok, false)
+    assert.match(missingResult.error, /could not be found or opened/i)
+  } finally {
+    await fsp.rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects a non-executable file on Unix platforms', { skip: process.platform === 'win32' }, async () => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'velorn-ffmpeg-permission-'))
+  const filePath = path.join(directory, 'ffmpeg')
+  try {
+    await fsp.writeFile(filePath, '#!/bin/sh\nexit 0\n', { mode: 0o644 })
+    const result = validateFfmpegPath(filePath)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /not executable/i)
+  } finally {
+    await fsp.rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('validates a real FFmpeg executable and reports its version', async () => {
+  const result = await probeFfmpegVersion(bundledFfmpegPath)
+  assert.equal(result.ok, true)
+  assert.match(result.version, /^ffmpeg version\b/i)
+})
+
+test('rejects an executable that is not FFmpeg', async () => {
+  const result = await probeFfmpegVersion(process.execPath)
+  assert.equal(result.ok, false)
+  assert.match(result.error, /did not identify itself as FFmpeg|exited with code/i)
+})
+
+test('bounds a hung FFmpeg version check with a timeout', async () => {
+  const spawnImpl = () => {
+    const child = new EventEmitter()
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = () => true
+    return child
+  }
+
+  const startedAt = Date.now()
+  const result = await probeFfmpegVersion(bundledFfmpegPath, { spawnImpl, timeoutMs: 100 })
+  assert.equal(result.ok, false)
+  assert.match(result.error, /timed out/i)
+  assert.ok(Date.now() - startedAt < 1000)
+})
+
+test('hardware-probe cache keys include the encoder and binary file signature', async () => {
+  const directory = await fsp.mkdtemp(path.join(os.tmpdir(), 'velorn-ffmpeg-cache-'))
+  const filePath = path.join(directory, 'ffmpeg')
+  try {
+    await fsp.writeFile(filePath, 'one')
+    const h264Key = getHardwareEncoderProbeCacheKey(filePath, 'h264_nvenc')
+    const h265Key = getHardwareEncoderProbeCacheKey(filePath, 'hevc_nvenc')
+    assert.notEqual(h264Key, h265Key)
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    await fsp.appendFile(filePath, 'two')
+    const replacedKey = getHardwareEncoderProbeCacheKey(filePath, 'h264_nvenc')
+    assert.notEqual(replacedKey, h264Key)
+  } finally {
+    await fsp.rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('routes a verified hardware export through the selected custom binary', () => {
+  const route = resolveHardwareExportRoute({
+    hardwareRequested: true,
+    useHardwareEncoder: true,
+    selection: { path: '/opt/ffmpeg-nvenc', source: 'setting', warning: null },
+    bundledPath: '',
+  })
+  assert.deepEqual(route, {
+    path: '/opt/ffmpeg-nvenc',
+    source: 'setting',
+    warning: null,
+  })
+})
+
+test('routes a hardware-probe downgrade through bundled FFmpeg', () => {
+  const route = resolveHardwareExportRoute({
+    hardwareRequested: true,
+    useHardwareEncoder: false,
+    selection: { path: '/opt/ffmpeg-without-working-nvenc', source: 'setting', warning: null },
+    bundledPath: bundledFfmpegPath,
+  })
+  assert.equal(route.path, bundledFfmpegPath)
+  assert.equal(route.source, 'bundled')
+})


### PR DESCRIPTION
## Summary

- Improve timeline audio startup, short-cut playback, multilayer playback, audio splits, and short-fragment export.
- Add a configurable external FFmpeg path for H.264/H.265 hardware export while preserving bundled FFmpeg for media utilities and safe software fallback.
- Expose the hardware FFmpeg setting in Settings > File Paths with Browse, Test, Reset, dynamic status, and VELORN_FFMPEG_PATH support.
- Bump Velorn to 0.3.26 and add complete release notes, including the three fixes already merged after v0.3.25.

## Why

The bundled Linux FFmpeg does not expose NVIDIA NVENC, preventing otherwise capable NVIDIA systems from using hardware export. Audio playback also cold-started media elements at cut boundaries and after mid-timeline starts, while legacy video-backed audio fragments and rounded export delays could make very short sounds disappear.

This release isolates external FFmpeg use to the final hardware encode path, keeps the bundled binary as the known-safe software fallback, prewarms nearby audio, bounds cold-start catch-up, preserves audio split state, repairs legacy audio-track clip types, and retains fractional audio timing through FFmpeg mixing.

Closes #92.

## Testing

- [x] All 14 package test scripts passed under Node 20: 116 tests total.
- [x] Electron main, preload, MCP server, and new helper syntax checks passed.
- [x] Production Vite build passed.
- [x] Linux AppImage and Debian packages built locally as v0.3.26.
- [x] Packaged ASAR contains both new Electron helpers.
- [x] Staged diff check and credential/local-path scan passed.
- [x] Real Ubuntu NVENC export and the reported audio workflows were verified manually.
- [x] Release notes were added for user-facing behavior and setup.

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in CONTRIBUTOR_LICENSE_AGREEMENT.md, and I have the right to submit this contribution.

## Notes

Existing non-blocking Vite chunk, Browserslist, module-type, and Linux desktop-association warnings remain unchanged.