### PR TITLE
Prepare Velorn v0.3.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Captions can be generated from edited timeline audio and styled in-app.
 
 ### Export
 
-The Export tab includes practical render presets, hardware-accelerated options where available, queue controls, and project-aware output settings.
+The Export tab includes practical render presets, hardware-accelerated options where available, numbered PNG image sequence export, queue controls, and project-aware output settings.
 
 <p align="center">
   <img src="docs/readme/export-settings.png" alt="Velorn export settings with presets, codec controls, and export queue" />

--- a/docs/RELEASE_NOTES_0.3.27.md
+++ b/docs/RELEASE_NOTES_0.3.27.md
@@ -1,0 +1,30 @@
+# Velorn v0.3.27
+
+Velorn v0.3.27 adds PNG image sequence export for compositing, VFX, archival, and frame-by-frame delivery workflows.
+
+## Highlights
+
+- **PNG image sequence export.** Choose **PNG Sequence** in the Export panel to render the visible timeline as individually numbered PNG frames.
+- **Predictable portable filenames.** Velorn creates names such as `project_000001.png`, using a filename stem that is safe across Windows, macOS, and Linux.
+- **Exact frame output.** PNG sequences use the selected frame rate and resolution, including odd custom dimensions that video encoders would normally round.
+- **Non-destructive output folders.** Velorn creates a new `<name>_png` child folder and refuses to reuse an existing directory, preventing accidental overwrites or unsafe cleanup.
+- **Safer cancellation and failure handling.** Incomplete sequence folders are removed when possible. If cleanup cannot complete, Velorn reports the exact folder that still contains partial files.
+- **Reliable export-job tracking.** Hidden export-worker events are correlated to the correct job so UI exports, queued exports, and agent-started background exports cannot complete or fail one another accidentally.
+- **Clearer standalone-editor documentation.** The README now makes clear that editing, captions, export, project management, and MCP editorial tools work without ComfyUI; all current generation features require a locally running ComfyUI instance.
+
+## Downloads
+
+- `Windows Installer`: standard Windows install experience for most users
+- `Windows Portable`: no-install Windows build for quick testing or portable use
+- `Mac (Apple Silicon)`: for M1, M2, M3, M4, and newer Macs
+- `Mac (Intel)`: for older Intel-based Macs
+- `Linux AppImage`: portable Linux build
+- `Linux deb`: Debian/Ubuntu package
+
+Ignore the auto-generated source-code archives unless you plan to build Velorn from source.
+
+## Notes
+
+- PNG sequences contain image frames only. Audio, video codecs, hardware encoding, and NVIDIA RTX 4K upscaling do not apply to this export format.
+- Choose a parent destination and Velorn will create a new sequence folder automatically. Existing directories are never claimed as PNG sequence outputs.
+- Normal video and audio export behavior is unchanged.

--- a/electron/main.js
+++ b/electron/main.js
@@ -5672,10 +5672,15 @@ ipcMain.handle('export:runInWorker', async (event, payload) => {
   if (exportWorkerWindow && !exportWorkerWindow.isDestroyed()) {
     return { success: false, error: 'Export already in progress' }
   }
+  const requestedJobId = typeof payload?.jobId === 'string' ? payload.jobId.trim() : ''
+  const jobId = /^[a-zA-Z0-9._:-]{1,160}$/.test(requestedJobId)
+    ? requestedJobId
+    : `export-${crypto.randomUUID()}`
+  const jobPayload = { ...payload, jobId }
   const workerUrl = isDev
     ? `http://127.0.0.1:5173?export=worker`
     : `file://${path.join(__dirname, '../dist/index.html')}?export=worker`
-  exportWorkerWindow = new BrowserWindow({
+  const workerWindow = new BrowserWindow({
     width: 400,
     height: 200,
     show: false,
@@ -5690,7 +5695,8 @@ ipcMain.handle('export:runInWorker', async (event, payload) => {
       webSecurity: false,
     },
   })
-  const workerContents = exportWorkerWindow.webContents
+  exportWorkerWindow = workerWindow
+  const workerContents = workerWindow.webContents
   // The export worker is a hidden window, so its console is invisible in
   // normal use. Mirror it to userData/export-worker.log so export failures
   // are diagnosable from disk — including renderer crashes, which otherwise
@@ -5723,6 +5729,27 @@ ipcMain.handle('export:runInWorker', async (event, payload) => {
       }
     }
   }
+  let terminalSent = false
+  const clearActiveWorker = () => {
+    if (exportWorkerWindow === workerWindow) {
+      exportWorkerWindow = null
+    }
+  }
+  const forwardToMain = (channel, data) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(channel, data, { jobId })
+    }
+  }
+  const finishWorker = (channel, data) => {
+    if (terminalSent) return false
+    terminalSent = true
+    forwardToMain(channel, data)
+    clearActiveWorker()
+    if (!workerWindow.isDestroyed()) {
+      workerWindow.close()
+    }
+    return true
+  }
   workerContents.on('console-message', (_event, level, message, lineNo, sourceId) => {
     workerLog(`[${new Date().toISOString().slice(11, 19)}] [${level}] ${message} (${String(sourceId).split('/').pop()}:${lineNo})`)
   })
@@ -5731,68 +5758,65 @@ ipcMain.handle('export:runInWorker', async (event, payload) => {
   // line forever AND blocks every future export with "already in progress".
   workerContents.on('render-process-gone', (_event, details) => {
     workerLog(`!!! RENDER PROCESS GONE: ${JSON.stringify(details)}`)
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(
-        'export:error',
-        `Export process crashed (${details?.reason || 'unknown'}, code ${details?.exitCode ?? '?'}). Details in ${workerLogActivePath}.`
-      )
-    }
-    if (exportWorkerWindow && !exportWorkerWindow.isDestroyed()) {
-      exportWorkerWindow.close()
-    }
-    exportWorkerWindow = null
+    const pngSequenceRecoveryNote = jobPayload?.options?.format === 'png-seq' && jobPayload?.outputPath
+      ? ` An incomplete PNG sequence may remain at ${jobPayload.outputPath}; Velorn did not delete it because the worker could not confirm folder ownership after the crash.`
+      : ''
+    finishWorker(
+      'export:error',
+      `Export process crashed (${details?.reason || 'unknown'}, code ${details?.exitCode ?? '?'}). Details in ${workerLogActivePath}.${pngSequenceRecoveryNote}`
+    )
   })
-  exportWorkerWindow.on('unresponsive', () => {
+  workerWindow.on('unresponsive', () => {
     workerLog('!!! WORKER WINDOW UNRESPONSIVE')
   })
-  const forwardToMain = (channel, data) => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(channel, data)
-    }
-  }
   const onProgress = (event, data) => {
-    if (event.sender === workerContents) forwardToMain('export:progress', data)
+    if (event.sender === workerContents && !terminalSent) forwardToMain('export:progress', data)
   }
   const onComplete = (event, data) => {
     if (event.sender === workerContents) {
-      forwardToMain('export:complete', data)
-      if (exportWorkerWindow && !exportWorkerWindow.isDestroyed()) {
-        exportWorkerWindow.close()
-        exportWorkerWindow = null
-      }
+      finishWorker('export:complete', data)
     }
   }
   const onError = (event, err) => {
     if (event.sender === workerContents) {
       console.error('[Export] Worker reported error:', err, typeof err)
-      forwardToMain('export:error', err)
-      if (exportWorkerWindow && !exportWorkerWindow.isDestroyed()) {
-        exportWorkerWindow.close()
-        exportWorkerWindow = null
-      }
+      finishWorker('export:error', err)
     }
   }
   ipcMain.on('export:progress', onProgress)
   ipcMain.on('export:complete', onComplete)
   ipcMain.on('export:error', onError)
   const sendJob = () => {
-    if (exportWorkerWindow && !exportWorkerWindow.isDestroyed()) {
-      exportWorkerWindow.webContents.send('export:job', payload)
+    if (!workerWindow.isDestroyed()) {
+      workerWindow.webContents.send('export:job', jobPayload)
     }
   }
-  ipcMain.once('export:workerReady', (event) => {
-    if (event.sender === workerContents) sendJob()
-  })
-  exportWorkerWindow.on('closed', () => {
+  const onWorkerReady = (event) => {
+    if (event.sender !== workerContents) return
+    ipcMain.removeListener('export:workerReady', onWorkerReady)
+    sendJob()
+  }
+  ipcMain.on('export:workerReady', onWorkerReady)
+  workerWindow.on('closed', () => {
     ipcMain.removeListener('export:progress', onProgress)
     ipcMain.removeListener('export:complete', onComplete)
     ipcMain.removeListener('export:error', onError)
+    ipcMain.removeListener('export:workerReady', onWorkerReady)
+    if (!terminalSent) {
+      terminalSent = true
+      forwardToMain('export:error', 'Export worker closed before reporting completion.')
+    }
+    clearActiveWorker()
   })
-  exportWorkerWindow.on('closed', () => {
-    exportWorkerWindow = null
-  })
-  await exportWorkerWindow.loadURL(workerUrl)
-  return { started: true }
+  try {
+    await workerWindow.loadURL(workerUrl)
+  } catch (err) {
+    terminalSent = true
+    clearActiveWorker()
+    if (!workerWindow.isDestroyed()) workerWindow.close()
+    throw err
+  }
+  return { started: true, jobId }
 })
 
 const formatFilterNumber = (value, fallback = '0.000000') => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -125,13 +125,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('export:cancel-job', () => cb())
   },
   onExportProgress: (cb) => {
-    ipcRenderer.on('export:progress', (_, data) => cb(data))
+    const handler = (_, data, metadata) => cb(data, metadata)
+    ipcRenderer.on('export:progress', handler)
+    return () => ipcRenderer.removeListener('export:progress', handler)
   },
   onExportComplete: (cb) => {
-    ipcRenderer.on('export:complete', (_, data) => cb(data))
+    const handler = (_, data, metadata) => cb(data, metadata)
+    ipcRenderer.on('export:complete', handler)
+    return () => ipcRenderer.removeListener('export:complete', handler)
   },
   onExportError: (cb) => {
-    ipcRenderer.on('export:error', (_, err) => cb(err))
+    const handler = (_, err, metadata) => cb(err, metadata)
+    ipcRenderer.on('export:error', handler)
+    return () => ipcRenderer.removeListener('export:error', handler)
   },
   onExportJob: (cb) => {
     ipcRenderer.once('export:job', (_, job) => cb(job))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "velorn",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "velorn",
-      "version": "0.3.26",
+      "version": "0.3.27",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@xyflow/react": "^12.10.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:music-visual-style": "node --experimental-default-type=module --test ./src/utils/musicVisualStyle.test.js",
     "test:dirty-tracker": "node --experimental-default-type=module --test ./src/services/projectDirtyTracker.test.js",
     "test:premiere-xml": "node --experimental-default-type=module --test ./src/services/premiereXmlExporter.test.js",
+    "test:png-sequence-export": "node --test ./src/services/pngSequenceExport.test.mjs",
     "test:export-frame-source": "node --experimental-default-type=module --test ./src/services/exportFrameSource.test.js",
     "test:export-source-preparation": "node --test ./tests/exportSourcePreparation.test.js",
     "test:audio-mix-eligibility": "node --test ./tests/audioMixEligibility.test.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velorn",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "description": "AI-native video editing built around real creative timelines, generative workflows, and local agent control.",
   "main": "electron/main.js",
   "scripts": {

--- a/src/components/ExportPanel.jsx
+++ b/src/components/ExportPanel.jsx
@@ -9,6 +9,15 @@ import buildPremiereXml from '../services/premiereXmlExporter'
 import { mixTimelineAudioToWav } from '../services/timelineAudioMix'
 import { analyzeAudioBuffer } from '../services/audioAnalysis'
 import {
+  resolveAvailablePngSequenceFolder,
+  sanitizePngSequenceBaseName,
+} from '../services/pngSequenceExport.mjs'
+import {
+  classifyExportWorkerEvent,
+  createExportWorkerJobId,
+  isCleanExportCancellation,
+} from '../services/exportWorkerLifecycle.mjs'
+import {
   checkRtxVideoUpscaleReadiness,
   installRtxVideoUpscaleRuntime,
 } from '../services/rtxVideoUpscale'
@@ -25,8 +34,8 @@ const EXPORT_FORMATS = [
   { id: 'webm', label: 'WebM (VP9)' },
   { id: 'prores', label: 'MOV (ProRes)' },
   { id: 'audio', label: 'Audio Only (WAV/MP3/M4A)' },
+  { id: 'png-seq', label: 'PNG Image Sequence' },
   { id: 'gif', label: 'GIF (Preview - Soon)', disabled: true },
-  { id: 'png-seq', label: 'PNG Sequence - Soon', disabled: true },
 ]
 
 const XML_EXPORT_FORMATS = [
@@ -71,6 +80,7 @@ const VIDEO_CODECS = {
   // Audio-only export renders no video; the empty list keeps the format
   // switcher's codec reset from inventing one.
   audio: [],
+  'png-seq': [],
 }
 
 const AUDIO_CODECS = {
@@ -88,6 +98,7 @@ const AUDIO_CODECS = {
     { id: 'mp3', label: 'MP3' },
     { id: 'aac', label: 'M4A (AAC)' },
   ],
+  'png-seq': [],
 }
 
 const ENCODER_PRESETS = [
@@ -387,6 +398,7 @@ function ExportPanel() {
   const [exportProgress, setExportProgress] = useState(0)
   const [exportError, setExportError] = useState(null)
   const [exportResult, setExportResult] = useState(null)
+  const [externalExportNotice, setExternalExportNotice] = useState(null)
   const [etaSeconds, setEtaSeconds] = useState(null)
   const [renderFps, setRenderFps] = useState(null)
   const [rtxReadiness, setRtxReadiness] = useState({
@@ -428,6 +440,10 @@ function ExportPanel() {
     || XML_EXPORT_FORMATS[0]
   const exportStartRef = useRef(null)
   const renderStartRef = useRef(null)
+  // The main process permits one hidden export worker at a time. Resolve its
+  // lifecycle here so queued jobs wait for completion instead of treating
+  // successful worker startup as a completed export.
+  const workerExportCompletionRef = useRef(null)
   const nvencCheckRequestRef = useRef(0)
   const [nvencStatus, setNvencStatus] = useState({
     checked: false,
@@ -569,7 +585,16 @@ function ExportPanel() {
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.electronAPI?.onExportProgress) return
-    const onProgress = (data) => {
+    const onProgress = (data, metadata) => {
+      const completion = workerExportCompletionRef.current
+      if (completion && classifyExportWorkerEvent(completion.jobId, metadata) === 'external') return
+      if (!completion) {
+        // Agent/MCP exports intentionally return after startup. Preserve their
+        // visible progress without giving them ownership of a UI job promise.
+        setIsExporting(true)
+        setExportError(null)
+        setExportResult(null)
+      }
       setExportStatus(data.status || '')
       if (typeof data.progress === 'number') setExportProgress(data.progress)
       if (exportStartRef.current && data.frame != null && data.totalFrames != null) {
@@ -582,7 +607,17 @@ function ExportPanel() {
         }
       }
     }
-    const onComplete = (data) => {
+    const onComplete = (data, metadata) => {
+      const completion = workerExportCompletionRef.current
+      if (completion && classifyExportWorkerEvent(completion.jobId, metadata) === 'external') {
+        setExternalExportNotice({
+          type: 'success',
+          message: data?.outputPath
+            ? `Background export completed: ${data.outputPath}`
+            : 'Background export completed.',
+        })
+        return
+      }
       // Stringified so saved devtools logs keep nested fields (frameSources,
       // perf) instead of collapsing them to {…}.
       console.log('[ExportPanel] Worker export complete', JSON.stringify(data))
@@ -590,24 +625,47 @@ function ExportPanel() {
       setExportStatus('Export complete')
       setExportProgress(100)
       setIsExporting(false)
+      workerExportCompletionRef.current = null
+      completion?.resolve(data)
     }
-    const onError = (err) => {
+    const onError = (err, metadata) => {
+      const completion = workerExportCompletionRef.current
       const msg = typeof err === 'string' ? err : (err?.message ?? (err && typeof err === 'object' && err.constructor?.name === 'Event' ? `Export error (${err.type})` : String(err)))
-      if (/cancelled/i.test(String(msg))) {
+      if (completion && classifyExportWorkerEvent(completion.jobId, metadata) === 'external') {
+        const stopped = isCleanExportCancellation(msg)
+        setExternalExportNotice({
+          type: stopped ? 'stopped' : 'error',
+          message: stopped
+            ? 'Background export stopped.'
+            : `Background export failed: ${msg || 'Unknown error'}`,
+        })
+        return
+      }
+      workerExportCompletionRef.current = null
+      if (isCleanExportCancellation(msg)) {
         console.log('[ExportPanel] Export stopped by user')
         setExportError(null)
         setExportStatus('Export stopped')
         setIsExporting(false)
+        completion?.reject(new Error('Export cancelled'))
         return
       }
       console.error('[ExportPanel] Worker export error', err, '-> displayed:', msg)
       setExportError(msg || 'Export failed')
       setExportStatus('Export failed')
       setIsExporting(false)
+      completion?.reject(new Error(msg || 'Export failed'))
     }
-    window.electronAPI.onExportProgress(onProgress)
-    window.electronAPI.onExportComplete(onComplete)
-    window.electronAPI.onExportError(onError)
+    const unsubscribe = [
+      window.electronAPI.onExportProgress(onProgress),
+      window.electronAPI.onExportComplete(onComplete),
+      window.electronAPI.onExportError(onError),
+    ]
+    return () => {
+      for (const removeListener of unsubscribe) {
+        if (typeof removeListener === 'function') removeListener()
+      }
+    }
   }, [])
 
   // Abort handle for exports running directly in this window (web build);
@@ -635,8 +693,12 @@ function ExportPanel() {
       if (key === 'format') {
         const supportedVideo = VIDEO_CODECS[value] || []
         const supportedAudio = AUDIO_CODECS[value] || []
-        next.videoCodec = supportedVideo[0]?.id || prev.videoCodec
-        next.audioCodec = supportedAudio[0]?.id || prev.audioCodec
+        next.videoCodec = supportedVideo.some((codec) => codec.id === prev.videoCodec)
+          ? prev.videoCodec
+          : supportedVideo[0]?.id || prev.videoCodec
+        next.audioCodec = supportedAudio.some((codec) => codec.id === prev.audioCodec)
+          ? prev.audioCodec
+          : supportedAudio[0]?.id || prev.audioCodec
         if (next.videoCodec && DEFAULT_CRF[next.videoCodec]) {
           next.crf = DEFAULT_CRF[next.videoCodec]
         }
@@ -674,7 +736,8 @@ function ExportPanel() {
       }
 
       if (key === 'customWidth' || key === 'customHeight') {
-        const numeric = Math.max(2, Math.round(Number(value) || 2))
+        const minimum = next.format === 'png-seq' ? 1 : 2
+        const numeric = Math.max(minimum, Math.round(Number(value) || minimum))
         next[key] = numeric
       }
       
@@ -837,7 +900,11 @@ function ExportPanel() {
           await runExportJob(nextItem.settings, `Queue: ${nextItem.name}`)
           updateQueueItem(nextItem.id, { status: 'completed', completedAt: new Date().toISOString() })
         } catch (err) {
-          updateQueueItem(nextItem.id, { status: 'failed', error: err.message || 'Export failed' })
+          const cancelled = isCleanExportCancellation(err)
+          updateQueueItem(nextItem.id, {
+            status: cancelled ? 'stopped' : 'failed',
+            error: cancelled ? null : (err.message || 'Export failed'),
+          })
         }
       }
     } finally {
@@ -867,28 +934,32 @@ function ExportPanel() {
     runQueue()
   }
 
-  const resolveResolution = () => {
+  const resolveResolution = (exportSettings = settings) => {
     const timelineSettings = getCurrentTimelineSettings() || { width: 1920, height: 1080, fps: 24 }
     const makeEvenDimension = (value) => Math.max(2, Math.round((Number(value) || 2) / 2) * 2)
-    if (settings.resolution === 'project') {
+    const makePngDimension = (value) => Math.max(1, Math.round(Number(value) || 1))
+    const normalizeDimension = exportSettings.format === 'png-seq'
+      ? makePngDimension
+      : makeEvenDimension
+    if (exportSettings.resolution === 'project') {
       return timelineSettings
     }
-    if (settings.resolution === 'custom') {
+    if (exportSettings.resolution === 'custom') {
       return {
-        width: makeEvenDimension(settings.customWidth || timelineSettings.width),
-        height: makeEvenDimension(settings.customHeight || timelineSettings.height),
+        width: normalizeDimension(exportSettings.customWidth || timelineSettings.width),
+        height: normalizeDimension(exportSettings.customHeight || timelineSettings.height),
         fps: timelineSettings.fps || 24,
       }
     }
-    const scaleOption = EXPORT_RESOLUTION_SCALE_OPTIONS.find(option => option.id === settings.resolution)
+    const scaleOption = EXPORT_RESOLUTION_SCALE_OPTIONS.find(option => option.id === exportSettings.resolution)
     if (scaleOption) {
       return {
-        width: makeEvenDimension((timelineSettings.width || 1920) * scaleOption.scale),
-        height: makeEvenDimension((timelineSettings.height || 1080) * scaleOption.scale),
+        width: normalizeDimension((timelineSettings.width || 1920) * scaleOption.scale),
+        height: normalizeDimension((timelineSettings.height || 1080) * scaleOption.scale),
         fps: timelineSettings.fps || 24,
       }
     }
-    const preset = RESOLUTION_PRESETS.find(p => p.name === settings.resolution)
+    const preset = RESOLUTION_PRESETS.find(p => p.name === exportSettings.resolution)
     if (preset) {
       return { width: preset.width, height: preset.height, fps: timelineSettings.fps || 24 }
     }
@@ -898,24 +969,28 @@ function ExportPanel() {
   const getResolutionLabel = (exportSettings = settings) => {
     const timelineSettings = getCurrentTimelineSettings() || { width: 1920, height: 1080, fps: 24 }
     const makeEvenDimension = (value) => Math.max(2, Math.round((Number(value) || 2) / 2) * 2)
+    const makePngDimension = (value) => Math.max(1, Math.round(Number(value) || 1))
+    const normalizeDimension = exportSettings.format === 'png-seq'
+      ? makePngDimension
+      : makeEvenDimension
     if (exportSettings.resolution === 'project') {
       return `Project (${timelineSettings.width}×${timelineSettings.height})`
     }
     if (exportSettings.resolution === 'custom') {
-      return `Custom (${makeEvenDimension(exportSettings.customWidth)}×${makeEvenDimension(exportSettings.customHeight)})`
+      return `Custom (${normalizeDimension(exportSettings.customWidth)}×${normalizeDimension(exportSettings.customHeight)})`
     }
     const scaleOption = EXPORT_RESOLUTION_SCALE_OPTIONS.find(option => option.id === exportSettings.resolution)
     if (scaleOption) {
-      return `${scaleOption.label} (${makeEvenDimension((timelineSettings.width || 1920) * scaleOption.scale)}×${makeEvenDimension((timelineSettings.height || 1080) * scaleOption.scale)})`
+      return `${scaleOption.label} (${normalizeDimension((timelineSettings.width || 1920) * scaleOption.scale)}×${normalizeDimension((timelineSettings.height || 1080) * scaleOption.scale)})`
     }
     return exportSettings.resolution
   }
 
-  const resolveFps = () => {
-    if (settings.fps === 'project') {
+  const resolveFps = (exportSettings = settings) => {
+    if (exportSettings.fps === 'project') {
       return getCurrentTimelineSettings()?.fps || 24
     }
-    return Number(settings.fps) || 24
+    return Number(exportSettings.fps) || 24
   }
 
   const rtxUpscaleEnabled = settings.postProcessUpscale === 'rtx-4k'
@@ -939,8 +1014,8 @@ function ExportPanel() {
           ? rtxReadiness.error
           : 'Runs directly on NVIDIA RTX. ComfyUI is not required. Optional runtime is about 1 GB.'
 
-  const resolveRange = () => {
-    if (settings.range === 'inout' && inPoint !== null && outPoint !== null) {
+  const resolveRange = (exportSettings = settings) => {
+    if (exportSettings.range === 'inout' && inPoint !== null && outPoint !== null) {
       return { start: Math.min(inPoint, outPoint), end: Math.max(inPoint, outPoint) }
     }
     return { start: 0, end: getTimelineEndTime() }
@@ -973,6 +1048,7 @@ function ExportPanel() {
 
   const performanceHints = useMemo(() => {
     const hints = []
+    const isPngSequence = settings.format === 'png-seq'
     const timelineSettings = getCurrentTimelineSettings() || { width: 1920, height: 1080, fps: 24 }
     const resolution = resolveResolution()
     const effectiveFps = settings.fps === 'project' ? timelineSettings.fps : Number(settings.fps || timelineSettings.fps)
@@ -982,7 +1058,9 @@ function ExportPanel() {
       hints.push('4K exports are heavy. Consider proxies or lower resolution for previews.')
     }
     if (settings.postProcessUpscale === 'rtx-4k') {
-      hints.push('RTX 4K runs after the normal render and streams one frame at a time to keep memory bounded.')
+      if (!isPngSequence) {
+        hints.push('RTX 4K runs after the normal render and streams one frame at a time to keep memory bounded.')
+      }
     }
     if (settings.useProxyMedia && proxyCoverage.ready > 0) {
       hints.push(`Proxy export will use ${proxyCoverage.ready}/${proxyCoverage.total} ready video prox${proxyCoverage.ready === 1 ? 'y' : 'ies'}.`)
@@ -992,19 +1070,24 @@ function ExportPanel() {
     if (effectiveFps >= 60) {
       hints.push('60fps export doubles frame workload. Lower FPS for faster renders.')
     }
-    if (!settings.useHardwareEncoder && settings.format === 'mp4' && settings.videoCodec !== 'vp9') {
-      hints.push('Enable NVIDIA NVENC to speed up H.264/H.265 exports on supported NVIDIA GPUs.')
-    }
-    if (nvencStatus.checked && !nvencStatus.available) {
-      hints.push('NVENC not detected in your FFmpeg build. GPU encoding will be unavailable.')
-    }
-    if (settings.format === 'webm' || settings.videoCodec === 'vp9') {
-      hints.push('VP9/WebM encodes slower than H.264/H.265.')
-    }
-    if (settings.useDirectFramePipe) {
-      hints.push('Fast FFmpeg pipe skips writing PNG frames before encoding.')
+    if (isPngSequence) {
+      hints.push('PNG image sequences create one lossless file per frame and can use substantial disk space.')
+      hints.push('PNG image sequences do not contain audio.')
     } else {
-      hints.push('Enable Fast FFmpeg pipe to avoid PNG frame files.')
+      if (!settings.useHardwareEncoder && settings.format === 'mp4' && settings.videoCodec !== 'vp9') {
+        hints.push('Enable NVIDIA NVENC to speed up H.264/H.265 exports on supported NVIDIA GPUs.')
+      }
+      if (nvencStatus.checked && !nvencStatus.available) {
+        hints.push('NVENC not detected in your FFmpeg build. GPU encoding will be unavailable.')
+      }
+      if (settings.format === 'webm' || settings.videoCodec === 'vp9') {
+        hints.push('VP9/WebM encodes slower than H.264/H.265.')
+      }
+      if (settings.useDirectFramePipe) {
+        hints.push('Fast FFmpeg pipe skips writing PNG frames before encoding.')
+      } else {
+        hints.push('Enable Fast FFmpeg pipe to avoid PNG frame files.')
+      }
     }
     
     const textClips = clips.filter(clip => clip.type === 'text')
@@ -1017,7 +1100,7 @@ function ExportPanel() {
     
     const audioClips = clips.filter(clip => clip.type === 'audio')
     const activeAudioTracks = tracks.filter(track => track.type === 'audio' && track.visible && !track.muted)
-    if (settings.includeAudio && audioClips.length > 0 && activeAudioTracks.length > 0) {
+    if (!isPngSequence && settings.includeAudio && audioClips.length > 0 && activeAudioTracks.length > 0) {
       hints.push('Audio mixdown runs offline; long timelines increase export time.')
     }
     
@@ -1025,9 +1108,10 @@ function ExportPanel() {
   }, [clips, transitions, tracks, settings, getCurrentTimelineSettings, nvencStatus, proxyCoverage])
 
   const runExportJob = async (jobSettings, labelOverride = null) => {
-    const shouldRunRtxUpscale = jobSettings.postProcessUpscale === 'rtx-4k'
-    if (jobSettings.format === 'gif' || jobSettings.format === 'png-seq') {
-      throw new Error('GIF and PNG sequence export are not wired yet.')
+    const isPngSequence = jobSettings.format === 'png-seq'
+    const shouldRunRtxUpscale = !isPngSequence && jobSettings.postProcessUpscale === 'rtx-4k'
+    if (jobSettings.format === 'gif') {
+      throw new Error('GIF export is not wired yet.')
     }
     if (shouldRunRtxUpscale && jobSettings.format !== 'mp4') {
       throw new Error('NVIDIA RTX Video Super Resolution currently requires an MP4 export.')
@@ -1035,7 +1119,7 @@ function ExportPanel() {
     if (shouldRunRtxUpscale && window.electronAPI?.platform !== 'win32') {
       throw new Error('NVIDIA RTX Video Super Resolution is currently available on Windows only.')
     }
-    if (jobSettings.useHardwareEncoder && nvencStatus.checked) {
+    if (!isPngSequence && jobSettings.useHardwareEncoder && nvencStatus.checked) {
       const codecSupported = jobSettings.videoCodec === 'h265'
         ? nvencStatus.h265
         : nvencStatus.h264
@@ -1050,6 +1134,7 @@ function ExportPanel() {
     setRenderFps(null)
     setExportError(null)
     setExportResult(null)
+    setExternalExportNotice(null)
     setIsExporting(true)
 
     if (shouldRunRtxUpscale) {
@@ -1061,17 +1146,17 @@ function ExportPanel() {
       }
     }
 
-    const { width, height } = resolveResolution()
-    const fps = resolveFps()
-    const range = resolveRange()
+    const { width, height } = resolveResolution(jobSettings)
+    const fps = resolveFps(jobSettings)
+    const range = resolveRange(jobSettings)
     const timelineSettings = getCurrentTimelineSettings() || { width: 1920, height: 1080, fps: 24 }
     const options = {
       filename: jobSettings.filename?.trim() || defaultFilename,
       format: jobSettings.format,
-      videoCodec: jobSettings.videoCodec,
-      audioCodec: jobSettings.audioCodec,
+      videoCodec: isPngSequence ? null : jobSettings.videoCodec,
+      audioCodec: isPngSequence ? null : jobSettings.audioCodec,
       proresProfile: jobSettings.proresProfile,
-      useHardwareEncoder: jobSettings.useHardwareEncoder,
+      useHardwareEncoder: isPngSequence ? false : jobSettings.useHardwareEncoder,
       nvencPreset: jobSettings.nvencPreset,
       preset: jobSettings.preset,
       qualityMode: jobSettings.qualityMode,
@@ -1085,35 +1170,65 @@ function ExportPanel() {
       fps,
       rangeStart: range.start,
       rangeEnd: range.end,
-      includeAudio: jobSettings.includeAudio,
+      includeAudio: isPngSequence ? false : jobSettings.includeAudio,
       audioBitrateKbps: Number(jobSettings.audioBitrateKbps),
       audioSampleRate: Number(jobSettings.audioSampleRate),
       audioChannels: Number(jobSettings.audioChannels),
-      normalizeAudio: (jobSettings.includeAudio || jobSettings.format === 'audio') && !!jobSettings.normalizeAudio,
+      normalizeAudio: isPngSequence
+        ? false
+        : (jobSettings.includeAudio || jobSettings.format === 'audio') && !!jobSettings.normalizeAudio,
       loudnessTarget: Number(jobSettings.loudnessTarget) || -14,
       useCachedRenders: false,
       useProxyMedia: jobSettings.useProxyMedia,
       fastSeek: false,
-      useDirectFramePipe: jobSettings.useDirectFramePipe,
+      useDirectFramePipe: isPngSequence ? false : jobSettings.useDirectFramePipe,
+      postProcessUpscale: isPngSequence ? 'none' : jobSettings.postProcessUpscale,
     }
 
     if (window.electronAPI?.runExportInWorker && typeof currentProjectHandle === 'string') {
       try {
-        const outputExtension = jobSettings.format === 'audio'
-          ? (jobSettings.audioCodec === 'mp3' ? 'mp3' : (jobSettings.audioCodec === 'wav' ? 'wav' : 'm4a'))
-          : (jobSettings.format === 'webm' ? 'webm' : (jobSettings.format === 'prores' ? 'mov' : 'mp4'))
         const outputFolder = await window.electronAPI.pathJoin(currentProjectHandle, 'renders')
-        await window.electronAPI.createDirectory(outputFolder)
-        const outputBaseName = shouldRunRtxUpscale ? `${options.filename}_rtx4k` : options.filename
-        const defaultPath = await window.electronAPI.pathJoin(outputFolder, `${outputBaseName}.${outputExtension}`)
-        const finalOutputPath = await window.electronAPI.saveFileDialog({
-          title: shouldRunRtxUpscale ? 'Export Timeline with NVIDIA RTX 4K Upscale' : 'Export Timeline',
-          defaultPath,
-          filters: [{ name: outputExtension.toUpperCase(), extensions: [outputExtension] }],
-        })
-        if (!finalOutputPath) {
-          setIsExporting(false)
-          throw new Error('Export cancelled')
+        const createRendersResult = await window.electronAPI.createDirectory(outputFolder)
+        if (createRendersResult?.success === false) {
+          throw new Error(createRendersResult.error || 'Could not create the project renders folder.')
+        }
+
+        let finalOutputPath
+        if (isPngSequence) {
+          if (!window.electronAPI.selectDirectory) {
+            throw new Error('PNG image sequence folder selection is unavailable. Restart Velorn and try again.')
+          }
+          setExportStatus('Choose where to save the PNG image sequence...')
+          const selectedParentFolder = await window.electronAPI.selectDirectory({
+            title: 'Choose PNG Image Sequence Location',
+            defaultPath: outputFolder,
+          })
+          if (!selectedParentFolder) {
+            setIsExporting(false)
+            throw new Error('Export cancelled')
+          }
+          finalOutputPath = await resolveAvailablePngSequenceFolder({
+            api: window.electronAPI,
+            parentFolder: selectedParentFolder,
+            filename: options.filename,
+          })
+          options.filename = sanitizePngSequenceBaseName(options.filename)
+          setExportStatus('Preparing PNG image sequence...')
+        } else {
+          const outputExtension = jobSettings.format === 'audio'
+            ? (jobSettings.audioCodec === 'mp3' ? 'mp3' : (jobSettings.audioCodec === 'wav' ? 'wav' : 'm4a'))
+            : (jobSettings.format === 'webm' ? 'webm' : (jobSettings.format === 'prores' ? 'mov' : 'mp4'))
+          const outputBaseName = shouldRunRtxUpscale ? `${options.filename}_rtx4k` : options.filename
+          const defaultPath = await window.electronAPI.pathJoin(outputFolder, `${outputBaseName}.${outputExtension}`)
+          finalOutputPath = await window.electronAPI.saveFileDialog({
+            title: shouldRunRtxUpscale ? 'Export Timeline with NVIDIA RTX 4K Upscale' : 'Export Timeline',
+            defaultPath,
+            filters: [{ name: outputExtension.toUpperCase(), extensions: [outputExtension] }],
+          })
+          if (!finalOutputPath) {
+            setIsExporting(false)
+            throw new Error('Export cancelled')
+          }
         }
         const sourceOutputPath = shouldRunRtxUpscale
           ? await window.electronAPI.pathJoin(outputFolder, `.velorn-rtx-source-${Date.now()}.mp4`)
@@ -1143,7 +1258,21 @@ function ExportPanel() {
             maskFrames: a.maskFrames?.map((f) => ({ ...f, url: undefined })),
           })),
         }
+        const jobId = createExportWorkerJobId()
+        let resolveWorkerExport
+        let rejectWorkerExport
+        const workerExportCompletion = new Promise((resolve, reject) => {
+          resolveWorkerExport = resolve
+          rejectWorkerExport = reject
+        })
+        // The worker can fail during window startup before the IPC invoke
+        // itself resolves; attach a handler immediately to avoid a transient
+        // unhandled rejection while we are still awaiting startup.
+        workerExportCompletion.catch(() => {})
+        const completionRecord = { jobId, resolve: resolveWorkerExport, reject: rejectWorkerExport }
+        workerExportCompletionRef.current = completionRecord
         const workerStart = await window.electronAPI.runExportInWorker({
+          jobId,
           projectPath: currentProjectHandle,
           outputPath: sourceOutputPath,
           options: { ...options, outputPath: sourceOutputPath },
@@ -1151,12 +1280,23 @@ function ExportPanel() {
           state,
         })
         if (workerStart?.success === false) {
+          if (workerExportCompletionRef.current === completionRecord) {
+            workerExportCompletionRef.current = null
+          }
           throw new Error(workerStart.error || 'Could not start the export worker.')
         }
-        return
+        if (workerStart?.jobId !== jobId) {
+          if (workerExportCompletionRef.current === completionRecord) {
+            workerExportCompletionRef.current = null
+          }
+          throw new Error('Could not correlate the export worker job. Restart Velorn and try again.')
+        }
+        return await workerExportCompletion
       } catch (err) {
-        setExportError(err?.message || 'Export failed')
-        setExportStatus('Export failed')
+        workerExportCompletionRef.current = null
+        const cancelled = isCleanExportCancellation(err)
+        setExportError(cancelled ? null : (err?.message || 'Export failed'))
+        setExportStatus(cancelled ? 'Export stopped' : 'Export failed')
         setIsExporting(false)
         throw err
       }
@@ -1173,6 +1313,12 @@ function ExportPanel() {
           ? 'Export worker unavailable: the project location is not a local folder path. Re-open the project from disk and try again.'
           : 'Export worker unavailable. Restart Velorn and try again.'
       )
+    }
+
+    if (isPngSequence) {
+      setExportStatus('Export failed')
+      setIsExporting(false)
+      throw new Error('PNG image sequence export is available in the Velorn desktop app.')
     }
 
     const directAbortController = new AbortController()
@@ -1203,7 +1349,7 @@ function ExportPanel() {
       }
     })
     
-    setExportResult(result)
+    setExportResult({ ...result, format: result?.format || jobSettings.format })
     setExportStatus('Export complete')
     setExportProgress(100)
     setIsExporting(false)
@@ -1216,8 +1362,9 @@ function ExportPanel() {
     try {
       await runExportJob(settings)
     } catch (err) {
-      setExportError(err.message || 'Export failed')
-      setExportStatus('Export failed')
+      const cancelled = isCleanExportCancellation(err)
+      setExportError(cancelled ? null : (err.message || 'Export failed'))
+      setExportStatus(cancelled ? 'Export stopped' : 'Export failed')
       setIsExporting(false)
     }
   }
@@ -1340,6 +1487,7 @@ function ExportPanel() {
             <span className="ml-auto text-[10px] text-sf-text-muted">Saved for this project</span>
           </div>
 
+          {settings.format !== 'png-seq' && (
           <div className="mb-3 shrink-0 rounded-lg border border-sf-dark-700 bg-sf-dark-950/45 p-2">
             <div className="mb-2 flex items-center justify-between gap-2">
               <div>
@@ -1382,6 +1530,7 @@ function ExportPanel() {
               })}
             </div>
           </div>
+          )}
           
           <div className="grid grid-cols-2 gap-3 shrink-0">
             <div>
@@ -1426,8 +1575,13 @@ function ExportPanel() {
               </p>
             </div>
           </div>
-          <p className="mt-1 text-[10px] text-sf-text-muted shrink-0">Output location will be chosen when export starts.</p>
+          <p className="mt-1 text-[10px] text-sf-text-muted shrink-0">
+            {settings.format === 'png-seq'
+              ? `Choose a parent location when export starts. Velorn will create ${sanitizePngSequenceBaseName(settings.filename || defaultFilename)}_png with frames named ${sanitizePngSequenceBaseName(settings.filename || defaultFilename)}_000001.png and onward.`
+              : 'Output location will be chosen when export starts.'}
+          </p>
           
+          {settings.format !== 'png-seq' && (
           <div className="mt-2 flex items-center gap-2 text-[10px] text-sf-text-muted shrink-0">
             <span className="uppercase tracking-wider">Render</span>
             <button
@@ -1448,13 +1602,23 @@ function ExportPanel() {
               Individual clips
             </button>
           </div>
+          )}
           
           <div className="mt-3 border-t border-sf-dark-700 pt-2 flex-1 min-h-0 overflow-y-auto pr-1 space-y-4">
-            {/* Video — the whole section is moot for an audio-only export */}
+            {/* Visual export settings — the whole section is moot for an audio-only export */}
             {settings.format !== 'audio' && (
             <div>
-              <div className="text-[10px] text-sf-text-muted uppercase tracking-wider mb-2">Video</div>
+              <div className="text-[10px] text-sf-text-muted uppercase tracking-wider mb-2">
+                {settings.format === 'png-seq' ? 'Image Sequence' : 'Video'}
+              </div>
               <div className="grid grid-cols-2 gap-3">
+                {settings.format === 'png-seq' && (
+                  <div className="col-span-2 rounded border border-sf-dark-700 bg-sf-dark-950/45 p-2 text-xs text-sf-text-secondary">
+                    Exports one numbered, lossless PNG for every rendered timeline frame. Image sequences do not include audio.
+                  </div>
+                )}
+                {settings.format !== 'png-seq' && (
+                <>
                 <div className="col-span-2">
                   <div className="flex items-center gap-2">
                     <button
@@ -1725,6 +1889,8 @@ function ExportPanel() {
                   </div>
                 </>
                 )}
+                </>
+                )}
                 
                 <div>
                   <label className="text-[10px] text-sf-text-muted uppercase tracking-wider">Resolution</label>
@@ -1753,8 +1919,8 @@ function ExportPanel() {
                     <div className="mt-1 grid grid-cols-[1fr_auto_1fr] items-center gap-1">
                       <input
                         type="number"
-                        min={2}
-                        step={2}
+                        min={settings.format === 'png-seq' ? 1 : 2}
+                        step={settings.format === 'png-seq' ? 1 : 2}
                         value={settings.customWidth}
                         onChange={(e) => handleSettingChange('customWidth', Number(e.target.value))}
                         className="w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-2 py-1 text-xs text-sf-text-primary focus:outline-none focus:border-sf-accent"
@@ -1763,17 +1929,19 @@ function ExportPanel() {
                       <span className="text-[10px] text-sf-text-muted">×</span>
                       <input
                         type="number"
-                        min={2}
-                        step={2}
+                        min={settings.format === 'png-seq' ? 1 : 2}
+                        step={settings.format === 'png-seq' ? 1 : 2}
                         value={settings.customHeight}
                         onChange={(e) => handleSettingChange('customHeight', Number(e.target.value))}
                         className="w-full bg-sf-dark-800 border border-sf-dark-600 rounded px-2 py-1 text-xs text-sf-text-primary focus:outline-none focus:border-sf-accent"
                         aria-label="Custom export height"
                       />
                     </div>
-                    <div className="mt-1 text-[10px] text-sf-text-muted">
-                      Values are rounded to even pixels for video encoders.
-                    </div>
+                    {settings.format !== 'png-seq' && (
+                      <div className="mt-1 text-[10px] text-sf-text-muted">
+                        Values are rounded to even pixels for video encoders.
+                      </div>
+                    )}
                   </div>
                 )}
                 
@@ -1822,6 +1990,7 @@ function ExportPanel() {
             )}
 
             {/* Audio */}
+            {settings.format !== 'png-seq' && (
             <div>
               <div className="text-[10px] text-sf-text-muted uppercase tracking-wider mb-2">Audio</div>
               <div className="grid grid-cols-2 gap-3">
@@ -1964,6 +2133,7 @@ function ExportPanel() {
                 )}
               </div>
             </div>
+            )}
             
           </div>
           
@@ -1985,7 +2155,13 @@ function ExportPanel() {
               }`}
             >
               <Play className="w-3 h-3" />
-              {isExporting ? 'Exporting...' : (queueRunning ? 'Queue Running' : 'Start Export')}
+              {isExporting
+                ? (settings.format === 'png-seq' ? 'Exporting PNGs...' : 'Exporting...')
+                : queueRunning
+                  ? 'Queue Running'
+                  : settings.format === 'png-seq'
+                    ? 'Export PNG Sequence'
+                    : 'Start Export'}
             </button>
             {isExporting && (
               <button
@@ -2049,11 +2225,31 @@ function ExportPanel() {
               {exportError}
             </div>
           )}
+
+          {externalExportNotice && (
+            <div className={`mt-2 shrink-0 text-[11px] ${
+              externalExportNotice.type === 'error'
+                ? 'text-sf-error'
+                : externalExportNotice.type === 'success'
+                  ? 'text-sf-success'
+                  : 'text-sf-text-secondary'
+            }`}>
+              {externalExportNotice.message}
+            </div>
+          )}
           
           {exportResult?.outputPath && !exportError && (
             <div className="mt-2 shrink-0 text-[11px] text-sf-text-secondary">
-              Saved to: {exportResult.outputPath}
-              {exportResult.encoderUsed && (
+              {exportResult.format === 'png-seq' || exportResult.encoderUsed === 'png-sequence'
+                ? `Saved PNG image sequence to: ${exportResult.outputPath}`
+                : `Saved to: ${exportResult.outputPath}`}
+              {(exportResult.format === 'png-seq' || exportResult.encoderUsed === 'png-sequence') && Number.isFinite(exportResult.frameCount) && (
+                <div>{exportResult.frameCount} PNG frame{exportResult.frameCount === 1 ? '' : 's'}</div>
+              )}
+              {exportResult.cleanupWarning && (
+                <div className="text-sf-warning">{exportResult.cleanupWarning}</div>
+              )}
+              {exportResult.encoderUsed && exportResult.format !== 'png-seq' && exportResult.encoderUsed !== 'png-sequence' && (
                 <div>Encoder: {exportResult.encoderUsed}</div>
               )}
             </div>
@@ -2134,7 +2330,11 @@ function ExportPanel() {
                   <div className="min-w-0">
                     <div className="text-xs text-sf-text-primary truncate">{item.name}</div>
                     <div className="text-[10px] text-sf-text-muted">
-                      {item.settings.format.toUpperCase()} • {item.settings.videoCodec?.toUpperCase()} • {getResolutionLabel(item.settings)} • {item.settings.fps} fps
+                      {item.settings.format === 'png-seq'
+                        ? `PNG Image Sequence • ${getResolutionLabel(item.settings)} • ${item.settings.fps === 'project' ? 'Project FPS' : `${item.settings.fps} fps`}`
+                        : item.settings.format === 'audio'
+                          ? `${item.settings.audioCodec?.toUpperCase() || 'Audio'} only`
+                          : `${item.settings.format.toUpperCase()} • ${item.settings.videoCodec?.toUpperCase()} • ${getResolutionLabel(item.settings)} • ${item.settings.fps === 'project' ? 'Project FPS' : `${item.settings.fps} fps`}`}
                     </div>
                     <div className="text-[10px] text-sf-text-muted">
                       Range: {item.settings.range}

--- a/src/services/exportWorkerLifecycle.mjs
+++ b/src/services/exportWorkerLifecycle.mjs
@@ -1,0 +1,39 @@
+const CLEAN_EXPORT_CANCELLATION_MESSAGES = new Set([
+  'export cancelled',
+  'rtx upscale cancelled',
+])
+
+/**
+ * Distinguish an ordinary user cancellation from an export failure whose
+ * diagnostics happen to contain the word "cancelled" (including a retained
+ * output path). Keep this exact so cleanup failures are never hidden.
+ */
+export const isCleanExportCancellation = (value) => {
+  const message = typeof value === 'string' ? value : value?.message
+  const normalized = String(message || '')
+    .trim()
+    .replace(/[.!]+$/g, '')
+    .toLowerCase()
+  return CLEAN_EXPORT_CANCELLATION_MESSAGES.has(normalized)
+}
+
+export const createExportWorkerJobId = () => {
+  const token = globalThis.crypto?.randomUUID?.()
+    || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  return `export-${token}`
+}
+
+/** Only the UI job that installed a completion record may consume an event. */
+export const isMatchingExportWorkerEvent = (expectedJobId, metadata) => (
+  typeof expectedJobId === 'string'
+  && expectedJobId.length > 0
+  && metadata?.jobId === expectedJobId
+)
+
+/**
+ * Events for another worker remain externally observable, but never own or
+ * settle the active UI export promise.
+ */
+export const classifyExportWorkerEvent = (expectedJobId, metadata) => (
+  isMatchingExportWorkerEvent(expectedJobId, metadata) ? 'active' : 'external'
+)

--- a/src/services/exporter.js
+++ b/src/services/exporter.js
@@ -55,6 +55,13 @@ import { applyTransitionClip, getFadeOverlayInfo, getTransitionCanvasStyle } fro
 import { isFullBakeFresh } from '../utils/clipBakeSignature'
 import { createGpuCompositor, isGpuExportEnabled } from './gpuCompositor'
 import { isAbsoluteRecordedPath } from './assetRelinkFallback'
+import {
+  cleanupCompletedPngSequenceTemp,
+  getPngSequenceFrameFilename,
+  getPngSequenceFramePattern,
+  sanitizePngSequenceBaseName,
+  withOwnedPngSequenceOutput,
+} from './pngSequenceExport.mjs'
 
 const DEFAULT_SAMPLE_RATE = 44100
 const AUDIO_FETCH_TIMEOUT_MS = 15000
@@ -1103,7 +1110,7 @@ const formatAudioMixDropError = (skipped, includedCount, expectedCount) => {
   return `${head} Dropped: ${details.join('; ')}`
 }
 
-export const exportTimeline = async (options = {}, onProgress = () => {}) => {
+const runExportTimeline = async (options = {}, onProgress = () => {}) => {
   const timelineState = useTimelineStore.getState()
   const assetsState = useAssetsStore.getState()
   const projectState = useProjectStore.getState()
@@ -1118,7 +1125,7 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
     rangeStart = 0,
     rangeEnd = timelineState.getTimelineEndTime(),
     format = 'mp4',
-    includeAudio = true,
+    includeAudio: requestedIncludeAudio = true,
     filename = 'export',
     videoCodec = 'h264',
     audioCodec = 'aac',
@@ -1140,7 +1147,7 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
     useCachedRenders = true,
     useProxyMedia = false,
     fastSeek = true,
-    useDirectFramePipe = true,
+    useDirectFramePipe: requestedDirectFramePipe = true,
     deliveryFraming = 'fit',
     glslQualityScale = 1,
     // Final exports sample each frame at its temporal center (pairs with
@@ -1154,8 +1161,18 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
     // transitions) over the range, onto a transparent canvas so the baked
     // file still composites over lower layers.
     soloClipIds = null,
-    transparent = false,
+    transparent: requestedTransparency = false,
   } = options
+  const pngSequenceExport = format === 'png-seq'
+  // An image sequence is a visual-only delivery. Keep this defensive in the
+  // renderer even though the export panel also hides/disables video/audio
+  // encoder settings for the format.
+  const includeAudio = pngSequenceExport ? false : requestedIncludeAudio
+  const useDirectFramePipe = pngSequenceExport ? false : requestedDirectFramePipe
+  const transparent = pngSequenceExport ? false : requestedTransparency
+  const pngSequenceBaseName = pngSequenceExport
+    ? sanitizePngSequenceBaseName(filename)
+    : null
   const soloClipSet = Array.isArray(soloClipIds) && soloClipIds.length > 0
     ? new Set(soloClipIds)
     : null
@@ -1167,6 +1184,12 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
   
   const totalDuration = Math.max(0, rangeEnd - rangeStart)
   const totalFrames = Math.ceil(totalDuration * fps)
+  if (pngSequenceExport && (!Number.isFinite(Number(fps)) || Number(fps) <= 0 || totalFrames <= 0)) {
+    throw new Error('The PNG sequence export range must contain at least one frame at a valid FPS.')
+  }
+  if (pngSequenceExport && (!Number.isFinite(Number(width)) || Number(width) <= 0 || !Number.isFinite(Number(height)) || Number(height) <= 0)) {
+    throw new Error('The PNG sequence export dimensions must be greater than zero.')
+  }
   const normalizedDeliveryFraming = ['fill', 'cover', 'center_crop', 'center-crop'].includes(String(deliveryFraming || '').toLowerCase())
     ? 'fill'
     : 'fit'
@@ -1199,18 +1222,18 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
   }
   
   const outputFolder = await window.electronAPI.pathJoin(projectState.currentProjectHandle, 'renders')
-  await window.electronAPI.createDirectory(outputFolder)
-  
-  const tempFolder = await window.electronAPI.pathJoin(outputFolder, `export_${Date.now()}`)
-  await window.electronAPI.createDirectory(tempFolder)
-  const framesFolder = await window.electronAPI.pathJoin(tempFolder, 'frames')
-  await window.electronAPI.createDirectory(framesFolder)
-  
+  if (!pngSequenceExport) {
+    await window.electronAPI.createDirectory(outputFolder)
+  }
+
   const audioOnlyExport = format === 'audio'
   const outputExtension = audioOnlyExport
     ? (audioCodec === 'mp3' ? 'mp3' : (audioCodec === 'wav' ? 'wav' : 'm4a'))
     : (format === 'webm' ? 'webm' : (format === 'prores' ? 'mov' : 'mp4'))
   let outputPath = options.outputPath
+  if (pngSequenceExport && !outputPath) {
+    throw new Error('Choose an output folder for the PNG sequence.')
+  }
   if (!outputPath) {
     const defaultOutputPath = await window.electronAPI.pathJoin(
       outputFolder,
@@ -1228,7 +1251,32 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
     }
     outputPath = saveDialog
   }
-  const framePattern = await window.electronAPI.pathJoin(framesFolder, 'frame_%06d.png')
+
+  // The wrapper creates and owns the fresh sequence directory. Temporary
+  // prepared sources live under that owned directory so a failed/cancelled
+  // export can remove everything without ever touching the selected parent.
+  const tempFolder = pngSequenceExport
+    ? await window.electronAPI.pathJoin(outputPath, '.velorn-export-temp')
+    : await window.electronAPI.pathJoin(outputFolder, `export_${Date.now()}`)
+  if (pngSequenceExport) {
+    const tempFolderResult = await window.electronAPI.createDirectory(tempFolder, { recursive: false })
+    if (!tempFolderResult?.success) {
+      throw new Error(tempFolderResult?.error || 'Failed to create the export temporary folder.')
+    }
+  } else {
+    await window.electronAPI.createDirectory(tempFolder)
+  }
+  const framesFolder = pngSequenceExport
+    ? outputPath
+    : await window.electronAPI.pathJoin(tempFolder, 'frames')
+  if (!pngSequenceExport) {
+    await window.electronAPI.createDirectory(framesFolder)
+  }
+
+  const framePattern = await window.electronAPI.pathJoin(
+    framesFolder,
+    pngSequenceExport ? getPngSequenceFramePattern(pngSequenceBaseName) : 'frame_%06d.png'
+  )
   const audioPath = await window.electronAPI.pathJoin(tempFolder, 'audio.wav')
 
   // ---- Audio-only export: the exact program mix a video export bakes in,
@@ -3159,18 +3207,39 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
       exportPerf.yieldMs += performance.now() - taskYieldStart
     } else {
       const frameBlob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'))
+      if (!frameBlob) {
+        throw new Error(`Failed to encode PNG frame ${frameIndex + 1}.`)
+      }
       const frameBuffer = await frameBlob.arrayBuffer()
-      const framePath = await window.electronAPI.pathJoin(framesFolder, `frame_${formatFrameNumber(frameIndex + 1)}.png`)
-      await window.electronAPI.writeFileFromArrayBuffer(framePath, frameBuffer)
+      const frameFilename = pngSequenceExport
+        ? getPngSequenceFrameFilename(pngSequenceBaseName, frameIndex + 1)
+        : `frame_${formatFrameNumber(frameIndex + 1)}.png`
+      const framePath = await window.electronAPI.pathJoin(framesFolder, frameFilename)
+      const writeResult = await window.electronAPI.writeFileFromArrayBuffer(framePath, frameBuffer)
+      if (!writeResult?.success) {
+        throw new Error(writeResult?.error || `Failed to write PNG frame ${frameIndex + 1}.`)
+      }
     }
     
     if (frameIndex % 5 === 0) {
-      const progress = 5 + Math.floor((frameIndex / totalFrames) * 70)
-      onProgress({ 
-        status: EXPORT_STATUS.rendering, 
+      const progress = pngSequenceExport
+        ? Math.max(1, Math.min(99, Math.floor(((frameIndex + 1) / totalFrames) * 99)))
+        : 5 + Math.floor((frameIndex / totalFrames) * 70)
+      onProgress({
+        status: pngSequenceExport ? 'Writing PNG image sequence...' : EXPORT_STATUS.rendering,
         progress,
         frame: frameIndex + 1,
-        totalFrames
+        totalFrames,
+        ...(pngSequenceExport
+          ? {
+            frameCount: totalFrames,
+            fps,
+            width,
+            height,
+            dimensions: { width, height },
+            framePattern,
+          }
+          : {}),
       })
     }
     if (frameIndex > 0 && frameIndex % 10 === 0) {
@@ -3227,6 +3296,67 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
       framePipeSessionId = null
     }
     throw err
+  }
+
+  if (pngSequenceExport) {
+    throwIfCancelled()
+    const cleanupWarning = await cleanupCompletedPngSequenceTemp({
+      api: window.electronAPI,
+      tempFolder,
+    })
+    if (cleanupWarning) {
+      console.warn('PNG sequence frames completed, but temporary files could not be removed:', cleanupWarning)
+    }
+    const completion = {
+      status: EXPORT_STATUS.done,
+      progress: 100,
+      frame: totalFrames,
+      totalFrames,
+      frameCount: totalFrames,
+      fps,
+      width,
+      height,
+      dimensions: { width, height },
+      framePattern,
+    }
+    onProgress(completion)
+    const perFrameMs = (ms) => (totalFrames > 0 ? Number((ms / totalFrames).toFixed(2)) : 0)
+    return {
+      format: 'png-seq',
+      outputPath,
+      encoderUsed: 'png-sequence',
+      frameCount: totalFrames,
+      fps,
+      width,
+      height,
+      dimensions: { width, height },
+      framePattern,
+      cleanupWarning: cleanupWarning
+        ? `PNG frames were saved, but temporary files could not be removed: ${cleanupWarning}`
+        : null,
+      hardwareFallback: false,
+      hardwareFfmpeg: null,
+      frameSources: webCodecsEnabled
+        ? {
+          webcodecs: webCodecsClipCount,
+          element: elementPathClipCount,
+          sourcePreparation,
+        }
+        : null,
+      perf: {
+        frames: totalFrames,
+        gpuCompositing: false,
+        perFrameMs: {
+          mediaSample: perFrameMs(exportPerf.sampleMs),
+          layerComposite: perFrameMs(exportPerf.layersMs - exportPerf.sampleMs),
+          readback: perFrameMs(exportPerf.readbackMs),
+          pipeWrite: 0,
+          uiYield: perFrameMs(exportPerf.yieldMs),
+        },
+        preSeek: { batches: exportPerf.preSeekBatches, clips: exportPerf.preSeekClips },
+        frameSource: getFrameSourceStats(),
+      },
+    }
   }
 
   if (framePipeSessionId) {
@@ -3837,6 +3967,30 @@ export const exportTimeline = async (options = {}, onProgress = () => {}) => {
       frameSource: getFrameSourceStats(),
     },
   }
+}
+
+/**
+ * PNG sequences are written into a new, caller-selected child directory.
+ * This wrapper is the ownership boundary: it creates that directory with an
+ * exclusive mkdir and removes exactly that directory if any later step fails
+ * or is cancelled. Existing folders (including the selected parent) are
+ * rejected and are never cleanup targets.
+ */
+export const exportTimeline = async (options = {}, onProgress = () => {}) => {
+  if (options.format !== 'png-seq') {
+    return runExportTimeline(options, onProgress)
+  }
+
+  const api = typeof window !== 'undefined' ? window.electronAPI : null
+  if (!api?.exists || !api?.createDirectory || !api?.deleteDirectory || !api?.pathJoin || !api?.writeFileFromArrayBuffer) {
+    throw new Error('PNG sequence export requires the Velorn desktop app.')
+  }
+
+  return withOwnedPngSequenceOutput({
+    api,
+    outputPath: options.outputPath,
+    run: outputPath => runExportTimeline({ ...options, outputPath }, onProgress),
+  })
 }
 
 export default exportTimeline

--- a/src/services/pngSequenceExport.mjs
+++ b/src/services/pngSequenceExport.mjs
@@ -1,0 +1,145 @@
+const WINDOWS_RESERVED_BASENAME = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i
+const WINDOWS_ABSOLUTE_PATH = /^[a-zA-Z]:[\\/]/
+const WINDOWS_UNC_PATH = /^\\\\[^\\/]+[\\/][^\\/]+/
+
+const isAbsoluteDesktopPath = (value) => (
+  value.startsWith('/')
+  || WINDOWS_ABSOLUTE_PATH.test(value)
+  || WINDOWS_UNC_PATH.test(value)
+)
+
+/**
+ * Produce one portable filename stem for a rendered PNG sequence.
+ *
+ * The result is safe on Windows, macOS, and Linux while retaining ordinary
+ * spaces and punctuation that are valid on every supported platform.
+ */
+export const sanitizePngSequenceBaseName = (value) => {
+  let safeName = String(value || 'export')
+    .normalize('NFKC')
+    .replace(/\.png$/i, '')
+    // Percent is legal in filenames, but it is a printf directive in the
+    // sequence pattern reported to FFmpeg-compatible tools.
+    .replace(/[<>:"/\\|?*%\u0000-\u001f]/g, '_')
+    .trim()
+    .replace(/^\.+$/, '')
+    .replace(/^\.+/, '_')
+    .replace(/[. ]+$/g, '')
+
+  // Sixty Unicode code points leaves enough room for the frame suffix under
+  // common 255-byte filesystem component limits, including four-byte UTF-8.
+  safeName = Array.from(safeName).slice(0, 60).join('').replace(/[. ]+$/g, '')
+
+  if (!safeName || safeName === '.' || safeName === '..') {
+    safeName = 'export'
+  }
+  if (WINDOWS_RESERVED_BASENAME.test(safeName)) {
+    safeName = `_${safeName}`
+  }
+  return safeName
+}
+
+export const getPngSequenceFrameFilename = (baseName, oneBasedFrameNumber) => {
+  const frameNumber = Math.max(1, Math.floor(Number(oneBasedFrameNumber) || 1))
+  return `${sanitizePngSequenceBaseName(baseName)}_${String(frameNumber).padStart(6, '0')}.png`
+}
+
+export const getPngSequenceFramePattern = (baseName) => (
+  `${sanitizePngSequenceBaseName(baseName)}_%06d.png`
+)
+
+/** Pick a currently unused child name without creating it. The ownership
+ * wrapper performs the exclusive mkdir later, closing the race safely. */
+export const resolveAvailablePngSequenceFolder = async ({
+  api,
+  parentFolder,
+  filename,
+  maxAttempts = 10000,
+}) => {
+  if (!api?.pathJoin || !api?.exists) {
+    throw new Error('PNG image sequence folder selection is unavailable. Restart Velorn and try again.')
+  }
+  if (typeof parentFolder !== 'string' || !isAbsoluteDesktopPath(parentFolder)) {
+    throw new Error('Choose an absolute parent folder for the PNG image sequence.')
+  }
+
+  const folderBaseName = `${sanitizePngSequenceBaseName(filename)}_png`
+  for (let index = 1; index <= maxAttempts; index += 1) {
+    const folderName = index === 1 ? folderBaseName : `${folderBaseName}_${index}`
+    const candidate = await api.pathJoin(parentFolder, folderName)
+    if (!(await api.exists(candidate))) return candidate
+  }
+
+  throw new Error('Could not find an available PNG image sequence folder name. Choose another location.')
+}
+
+/**
+ * Remove the internal scratch directory after all PNG frames are complete.
+ * Housekeeping must never turn a successful render into destructive cleanup
+ * of the finished sequence, so failures are returned as a warning.
+ */
+export const cleanupCompletedPngSequenceTemp = async ({ api, tempFolder }) => {
+  try {
+    const result = await api?.deleteDirectory?.(tempFolder, { recursive: true })
+    if (result?.success) return null
+    return result?.error || 'Unknown temporary-folder cleanup error'
+  } catch (err) {
+    return err?.message || String(err)
+  }
+}
+
+/**
+ * Run an export with ownership of one newly-created output directory.
+ * Existing paths are rejected before creation and are never cleanup targets.
+ * The caller-selected parent is not accepted separately, so cleanup can only
+ * ever address the exact child path that this function successfully created.
+ */
+export const withOwnedPngSequenceOutput = async ({ api, outputPath, run }) => {
+  if (!api?.exists || !api?.createDirectory || !api?.deleteDirectory) {
+    throw new Error('PNG sequence export requires the Velorn desktop app.')
+  }
+  if (typeof run !== 'function') {
+    throw new Error('PNG sequence export is missing its render operation.')
+  }
+
+  const exactOutputPath = typeof outputPath === 'string' ? outputPath : ''
+  if (!exactOutputPath.trim()) {
+    throw new Error('Choose an output folder for the PNG sequence.')
+  }
+  if (!isAbsoluteDesktopPath(exactOutputPath)) {
+    throw new Error('The PNG sequence output folder must use an absolute desktop path.')
+  }
+  if (await api.exists(exactOutputPath)) {
+    throw new Error('The PNG sequence output folder already exists. Choose another name or location.')
+  }
+
+  // recursive:false maps to an exclusive mkdir in Electron. If another
+  // process creates the path after the exists check, mkdir fails with EEXIST
+  // and we never claim ownership or run cleanup against it.
+  const createResult = await api.createDirectory(exactOutputPath, { recursive: false })
+  if (!createResult?.success) {
+    throw new Error(createResult?.error || 'Failed to create the PNG sequence output folder.')
+  }
+
+  try {
+    return await run(exactOutputPath)
+  } catch (err) {
+    let cleanupError = null
+    try {
+      const cleanupResult = await api.deleteDirectory(exactOutputPath, { recursive: true })
+      if (!cleanupResult?.success) {
+        cleanupError = cleanupResult?.error || 'Unknown cleanup error'
+      }
+    } catch (caughtCleanupError) {
+      cleanupError = caughtCleanupError?.message || String(caughtCleanupError)
+    }
+    if (cleanupError) {
+      console.warn('Failed to clean incomplete PNG sequence output:', cleanupError)
+      const originalMessage = err?.message || String(err)
+      throw new Error(
+        `${originalMessage} Incomplete PNG sequence files remain at ${exactOutputPath} because cleanup failed: ${cleanupError}`
+      )
+    }
+    throw err
+  }
+}

--- a/src/services/pngSequenceExport.test.mjs
+++ b/src/services/pngSequenceExport.test.mjs
@@ -1,0 +1,313 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  cleanupCompletedPngSequenceTemp,
+  getPngSequenceFrameFilename,
+  getPngSequenceFramePattern,
+  resolveAvailablePngSequenceFolder,
+  sanitizePngSequenceBaseName,
+  withOwnedPngSequenceOutput,
+} from './pngSequenceExport.mjs'
+import {
+  classifyExportWorkerEvent,
+  createExportWorkerJobId,
+  isCleanExportCancellation,
+  isMatchingExportWorkerEvent,
+} from './exportWorkerLifecycle.mjs'
+
+test('clean cancellation classification does not hide cleanup or path diagnostics', () => {
+  assert.equal(isCleanExportCancellation(new Error('Export cancelled')), true)
+  assert.equal(isCleanExportCancellation('Export cancelled.'), true)
+  assert.equal(isCleanExportCancellation(new Error('RTX upscale cancelled')), true)
+  assert.equal(
+    isCleanExportCancellation(
+      new Error('Export cancelled Incomplete PNG sequence files remain at /exports/cancelled edit because cleanup failed: File is locked')
+    ),
+    false
+  )
+  assert.equal(
+    isCleanExportCancellation(new Error('PNG write failed at /exports/cancelled edit/frame.png')),
+    false
+  )
+})
+
+test('worker lifecycle accepts only events for the active UI export job', () => {
+  const jobId = createExportWorkerJobId()
+  assert.match(jobId, /^export-[a-zA-Z0-9._:-]+$/)
+  assert.equal(isMatchingExportWorkerEvent(jobId, { jobId }), true)
+  assert.equal(isMatchingExportWorkerEvent(jobId, { jobId: 'export-unrelated-mcp-job' }), false)
+  assert.equal(isMatchingExportWorkerEvent(jobId, undefined), false)
+  assert.equal(isMatchingExportWorkerEvent('', { jobId }), false)
+  assert.equal(classifyExportWorkerEvent(jobId, { jobId }), 'active')
+  assert.equal(classifyExportWorkerEvent(jobId, { jobId: 'export-unrelated-mcp-job' }), 'external')
+  assert.equal(classifyExportWorkerEvent('', { jobId: 'export-mcp-job' }), 'external')
+})
+
+test('sanitizePngSequenceBaseName keeps a readable portable stem', () => {
+  assert.equal(sanitizePngSequenceBaseName('My Finished Edit.png'), 'My Finished Edit')
+  assert.equal(sanitizePngSequenceBaseName('scene: one / final?'), 'scene_ one _ final_')
+  assert.equal(sanitizePngSequenceBaseName('100% Final'), '100_ Final')
+})
+
+test('sanitizePngSequenceBaseName handles empty and Windows-reserved names', () => {
+  assert.equal(sanitizePngSequenceBaseName('  ...  '), 'export')
+  assert.equal(sanitizePngSequenceBaseName('CON'), '_CON')
+  assert.equal(sanitizePngSequenceBaseName('LPT9.png'), '_LPT9')
+  assert.equal(sanitizePngSequenceBaseName('.hidden'), '_hidden')
+  assert.equal(Array.from(sanitizePngSequenceBaseName('🎬'.repeat(80))).length, 60)
+})
+
+test('PNG sequence names are one-based and six-digit padded', () => {
+  assert.equal(getPngSequenceFrameFilename('Launch Cut', 1), 'Launch Cut_000001.png')
+  assert.equal(getPngSequenceFrameFilename('Launch Cut', 42), 'Launch Cut_000042.png')
+  assert.equal(getPngSequenceFramePattern('Launch Cut'), 'Launch Cut_%06d.png')
+})
+
+test('available output folder advances without creating or overwriting', async () => {
+  const checked = []
+  const api = {
+    pathJoin: async (parent, child) => `${parent}/${child}`,
+    exists: async path => {
+      checked.push(path)
+      return path.endsWith('/Launch Cut_png') || path.endsWith('/Launch Cut_png_2')
+    },
+  }
+
+  const result = await resolveAvailablePngSequenceFolder({
+    api,
+    parentFolder: '/selected',
+    filename: 'Launch Cut',
+  })
+
+  assert.equal(result, '/selected/Launch Cut_png_3')
+  assert.deepEqual(checked, [
+    '/selected/Launch Cut_png',
+    '/selected/Launch Cut_png_2',
+    '/selected/Launch Cut_png_3',
+  ])
+})
+
+test('owned output keeps a successful fresh directory', async () => {
+  const calls = []
+  const api = {
+    exists: async path => (calls.push(['exists', path]), false),
+    createDirectory: async (path, options) => (calls.push(['create', path, options]), { success: true }),
+    deleteDirectory: async path => (calls.push(['delete', path]), { success: true }),
+  }
+
+  const result = await withOwnedPngSequenceOutput({
+    api,
+    outputPath: '/selected/My Edit_png',
+    run: async path => ({ outputPath: path }),
+  })
+
+  assert.deepEqual(result, { outputPath: '/selected/My Edit_png' })
+  assert.deepEqual(calls, [
+    ['exists', '/selected/My Edit_png'],
+    ['create', '/selected/My Edit_png', { recursive: false }],
+  ])
+})
+
+test('owned output removes exactly its fresh child after render failure', async () => {
+  const deleted = []
+  const api = {
+    exists: async () => false,
+    createDirectory: async () => ({ success: true }),
+    deleteDirectory: async (path, options) => {
+      deleted.push([path, options])
+      return { success: true }
+    },
+  }
+
+  await assert.rejects(
+    withOwnedPngSequenceOutput({
+      api,
+      outputPath: '/selected/My Edit_png',
+      run: async () => { throw new Error('Export cancelled') },
+    }),
+    /Export cancelled/
+  )
+  assert.deepEqual(deleted, [['/selected/My Edit_png', { recursive: true }]])
+})
+
+test('owned output never creates or deletes a preexisting path', async () => {
+  let created = false
+  let deleted = false
+  const api = {
+    exists: async () => true,
+    createDirectory: async () => (created = true, { success: true }),
+    deleteDirectory: async () => (deleted = true, { success: true }),
+  }
+
+  await assert.rejects(
+    withOwnedPngSequenceOutput({ api, outputPath: '/selected', run: async () => null }),
+    /already exists/
+  )
+  assert.equal(created, false)
+  assert.equal(deleted, false)
+})
+
+test('owned output rejects relative cleanup targets', async () => {
+  let created = false
+  let deleted = false
+  const api = {
+    exists: async () => false,
+    createDirectory: async () => (created = true, { success: true }),
+    deleteDirectory: async () => (deleted = true, { success: true }),
+  }
+
+  await assert.rejects(
+    withOwnedPngSequenceOutput({ api, outputPath: 'relative/output', run: async () => null }),
+    /absolute desktop path/
+  )
+  assert.equal(created, false)
+  assert.equal(deleted, false)
+})
+
+test('owned output accepts absolute Windows drive and UNC paths', async () => {
+  const created = []
+  const api = {
+    exists: async () => false,
+    createDirectory: async path => (created.push(path), { success: true }),
+    deleteDirectory: async () => ({ success: true }),
+  }
+
+  await withOwnedPngSequenceOutput({
+    api,
+    outputPath: 'D:\\Exports\\My Edit_png',
+    run: async path => path,
+  })
+  await withOwnedPngSequenceOutput({
+    api,
+    outputPath: '\\\\server\\share\\My Edit_png',
+    run: async path => path,
+  })
+
+  assert.deepEqual(created, [
+    'D:\\Exports\\My Edit_png',
+    '\\\\server\\share\\My Edit_png',
+  ])
+})
+
+test('owned output does not claim or delete a directory when exclusive creation fails', async () => {
+  let deleted = false
+  const api = {
+    exists: async () => false,
+    createDirectory: async () => ({ success: false, error: 'EEXIST' }),
+    deleteDirectory: async () => (deleted = true, { success: true }),
+  }
+
+  await assert.rejects(
+    withOwnedPngSequenceOutput({ api, outputPath: '/selected/My Edit_png', run: async () => null }),
+    /EEXIST/
+  )
+  assert.equal(deleted, false)
+})
+
+test('incomplete-output cleanup failure surfaces the retained folder path', async () => {
+  const api = {
+    exists: async () => false,
+    createDirectory: async () => ({ success: true }),
+    deleteDirectory: async () => ({ success: false, error: 'File is locked' }),
+  }
+
+  const originalWarn = console.warn
+  console.warn = () => {}
+  try {
+    await assert.rejects(
+      withOwnedPngSequenceOutput({
+        api,
+        outputPath: '/selected/My Edit_png',
+        run: async () => { throw new Error('PNG write failed') },
+      }),
+      /PNG write failed.*\/selected\/My Edit_png.*File is locked/
+    )
+  } finally {
+    console.warn = originalWarn
+  }
+})
+
+test('completed-output temp cleanup returns a warning instead of throwing', async () => {
+  const warning = await cleanupCompletedPngSequenceTemp({
+    api: {
+      deleteDirectory: async () => ({ success: false, error: 'Antivirus lock' }),
+    },
+    tempFolder: '/selected/My Edit_png/.velorn-export-temp',
+  })
+
+  assert.equal(warning, 'Antivirus lock')
+})
+
+test('owned output works against a real fresh filesystem directory', async () => {
+  const parent = await mkdtemp(join(tmpdir(), 'velorn-png-sequence-'))
+  const outputPath = join(parent, 'Real Export_png')
+  const api = {
+    exists: async path => {
+      try {
+        await access(path)
+        return true
+      } catch {
+        return false
+      }
+    },
+    createDirectory: async (path, options = {}) => {
+      try {
+        await mkdir(path, { recursive: options.recursive !== false })
+        return { success: true }
+      } catch (err) {
+        return { success: false, error: err.message }
+      }
+    },
+    deleteDirectory: async path => {
+      try {
+        await rm(path, { recursive: true, force: true })
+        return { success: true }
+      } catch (err) {
+        return { success: false, error: err.message }
+      }
+    },
+  }
+
+  try {
+    const result = await withOwnedPngSequenceOutput({
+      api,
+      outputPath,
+      run: async ownedPath => {
+        const framePath = join(ownedPath, getPngSequenceFrameFilename('Real Export', 1))
+        await writeFile(framePath, 'png-placeholder')
+        return { outputPath: ownedPath, framePath }
+      },
+    })
+
+    assert.equal(result.outputPath, outputPath)
+    await access(result.framePath)
+  } finally {
+    await rm(parent, { recursive: true, force: true })
+  }
+})
+
+test('exported filenames round-trip through Velorn image-sequence detection', async () => {
+  // The production detector is an ESM .js file in a legacy CommonJS package.
+  // Loading its source as a data module keeps this test compatible with the
+  // Node 20 release builder without changing the Electron package type.
+  const detectorSource = await readFile(
+    new URL('../utils/imageSequenceDetection.js', import.meta.url),
+    'utf8'
+  )
+  const detectorModuleUrl = `data:text/javascript;base64,${Buffer.from(detectorSource).toString('base64')}`
+  const { detectImageSequences } = await import(detectorModuleUrl)
+  const files = [1, 2, 3].map(frame => ({
+    name: getPngSequenceFrameFilename('Round Trip', frame),
+    path: `/frames/${getPngSequenceFrameFilename('Round Trip', frame)}`,
+  }))
+
+  const detected = detectImageSequences(files)
+  assert.equal(detected.sequences.length, 1)
+  assert.equal(detected.sequences[0].count, 3)
+  assert.equal(detected.sequences[0].pattern, 'Round Trip_%06d.png')
+  assert.deepEqual(detected.leftovers, [])
+})


### PR DESCRIPTION
## Summary

- add PNG image sequence export to the Export panel
- render numbered, portable PNG filenames into a newly created output folder
- preserve completed output while safely cleaning incomplete jobs on cancellation or failure
- correlate hidden export-worker events with the correct UI, queued, or agent-started job
- bump Velorn to 0.3.27 and add release notes and README coverage

## Why

Velorn could import image sequences but could not export them. This adds a safe frame-by-frame delivery path for compositing, VFX, archival, and downstream image-sequence workflows without changing normal video or audio exports.

## Testing

- [x] Fresh `npm ci` completed.
- [x] All 15 test suites passed: 132 tests, 0 failures.
- [x] Production Vite build passed.
- [x] Electron main and preload syntax checks passed.
- [x] Package and lockfile versions both report 0.3.27.
- [x] `git diff --check` passed.
- [x] PNG sequence export was verified manually in Velorn on Ubuntu.

Known existing Vite chunk, Browserslist, module-type, npm deprecation, and dependency-audit warnings remain unchanged.

## Contributor License Agreement

- [x] I have read and agree to the Contributor License Agreement in CONTRIBUTOR_LICENSE_AGREEMENT.md, and I have the right to submit this contribution.
