### PR TITLE
Prepare Velorn v0.3.29

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -386,11 +386,21 @@ These tools use the same persistent Director state as the visible Music Video UI
 
 | Tool | Purpose |
 | --- | --- |
+| `search_stock_media` | Search Pexels photos/videos and open the same results in Velorn's Stock tab. |
+| `import_stock_media` | Preview/bulk-import selected Pexels IDs or the first N non-duplicate results into a project folder. |
 | `import_asset_from_path` | Preview/import a local media file into the active project. |
 | `relink_asset` | Preview/relink an existing asset record to a local file path. |
 | `add_asset_to_timeline` | Preview/place one project asset on the active timeline. |
 | `add_assets_to_timeline` | Preview/place multiple assets as review lanes or a sequence. |
 | `replace_clip_with_asset` | Preview/replace a clip with another asset while preserving the edit slot and styling by default. |
+
+Pexels search/import requires the user's API key in `Settings > Stock (Pexels)`. A safe agent flow is:
+
+```text
+Search Pexels photos for "ocean drone shots" with search_stock_media. Show me the result IDs first. Then preview importing 10 non-duplicate results with import_stock_media into Stock/Pexels/Ocean Drone Shots. Wait for approval before applying, and do not place anything on the timeline until I approve a separate add_assets_to_timeline preview.
+```
+
+`import_stock_media` re-runs the search before applying so result IDs are validated against Pexels instead of accepting arbitrary download URLs. Imported files become project-owned media and keep Pexels source/creator provenance in their asset metadata.
 
 ### Generation
 

--- a/docs/RELEASE_NOTES_0.3.29.md
+++ b/docs/RELEASE_NOTES_0.3.29.md
@@ -1,0 +1,30 @@
+# Velorn v0.3.29
+
+Velorn v0.3.29 lets local MCP agents search and import Pexels stock media through the same project-owned workflow as the visible Stock tab, and keeps transitions attached when an edit is moved as a group.
+
+## New
+
+- **Pexels search for MCP agents.** Agents can search Pexels photos or videos using the API key already saved in Velorn Settings, including orientation and pagination controls.
+- **Safe bulk stock import.** Agents can preview and import selected Pexels result IDs or the first non-duplicate results into an organized project folder. Imported media becomes project-owned and keeps Pexels source and creator provenance.
+- **Visible Stock-tab handoff.** Agent searches open the matching results in Velorn's Stock tab by default, so creators can review the same media before importing or placing it on a timeline.
+- **Composable timeline placement.** Stock import remains separate from the existing preview-first timeline placement tools, keeping downloads and edit decisions independently reviewable.
+
+## Fixed
+
+- **Transitions follow group moves.** When both clips attached to a between-clip transition move together by the same amount, the transition timing now moves with them instead of remaining behind at its old timeline position.
+
+## Notes
+
+- Pexels features require a Pexels API key in `Settings > Stock (Pexels)`.
+- Restart Velorn and reconnect an MCP client after updating so the client refreshes the available tool list.
+
+## Downloads
+
+- `Windows Installer`: standard Windows install experience for most users
+- `Windows Portable`: no-install Windows build for quick testing or portable use
+- `Mac (Apple Silicon)`: for M1, M2, M3, M4, and newer Macs
+- `Mac (Intel)`: for older Intel-based Macs
+- `Linux AppImage`: portable Linux build
+- `Linux deb`: Debian/Ubuntu package
+
+Ignore the auto-generated source-code archives unless you plan to build Velorn from source.

--- a/electron/mcpServer.js
+++ b/electron/mcpServer.js
@@ -31,6 +31,7 @@ const MCP_ACTION_PLAN_WRITABLE_TOOLS = new Set([
   'create_project_checkpoint',
   'restore_project_checkpoint',
   'set_in_out_range',
+  'import_stock_media',
   'import_asset_from_path',
   'relink_asset',
   'set_clip_style',
@@ -6258,6 +6259,50 @@ function createToolDefinitions() {
       },
     },
     {
+      name: 'search_stock_media',
+      description: 'Search Pexels photos or videos using the API key saved in Velorn Settings. Read-only. Returns result IDs, thumbnails, creator/source metadata, and opens the same results in the visible Stock tab by default. Use import_stock_media with previewOnly before downloading selected results.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Pexels search query, for example "ocean drone shots".' },
+          mediaType: { type: 'string', enum: ['photos', 'videos'], description: 'Search photos or videos. Defaults to photos for MCP searches.' },
+          page: { type: 'integer', description: 'Pexels results page. Defaults to 1.' },
+          perPage: { type: 'integer', description: 'Results to return per page, 1-80. Defaults to 20.' },
+          orientation: { type: 'string', enum: ['landscape', 'portrait', 'square'], description: 'Optional Pexels orientation filter.' },
+          openStockTab: { type: 'boolean', description: 'Open/populate Velorn\'s visible Stock tab with these results. Defaults to true.' },
+        },
+        required: ['query'],
+      },
+    },
+    {
+      name: 'import_stock_media',
+      description: 'Preview or bulk-import Pexels search results into the active Velorn project. Re-runs the Pexels search, validates optional result IDs, skips media already imported from Pexels by default, saves provenance, and can organize results into a Stock/Pexels/query folder. Defaults to previewOnly; applying downloads project-owned media files and may take time.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'The same Pexels query used for search_stock_media.' },
+          mediaType: { type: 'string', enum: ['photos', 'videos'], description: 'Import photos or videos. Defaults to photos.' },
+          resultIds: {
+            type: 'array',
+            items: { oneOf: [{ type: 'string' }, { type: 'integer' }] },
+            description: 'Optional exact Pexels result IDs from search_stock_media. Their order controls import order. Maximum 20.',
+          },
+          count: { type: 'integer', description: 'When resultIds is omitted, import the first N non-duplicate results. Defaults to 10, maximum 20.' },
+          page: { type: 'integer', description: 'Pexels results page matching search_stock_media. Defaults to 1.' },
+          perPage: { type: 'integer', description: 'Search page size, 1-80. Keep this consistent with search_stock_media when using resultIds.' },
+          orientation: { type: 'string', enum: ['landscape', 'portrait', 'square'], description: 'Optional orientation filter matching search_stock_media.' },
+          folderId: { type: 'string', description: 'Optional existing Velorn asset-folder ID.' },
+          folderPath: { oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }], description: 'Optional folder path to create/reuse. Defaults to Stock/Pexels/<query>.' },
+          organizeInFolder: { type: 'boolean', description: 'Set false to import into the project asset root when folderId/folderPath are omitted. Defaults to true.' },
+          skipExisting: { type: 'boolean', description: 'Skip Pexels IDs already present in the project. Defaults to true.' },
+          stopOnError: { type: 'boolean', description: 'Stop after the first failed download/import. Defaults to false so remaining approved items can continue.' },
+          openStockTab: { type: 'boolean', description: 'Open/populate the visible Stock tab with the matching results. Defaults to true.' },
+          previewOnly: { type: 'boolean', description: 'When true, revalidates and returns the exact import/folder plan without downloading files. Defaults to true.' },
+        },
+        required: ['query'],
+      },
+    },
+    {
       name: 'get_ai_review_passes',
       description: 'Return practical AI review recipes for Velorn MCP clients: timeline health, visible-shot review, hero presence checks, marker cleanup, disabled clip labeling, clip enable/disable previews, delivery checks, and current-frame questions.',
       inputSchema: {
@@ -10771,6 +10816,10 @@ class ComfyStudioMcpServer {
           assets: assets.slice(0, limit),
         })
       }
+      case 'search_stock_media':
+        return this.runRendererActionTool('search_stock_media', args, { bridgeName: 'MCP stock search bridge', suggestedTool: 'search_stock_media' })
+      case 'import_stock_media':
+        return this.runRendererActionTool('import_stock_media', args, { bridgeName: 'MCP stock import bridge', suggestedTool: 'import_stock_media', defaultPreviewOnly: true })
       case 'get_ai_review_passes':
         return textResult(buildAiReviewPasses(snapshot))
       case 'get_mcp_recipes':

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "velorn",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "velorn",
-      "version": "0.3.28",
+      "version": "0.3.29",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@xyflow/react": "^12.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "velorn",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "AI-native video editing built around real creative timelines, generative workflows, and local agent control.",
   "main": "electron/main.js",
   "scripts": {
@@ -24,8 +24,10 @@
     "test:music-visual-style": "node --experimental-default-type=module --test ./src/utils/musicVisualStyle.test.js",
     "test:dirty-tracker": "node --experimental-default-type=module --test ./src/services/projectDirtyTracker.test.js",
     "test:premiere-xml": "node --experimental-default-type=module --test ./src/services/premiereXmlExporter.test.js",
+    "test:pexels-stock": "node --test ./src/services/pexelsStock.test.mjs",
     "test:png-sequence-export": "node --test ./src/services/pngSequenceExport.test.mjs",
     "test:qwen3-tts-workflow": "node --test --test-isolation=none ./tests/qwen3TtsWorkflowCompatibility.test.mjs",
+    "test:transition-clip-moves": "node ./src/utils/transitionClipMoves.test.mjs",
     "test:export-frame-source": "node --experimental-default-type=module --test ./src/services/exportFrameSource.test.js",
     "test:export-source-preparation": "node --test ./tests/exportSourcePreparation.test.js",
     "test:audio-mix-eligibility": "node --test ./tests/audioMixEligibility.test.mjs",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ import { startComfyAutoImport } from './services/comfyAutoImport'
 import { startMcpSnapshotPublisher } from './services/mcpSnapshot'
 import { MCP_ACTION_BRIDGE_VERSION, startMcpActionBridge } from './services/mcpActions'
 import { attachProjectDirtyWatchers, isProjectDirty } from './services/projectDirtyTracker'
+import { VELORN_OPEN_STOCK_EVENT } from './services/pexelsStock'
 
 // Tab workspaces load on first visit instead of shipping in the startup
 // bundle. This keeps launch parse time down; GenerateWorkspace alone carries
@@ -341,6 +342,12 @@ function App() {
     const handler = () => setMainTab('generate')
     window.addEventListener('comfystudio-open-generate-tab', handler)
     return () => window.removeEventListener('comfystudio-open-generate-tab', handler)
+  }, [])
+
+  useEffect(() => {
+    const handler = () => setMainTab('stock')
+    window.addEventListener(VELORN_OPEN_STOCK_EVENT, handler)
+    return () => window.removeEventListener(VELORN_OPEN_STOCK_EVENT, handler)
   }, [])
 
   // Reveal-in-assets (timeline clip menu / Shift+F): make sure the Assets

--- a/src/components/StockPanel.jsx
+++ b/src/components/StockPanel.jsx
@@ -6,37 +6,22 @@ import { importAsset, isElectron } from '../services/fileSystem'
 import { enqueuePlaybackTranscode } from '../services/playbackCache'
 import { enqueueProxyTranscode, isProxyPlaybackEnabled } from '../services/proxyCache'
 import { getPexelsApiKey } from '../services/pexelsSettings'
+import {
+  PEXELS_DEFAULT_PER_PAGE,
+  VELORN_OPEN_STOCK_EVENT,
+  buildPexelsAssetRecord,
+  downloadPexelsMediaItem,
+  getBestPexelsVideoFile,
+  loadDefaultPexelsMedia,
+  readPexelsStockPanelState,
+  searchPexelsMedia,
+  writePexelsStockPanelState,
+} from '../services/pexelsStock'
 
-const PEXELS_PHOTOS_URL = 'https://api.pexels.com/v1/search'
-const PEXELS_VIDEOS_URL = 'https://api.pexels.com/videos/search'
-const PEXELS_CURATED_PHOTOS_URL = 'https://api.pexels.com/v1/curated'
-const PEXELS_POPULAR_VIDEOS_URL = 'https://api.pexels.com/videos/popular'
-const PER_PAGE = 20
-const STOCK_PANEL_STORAGE_KEY = 'comfystudio-stock-panel-state-v1'
-
-function loadPersistedStockState() {
-  try {
-    const raw = localStorage.getItem(STOCK_PANEL_STORAGE_KEY)
-    if (!raw) return null
-    return JSON.parse(raw)
-  } catch (error) {
-    console.error('Failed to load Stock panel state:', error)
-    return null
-  }
-}
-
-/** Pick best video file for playback or download (prefer HD mp4). */
-function getBestVideoUrl(item) {
-  const files = item?.video_files || []
-  const best = files.find(f => f.quality === 'hd' && f.file_type === 'video/mp4')
-    || files.find(f => f.quality === 'hd')
-    || files.find(f => f.file_type === 'video/mp4')
-    || files[0]
-  return best?.link || null
-}
+const PER_PAGE = PEXELS_DEFAULT_PER_PAGE
 
 function StockPanel() {
-  const persistedState = loadPersistedStockState()
+  const persistedState = readPexelsStockPanelState()
   const [apiKey, setApiKey] = useState(null)
   const [searchQuery, setSearchQuery] = useState(persistedState?.searchQuery || '')
   const [mediaType, setMediaType] = useState(
@@ -61,19 +46,35 @@ function StockPanel() {
 
   // Persist panel state so tab switches keep current stock context/results.
   useEffect(() => {
-    try {
-      localStorage.setItem(STOCK_PANEL_STORAGE_KEY, JSON.stringify({
-        searchQuery,
-        mediaType,
-        results,
-        page,
-        totalResults,
-        isDefaultContent,
-      }))
-    } catch (error) {
-      console.error('Failed to save Stock panel state:', error)
-    }
+    writePexelsStockPanelState({
+      searchQuery,
+      mediaType,
+      results,
+      page,
+      totalResults,
+      isDefaultContent,
+    })
   }, [searchQuery, mediaType, results, page, totalResults, isDefaultContent])
+
+  // MCP searches can open an already-mounted Stock tab. A newly-mounted tab
+  // hydrates the same payload from localStorage above; this event handles the
+  // case where the tab was already visible when the search completed.
+  useEffect(() => {
+    const handler = (event) => {
+      const state = event?.detail?.stockState
+      if (!state || !Array.isArray(state.results)) return
+      setSearchQuery(String(state.searchQuery || ''))
+      setMediaType(state.mediaType === 'photos' ? 'photos' : 'videos')
+      setResults(state.results)
+      setPage(Math.max(1, Number(state.page) || 1))
+      setTotalResults(Math.max(0, Number(state.totalResults) || 0))
+      setIsDefaultContent(Boolean(state.isDefaultContent))
+      setError(null)
+      setPreviewVideo(null)
+    }
+    window.addEventListener(VELORN_OPEN_STOCK_EVENT, handler)
+    return () => window.removeEventListener(VELORN_OPEN_STOCK_EVENT, handler)
+  }, [])
 
   // Fetch trending/popular content when no search query (first visit or cleared search)
   const loadDefaultContent = useCallback(async (pageNum = 1) => {
@@ -81,23 +82,10 @@ function StockPanel() {
     setError(null)
     setLoading(true)
     try {
-      const url = mediaType === 'videos'
-        ? `${PEXELS_POPULAR_VIDEOS_URL}?per_page=${PER_PAGE}&page=${pageNum}`
-        : `${PEXELS_CURATED_PHOTOS_URL}?per_page=${PER_PAGE}&page=${pageNum}`
-      const res = await fetch(url, { headers: { Authorization: apiKey } })
-      if (!res.ok) {
-        if (res.status === 401) throw new Error('Invalid Pexels API key.')
-        throw new Error(`Request failed: ${res.status}`)
-      }
-      const data = await res.json()
-      if (mediaType === 'videos') {
-        setResults(data.videos || [])
-        setTotalResults(data.total_results || 0)
-      } else {
-        setResults(data.photos || [])
-        setTotalResults(data.total_results || 0)
-      }
-      setPage(pageNum)
+      const response = await loadDefaultPexelsMedia({ apiKey, mediaType, page: pageNum, perPage: PER_PAGE })
+      setResults(response.items)
+      setTotalResults(response.totalResults)
+      setPage(response.page)
       setIsDefaultContent(true)
     } catch (err) {
       setError(err.message || 'Failed to load content')
@@ -128,26 +116,10 @@ function StockPanel() {
     setIsDefaultContent(false)
     setLoading(true)
     try {
-      const url = mediaType === 'videos'
-        ? `${PEXELS_VIDEOS_URL}?query=${encodeURIComponent(query)}&per_page=${PER_PAGE}&page=${pageNum}`
-        : `${PEXELS_PHOTOS_URL}?query=${encodeURIComponent(query)}&per_page=${PER_PAGE}&page=${pageNum}`
-      const res = await fetch(url, {
-        headers: { Authorization: apiKey },
-      })
-      if (!res.ok) {
-        const errText = await res.text()
-        if (res.status === 401) throw new Error('Invalid Pexels API key.')
-        throw new Error(errText || `Request failed: ${res.status}`)
-      }
-      const data = await res.json()
-      if (mediaType === 'videos') {
-        setResults(data.videos || [])
-        setTotalResults(data.total_results || 0)
-      } else {
-        setResults(data.photos || [])
-        setTotalResults(data.total_results || 0)
-      }
-      setPage(pageNum)
+      const response = await searchPexelsMedia({ apiKey, query, mediaType, page: pageNum, perPage: PER_PAGE })
+      setResults(response.items)
+      setTotalResults(response.totalResults)
+      setPage(response.page)
     } catch (err) {
       setError(err.message || 'Search failed')
       setResults([])
@@ -164,51 +136,21 @@ function StockPanel() {
     setAddingId(item.id)
     setError(null)
     try {
-      if (mediaType === 'photos') {
-        const url = item.src?.original || item.src?.large
-        if (!url) throw new Error('No image URL')
-        const res = await fetch(url)
-        if (!res.ok) throw new Error('Failed to download image')
-        const blob = await res.blob()
-        const ext = blob.type === 'image/png' ? 'png' : 'jpg'
-        const file = new File([blob], `pexels_${item.id}.${ext}`, { type: blob.type })
-        const assetInfo = await importAsset(currentProjectHandle, file, 'images')
-        const blobUrl = URL.createObjectURL(blob)
-        addAsset({
-          ...assetInfo,
-          name: assetInfo.name || `Pexels_${item.id}`,
-          type: 'image',
-          url: blobUrl,
-          folderId: null,
-          isImported: true,
-        })
-      } else {
-        // Pick best video file (prefer hd, then first mp4)
-        const videoUrl = getBestVideoUrl(item)
-        if (!videoUrl) throw new Error('No video download URL')
-        const res = await fetch(videoUrl)
-        if (!res.ok) throw new Error('Failed to download video')
-        const blob = await res.blob()
-        const file = new File([blob], `pexels_${item.id}.mp4`, { type: 'video/mp4' })
-        const assetInfo = await importAsset(currentProjectHandle, file, 'video')
-        const blobUrl = URL.createObjectURL(blob)
-        const best = item.video_files?.find(f => f.quality === 'hd' && f.file_type === 'video/mp4')
-          || item.video_files?.find(f => f.quality === 'hd')
-          || item.video_files?.[0]
-        const newAsset = addAsset({
-          ...assetInfo,
-          name: assetInfo.name || `Pexels_${item.id}`,
-          type: 'video',
-          url: blobUrl,
-          folderId: null,
-          isImported: true,
-          settings: { duration: item.duration, fps: best?.fps },
-        })
-        if (isElectron() && currentProjectHandle && newAsset?.absolutePath) {
-          enqueuePlaybackTranscode(currentProjectHandle, newAsset.id, newAsset.absolutePath).catch(() => {})
-          if (isProxyPlaybackEnabled()) {
-            enqueueProxyTranscode(currentProjectHandle, newAsset.id, newAsset.absolutePath).catch(() => {})
-          }
+      const downloaded = await downloadPexelsMediaItem({ item, mediaType })
+      const assetInfo = await importAsset(currentProjectHandle, downloaded.file, downloaded.spec.category)
+      const blobUrl = URL.createObjectURL(downloaded.blob)
+      const newAsset = addAsset(buildPexelsAssetRecord({
+        item,
+        mediaType,
+        query: searchQuery,
+        imported: assetInfo,
+        blobUrl,
+        sourceTool: 'stock_panel',
+      }))
+      if (downloaded.spec.assetType === 'video' && isElectron() && currentProjectHandle && newAsset?.absolutePath) {
+        enqueuePlaybackTranscode(currentProjectHandle, newAsset.id, newAsset.absolutePath).catch(() => {})
+        if (isProxyPlaybackEnabled()) {
+          enqueueProxyTranscode(currentProjectHandle, newAsset.id, newAsset.absolutePath).catch(() => {})
         }
       }
     } catch (err) {
@@ -464,7 +406,7 @@ function StockPanel() {
             </button>
             <div className="flex-1 min-h-0 flex items-center justify-center p-4">
               <video
-                src={getBestVideoUrl(previewVideo)}
+                src={getBestPexelsVideoFile(previewVideo)?.link || ''}
                 controls
                 className="max-w-full max-h-[70vh] w-full rounded"
                 preload="metadata"

--- a/src/services/mcpActions.js
+++ b/src/services/mcpActions.js
@@ -32,11 +32,29 @@ import {
   startWorkflowInstall,
 } from './workflowInstallJobs'
 import { saveLocalComfyConnectionPort } from './localComfyConnection'
-import { getAbsoluteFileUrl, importAsset, writeGeneratedOverlayToProject } from './fileSystem'
+import { getAbsoluteFileUrl, importAsset, isElectron, writeGeneratedOverlayToProject } from './fileSystem'
 import { canImportImageSequences, importImageSequenceAsAsset } from './imageSequenceImport'
 import { detectImageSequences, parseSequenceFileName } from '../utils/imageSequenceDetection'
 import buildFcpXml from './fcpxmlExporter'
 import buildPremiereXml from './premiereXmlExporter'
+import { enqueuePlaybackTranscode } from './playbackCache'
+import { enqueueProxyTranscode, isProxyPlaybackEnabled } from './proxyCache'
+import { getPexelsApiKey } from './pexelsSettings'
+import {
+  PEXELS_DEFAULT_PER_PAGE,
+  PEXELS_MAX_MCP_IMPORT_ITEMS,
+  VELORN_OPEN_STOCK_EVENT,
+  buildDefaultPexelsFolderPath,
+  buildPexelsAssetRecord,
+  downloadPexelsMediaItem,
+  getExistingPexelsIds,
+  normalizePexelsMediaType,
+  normalizePexelsQuery,
+  searchPexelsMedia,
+  selectPexelsImportItems,
+  summarizePexelsMediaItem,
+  writePexelsStockPanelState,
+} from './pexelsStock'
 import {
   handleTranscribeCaptions,
   handleGetCaptionStatus,
@@ -44,7 +62,7 @@ import {
   handleGenerateCaptions,
 } from './mcpCaptions'
 
-export const MCP_ACTION_BRIDGE_VERSION = 5
+export const MCP_ACTION_BRIDGE_VERSION = 6
 
 const MCP_PROJECT_CHECKPOINTS = new Map()
 const MCP_PROJECT_CHECKPOINT_LIMIT = 20
@@ -4874,6 +4892,7 @@ async function handleMoveUnusedAssetsToFolder(payload = {}) {
 }
 
 function summarizeAsset(asset) {
+  const stockSource = asset.stockSource || asset.settings?.stockSource || null
   return {
     id: asset.id,
     name: asset.name || asset.id,
@@ -4892,6 +4911,16 @@ function summarizeAsset(asset) {
     audioEnabled: typeof asset.audioEnabled === 'boolean' ? asset.audioEnabled : null,
     generationStatus: asset.generationStatus || asset.status || 'none',
     createdAt: asset.createdAt || asset.imported || null,
+    ...(stockSource ? {
+      stockSource: {
+        provider: stockSource.provider || '',
+        id: stockSource.id ?? null,
+        mediaType: stockSource.mediaType || '',
+        query: stockSource.query || '',
+        pageUrl: stockSource.pageUrl || '',
+        photographer: stockSource.photographer || '',
+      },
+    } : {}),
   }
 }
 
@@ -7753,6 +7782,237 @@ async function handleRestoreProjectCheckpoint(payload = {}) {
   }
 }
 
+function publishPexelsSearchToStockTab(searchResult, { openStockTab = true } = {}) {
+  const stockState = {
+    searchQuery: searchResult.query,
+    mediaType: searchResult.mediaType,
+    results: searchResult.items,
+    page: searchResult.page,
+    totalResults: searchResult.totalResults,
+    isDefaultContent: false,
+  }
+  writePexelsStockPanelState(stockState)
+  if (openStockTab && typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(VELORN_OPEN_STOCK_EVENT, { detail: { stockState } }))
+  }
+  return stockState
+}
+
+async function getPexelsKeyForMcp() {
+  const apiKey = String(await getPexelsApiKey() || '').trim()
+  if (!apiKey) {
+    throw new Error('Add a Pexels API key in Velorn Settings > Stock (Pexels), then try again.')
+  }
+  return apiKey
+}
+
+async function runPexelsMcpSearch(payload = {}, { minimumPerPage = 1 } = {}) {
+  const query = normalizePexelsQuery(payload.query || payload.search || payload.searchQuery)
+  if (!query) throw new Error('Provide a Pexels search query.')
+  const mediaType = normalizePexelsMediaType(payload.mediaType || payload.type || payload.kind, 'photos')
+  const requestedPerPage = Number(payload.perPage ?? payload.per_page ?? payload.limit)
+  const perPage = Math.max(
+    minimumPerPage,
+    Number.isFinite(requestedPerPage) && requestedPerPage > 0 ? Math.round(requestedPerPage) : PEXELS_DEFAULT_PER_PAGE,
+  )
+  return searchPexelsMedia({
+    apiKey: await getPexelsKeyForMcp(),
+    query,
+    mediaType,
+    page: payload.page,
+    perPage,
+    orientation: payload.orientation,
+  })
+}
+
+async function handleSearchStockMedia(payload = {}) {
+  const searchResult = await runPexelsMcpSearch(payload)
+  const stockTabOpened = payload.openStockTab !== false
+  publishPexelsSearchToStockTab(searchResult, { openStockTab: stockTabOpened })
+  return {
+    success: true,
+    action: 'search_stock_media',
+    provider: 'pexels',
+    query: searchResult.query,
+    mediaType: searchResult.mediaType,
+    orientation: searchResult.orientation,
+    page: searchResult.page,
+    perPage: searchResult.perPage,
+    totalResults: searchResult.totalResults,
+    returnedCount: searchResult.results.length,
+    results: searchResult.results,
+    stockTabOpened,
+    message: `Found ${searchResult.results.length} Pexels ${searchResult.mediaType} result${searchResult.results.length === 1 ? '' : 's'} for "${searchResult.query}"${stockTabOpened ? ' and opened them in the Stock tab' : ''}.`,
+  }
+}
+
+function resolveStockImportFolder(payload, query) {
+  const explicitFolderId = String(payload.folderId || '').trim()
+  if (explicitFolderId) {
+    const folder = (useAssetsStore.getState().folders || []).find((candidate) => candidate?.id === explicitFolderId)
+    if (!folder) throw new Error(`Asset folder ${explicitFolderId} was not found.`)
+    return {
+      folderId: explicitFolderId,
+      folderPath: getAssetFolderPathSegments(useAssetsStore.getState().folders || [], explicitFolderId),
+      folderPlan: null,
+    }
+  }
+
+  if (payload.organizeInFolder === false) {
+    return { folderId: null, folderPath: [], folderPlan: null }
+  }
+
+  const requestedPath = payload.folderPath || payload.targetFolderPath || payload.folderName
+  const folderPath = requestedPath || buildDefaultPexelsFolderPath(query)
+  const folderPlan = buildCreateAssetFolderPlan({ path: folderPath, previewOnly: true })
+  return {
+    folderId: null,
+    folderPath: folderPlan.path,
+    folderPlan,
+  }
+}
+
+async function buildStockMediaImportPlan(payload = {}) {
+  if (!useProjectStore.getState().currentProjectHandle) {
+    throw new Error('Open a saved Velorn project before importing stock media.')
+  }
+
+  const resultIds = normalizeStringArray(payload.resultIds || payload.pexelsIds || payload.ids)
+  if (resultIds.length > PEXELS_MAX_MCP_IMPORT_ITEMS) {
+    throw new Error(`Import at most ${PEXELS_MAX_MCP_IMPORT_ITEMS} Pexels results per call.`)
+  }
+  const requestedCount = Number(payload.count ?? payload.limit ?? (resultIds.length || 10))
+  const count = Math.max(1, Math.min(PEXELS_MAX_MCP_IMPORT_ITEMS, Number.isFinite(requestedCount) ? Math.round(requestedCount) : 10))
+  const searchResult = await runPexelsMcpSearch(payload, {
+    minimumPerPage: Math.max(PEXELS_DEFAULT_PER_PAGE, count, resultIds.length),
+  })
+  const existingIds = getExistingPexelsIds(useAssetsStore.getState().assets || [])
+  const selection = selectPexelsImportItems({
+    items: searchResult.items,
+    resultIds,
+    count,
+    existingIds,
+    skipExisting: payload.skipExisting !== false,
+  })
+  if (selection.missingIds.length > 0) {
+    throw new Error(`Pexels result IDs were not found on page ${searchResult.page}: ${selection.missingIds.join(', ')}. Search again or pass the matching page/perPage values.`)
+  }
+  const target = resolveStockImportFolder(payload, searchResult.query)
+  return {
+    action: 'import_stock_media',
+    provider: 'pexels',
+    query: searchResult.query,
+    mediaType: searchResult.mediaType,
+    orientation: searchResult.orientation,
+    page: searchResult.page,
+    perPage: searchResult.perPage,
+    totalResults: searchResult.totalResults,
+    requestedCount: count,
+    requestedIds: selection.requestedIds,
+    skipExisting: payload.skipExisting !== false,
+    candidates: selection.candidates,
+    candidateResults: selection.candidates.map((item) => summarizePexelsMediaItem(item, searchResult.mediaType)),
+    duplicateResults: selection.duplicateItems.map((item) => summarizePexelsMediaItem(item, searchResult.mediaType)),
+    targetFolderId: target.folderId,
+    targetFolderPath: target.folderPath,
+    folderPlan: target.folderPlan,
+    openStockTab: payload.openStockTab !== false,
+    searchResult,
+  }
+}
+
+async function handleImportStockMedia(payload = {}) {
+  const plan = await buildStockMediaImportPlan(payload)
+  publishPexelsSearchToStockTab(plan.searchResult, { openStockTab: plan.openStockTab })
+
+  if (payload.previewOnly !== false) {
+    return {
+      previewOnly: true,
+      action: 'import_stock_media',
+      message: `Pexels import plan only. ${plan.candidateResults.length} item${plan.candidateResults.length === 1 ? '' : 's'} would be downloaded; ${plan.duplicateResults.length} existing item${plan.duplicateResults.length === 1 ? '' : 's'} would be skipped.`,
+      provider: plan.provider,
+      query: plan.query,
+      mediaType: plan.mediaType,
+      page: plan.page,
+      perPage: plan.perPage,
+      totalResults: plan.totalResults,
+      requestedCount: plan.requestedCount,
+      requestedIds: plan.requestedIds,
+      candidates: plan.candidateResults,
+      skippedExisting: plan.duplicateResults,
+      targetFolderId: plan.targetFolderId,
+      targetFolderPath: plan.targetFolderPath,
+      folderPlan: plan.folderPlan,
+      stockTabOpened: plan.openStockTab,
+    }
+  }
+
+  let folderId = plan.targetFolderId
+  if (!folderId && plan.targetFolderPath.length > 0) {
+    folderId = await resolveMcpFolderIdForImportedAsset({ folderPath: plan.targetFolderPath })
+  }
+
+  const projectHandle = useProjectStore.getState().currentProjectHandle
+  const importedAssets = []
+  const failures = []
+  for (const item of plan.candidates) {
+    try {
+      const downloaded = await downloadPexelsMediaItem({ item, mediaType: plan.mediaType })
+      const imported = await importAsset(projectHandle, downloaded.file, downloaded.spec.category)
+      const blobUrl = typeof globalThis.URL?.createObjectURL === 'function'
+        ? globalThis.URL.createObjectURL(downloaded.blob)
+        : imported.url
+      const asset = useAssetsStore.getState().addAsset(buildPexelsAssetRecord({
+        item,
+        mediaType: plan.mediaType,
+        query: plan.query,
+        imported,
+        blobUrl,
+        folderId,
+        sourceTool: 'import_stock_media',
+      }))
+      importedAssets.push(asset)
+
+      if (downloaded.spec.assetType === 'video' && isElectron() && projectHandle && asset?.absolutePath) {
+        enqueuePlaybackTranscode(projectHandle, asset.id, asset.absolutePath).catch(() => {})
+        if (isProxyPlaybackEnabled()) {
+          enqueueProxyTranscode(projectHandle, asset.id, asset.absolutePath).catch(() => {})
+        }
+      }
+    } catch (error) {
+      failures.push({
+        id: String(item?.id ?? ''),
+        error: error?.message || String(error),
+      })
+      if (payload.stopOnError === true) break
+    }
+  }
+
+  if (importedAssets.length === 0 && failures.length > 0) {
+    throw new Error(`No Pexels media was imported. ${failures.map((failure) => `${failure.id}: ${failure.error}`).join('; ')}`)
+  }
+  const savedProject = importedAssets.length > 0 && typeof useProjectStore.getState().saveProject === 'function'
+    ? await useProjectStore.getState().saveProject()
+    : null
+  return {
+    success: failures.length === 0,
+    partial: failures.length > 0,
+    action: 'import_stock_media',
+    message: `Imported ${importedAssets.length} Pexels ${plan.mediaType} item${importedAssets.length === 1 ? '' : 's'}${plan.duplicateResults.length > 0 ? `; skipped ${plan.duplicateResults.length} already in the project` : ''}${failures.length > 0 ? `; ${failures.length} failed` : ''}.`,
+    provider: plan.provider,
+    query: plan.query,
+    mediaType: plan.mediaType,
+    folderId,
+    folderPath: plan.targetFolderPath,
+    importedCount: importedAssets.length,
+    importedAssets: importedAssets.map(summarizeAsset),
+    skippedExisting: plan.duplicateResults,
+    failures,
+    savedProject: Boolean(savedProject),
+    stockTabOpened: plan.openStockTab,
+  }
+}
+
 async function resolveMcpFolderIdForImportedAsset(payload = {}) {
   const folderId = String(payload.folderId || '').trim()
   if (folderId) {
@@ -8441,6 +8701,10 @@ async function handleMcpAction(request = {}) {
       return handleCreateProjectCheckpoint(request.payload || {})
     case 'restore_project_checkpoint':
       return handleRestoreProjectCheckpoint(request.payload || {})
+    case 'search_stock_media':
+      return handleSearchStockMedia(request.payload || {})
+    case 'import_stock_media':
+      return handleImportStockMedia(request.payload || {})
     case 'import_asset_from_path':
       return handleImportAssetFromPath(request.payload || {})
     case 'relink_asset':

--- a/src/services/pexelsStock.js
+++ b/src/services/pexelsStock.js
@@ -1,0 +1,338 @@
+const PEXELS_PHOTOS_SEARCH_URL = 'https://api.pexels.com/v1/search'
+const PEXELS_VIDEOS_SEARCH_URL = 'https://api.pexels.com/videos/search'
+const PEXELS_CURATED_PHOTOS_URL = 'https://api.pexels.com/v1/curated'
+const PEXELS_POPULAR_VIDEOS_URL = 'https://api.pexels.com/videos/popular'
+
+export const PEXELS_STOCK_PANEL_STORAGE_KEY = 'comfystudio-stock-panel-state-v1'
+export const PEXELS_DEFAULT_PER_PAGE = 20
+export const PEXELS_MAX_PER_PAGE = 80
+export const PEXELS_MAX_MCP_IMPORT_ITEMS = 20
+export const VELORN_OPEN_STOCK_EVENT = 'velorn-open-stock-tab'
+
+function clampInteger(value, fallback, min, max) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return fallback
+  return Math.min(max, Math.max(min, Math.round(numeric)))
+}
+
+export function normalizePexelsQuery(value) {
+  return String(value || '').trim().replace(/\s+/g, ' ').slice(0, 200)
+}
+
+export function normalizePexelsMediaType(value, fallback = 'videos') {
+  const normalized = String(value || '').trim().toLowerCase()
+  if (['photo', 'photos', 'image', 'images', 'still', 'stills'].includes(normalized)) return 'photos'
+  if (['video', 'videos', 'footage', 'clip', 'clips'].includes(normalized)) return 'videos'
+  return fallback === 'photos' ? 'photos' : 'videos'
+}
+
+export function normalizePexelsOrientation(value) {
+  const normalized = String(value || '').trim().toLowerCase()
+  return ['landscape', 'portrait', 'square'].includes(normalized) ? normalized : ''
+}
+
+export function getBestPexelsVideoFile(item) {
+  const files = Array.isArray(item?.video_files) ? item.video_files : []
+  return files.find((file) => file?.quality === 'hd' && file?.file_type === 'video/mp4')
+    || files.find((file) => file?.quality === 'hd')
+    || files.find((file) => file?.file_type === 'video/mp4')
+    || files[0]
+    || null
+}
+
+export function getPexelsMediaDownloadSpec(item, mediaType) {
+  const normalizedType = normalizePexelsMediaType(mediaType)
+  const id = String(item?.id ?? '').trim()
+  if (!id) throw new Error('Pexels result is missing an ID.')
+
+  if (normalizedType === 'photos') {
+    const url = item?.src?.original || item?.src?.large2x || item?.src?.large || ''
+    if (!url) throw new Error(`Pexels photo ${id} has no downloadable image URL.`)
+    return {
+      id,
+      url,
+      fileName: `pexels_${id}.jpg`,
+      category: 'images',
+      assetType: 'image',
+      mimeType: 'image/jpeg',
+      fps: null,
+      duration: null,
+    }
+  }
+
+  const file = getBestPexelsVideoFile(item)
+  if (!file?.link) throw new Error(`Pexels video ${id} has no downloadable video URL.`)
+  return {
+    id,
+    url: file.link,
+    fileName: `pexels_${id}.mp4`,
+    category: 'video',
+    assetType: 'video',
+    mimeType: file.file_type || 'video/mp4',
+    fps: Number(file.fps) || null,
+    duration: Number(item?.duration) || null,
+  }
+}
+
+export function summarizePexelsMediaItem(item, mediaType) {
+  const normalizedType = normalizePexelsMediaType(mediaType)
+  const spec = getPexelsMediaDownloadSpec(item, normalizedType)
+  const isPhoto = normalizedType === 'photos'
+  const photographer = String(item?.photographer || item?.user?.name || '').trim()
+  const photographerUrl = String(item?.photographer_url || item?.user?.url || '').trim()
+  const pageUrl = String(item?.url || '').trim()
+  const thumbnailUrl = isPhoto
+    ? String(item?.src?.medium || item?.src?.large || item?.src?.original || '')
+    : String(item?.image || item?.video_pictures?.[0]?.picture || '')
+
+  return {
+    id: spec.id,
+    provider: 'pexels',
+    mediaType: isPhoto ? 'photo' : 'video',
+    name: String(item?.alt || '').trim() || `Pexels ${isPhoto ? 'photo' : 'video'} ${spec.id}`,
+    width: Number(item?.width) || null,
+    height: Number(item?.height) || null,
+    duration: spec.duration,
+    fps: spec.fps,
+    photographer,
+    photographerUrl,
+    pageUrl,
+    thumbnailUrl,
+  }
+}
+
+function buildPexelsUrl(baseUrl, params = {}) {
+  const url = new URL(baseUrl)
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === null || typeof value === 'undefined' || value === '') return
+    url.searchParams.set(key, String(value))
+  })
+  return url.toString()
+}
+
+async function parsePexelsResponse(response) {
+  if (response.ok) return response.json()
+  if (response.status === 401) throw new Error('Invalid Pexels API key.')
+  let detail = ''
+  try {
+    detail = String(await response.text()).trim()
+  } catch {
+    // Best effort only; the status still gives a useful error.
+  }
+  throw new Error(detail || `Pexels request failed with status ${response.status}.`)
+}
+
+export async function searchPexelsMedia({
+  apiKey,
+  query,
+  mediaType = 'videos',
+  page = 1,
+  perPage = PEXELS_DEFAULT_PER_PAGE,
+  orientation = '',
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const key = String(apiKey || '').trim()
+  if (!key) throw new Error('Add your Pexels API key in Velorn Settings before searching stock media.')
+  const normalizedQuery = normalizePexelsQuery(query)
+  if (!normalizedQuery) throw new Error('Provide a Pexels search query.')
+  if (typeof fetchImpl !== 'function') throw new Error('Network requests are not available in this Velorn session.')
+
+  const normalizedType = normalizePexelsMediaType(mediaType)
+  const normalizedPage = clampInteger(page, 1, 1, 10_000)
+  const normalizedPerPage = clampInteger(perPage, PEXELS_DEFAULT_PER_PAGE, 1, PEXELS_MAX_PER_PAGE)
+  const normalizedOrientation = normalizePexelsOrientation(orientation)
+  const baseUrl = normalizedType === 'photos' ? PEXELS_PHOTOS_SEARCH_URL : PEXELS_VIDEOS_SEARCH_URL
+  const url = buildPexelsUrl(baseUrl, {
+    query: normalizedQuery,
+    per_page: normalizedPerPage,
+    page: normalizedPage,
+    orientation: normalizedOrientation,
+  })
+  const response = await fetchImpl(url, { headers: { Authorization: key } })
+  const data = await parsePexelsResponse(response)
+  const items = normalizedType === 'photos'
+    ? (Array.isArray(data?.photos) ? data.photos : [])
+    : (Array.isArray(data?.videos) ? data.videos : [])
+
+  return {
+    provider: 'pexels',
+    query: normalizedQuery,
+    mediaType: normalizedType,
+    orientation: normalizedOrientation || null,
+    page: clampInteger(data?.page, normalizedPage, 1, 10_000),
+    perPage: normalizedPerPage,
+    totalResults: Math.max(0, Number(data?.total_results) || 0),
+    items,
+    results: items.map((item) => summarizePexelsMediaItem(item, normalizedType)),
+  }
+}
+
+export async function loadDefaultPexelsMedia({
+  apiKey,
+  mediaType = 'videos',
+  page = 1,
+  perPage = PEXELS_DEFAULT_PER_PAGE,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  const key = String(apiKey || '').trim()
+  if (!key) throw new Error('Add your Pexels API key in Velorn Settings before browsing stock media.')
+  if (typeof fetchImpl !== 'function') throw new Error('Network requests are not available in this Velorn session.')
+
+  const normalizedType = normalizePexelsMediaType(mediaType)
+  const normalizedPage = clampInteger(page, 1, 1, 10_000)
+  const normalizedPerPage = clampInteger(perPage, PEXELS_DEFAULT_PER_PAGE, 1, PEXELS_MAX_PER_PAGE)
+  const baseUrl = normalizedType === 'photos' ? PEXELS_CURATED_PHOTOS_URL : PEXELS_POPULAR_VIDEOS_URL
+  const url = buildPexelsUrl(baseUrl, { per_page: normalizedPerPage, page: normalizedPage })
+  const response = await fetchImpl(url, { headers: { Authorization: key } })
+  const data = await parsePexelsResponse(response)
+  const items = normalizedType === 'photos'
+    ? (Array.isArray(data?.photos) ? data.photos : [])
+    : (Array.isArray(data?.videos) ? data.videos : [])
+
+  return {
+    provider: 'pexels',
+    query: '',
+    mediaType: normalizedType,
+    orientation: null,
+    page: clampInteger(data?.page, normalizedPage, 1, 10_000),
+    perPage: normalizedPerPage,
+    totalResults: Math.max(0, Number(data?.total_results) || 0),
+    items,
+    results: items.map((item) => summarizePexelsMediaItem(item, normalizedType)),
+  }
+}
+
+export async function downloadPexelsMediaItem({
+  item,
+  mediaType,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  if (typeof fetchImpl !== 'function') throw new Error('Network requests are not available in this Velorn session.')
+  const spec = getPexelsMediaDownloadSpec(item, mediaType)
+  const response = await fetchImpl(spec.url)
+  if (!response.ok) throw new Error(`Failed to download Pexels ${spec.assetType} ${spec.id} (${response.status}).`)
+  const blob = await response.blob()
+  const resolvedMimeType = blob.type || spec.mimeType
+  const extension = resolvedMimeType === 'image/png' ? 'png' : (spec.assetType === 'image' ? 'jpg' : 'mp4')
+  const fileName = `pexels_${spec.id}.${extension}`
+  const file = new File([blob], fileName, { type: resolvedMimeType })
+  return { blob, file, spec: { ...spec, fileName, mimeType: resolvedMimeType } }
+}
+
+export function buildPexelsStockSource(item, mediaType, query = '') {
+  const summary = summarizePexelsMediaItem(item, mediaType)
+  return {
+    provider: 'pexels',
+    id: summary.id,
+    mediaType: summary.mediaType,
+    query: normalizePexelsQuery(query),
+    pageUrl: summary.pageUrl,
+    photographer: summary.photographer,
+    photographerUrl: summary.photographerUrl,
+    alt: String(item?.alt || '').trim(),
+  }
+}
+
+export function buildPexelsAssetRecord({
+  item,
+  mediaType,
+  query = '',
+  imported = {},
+  blobUrl = null,
+  folderId = null,
+  sourceTool = 'stock_panel',
+} = {}) {
+  const normalizedType = normalizePexelsMediaType(mediaType)
+  const spec = getPexelsMediaDownloadSpec(item, normalizedType)
+  const stockSource = buildPexelsStockSource(item, normalizedType, query)
+  return {
+    ...imported,
+    name: imported?.name || `Pexels_${spec.id}`,
+    type: spec.assetType,
+    url: blobUrl || imported?.url || null,
+    folderId: folderId || null,
+    isImported: true,
+    sourceTool,
+    stockSource,
+    settings: {
+      ...(imported?.settings || {}),
+      ...(spec.duration ? { duration: spec.duration } : {}),
+      ...(spec.fps ? { fps: spec.fps } : {}),
+      stockSource,
+    },
+  }
+}
+
+export function getExistingPexelsIds(assets = []) {
+  const ids = new Set()
+  for (const asset of assets || []) {
+    const source = asset?.stockSource || asset?.settings?.stockSource
+    if (String(source?.provider || '').toLowerCase() === 'pexels' && source?.id !== null && typeof source?.id !== 'undefined') {
+      ids.add(String(source.id))
+      continue
+    }
+    const match = /(?:^|[\\/_-])pexels[_ -]?(\d+)(?:\.|$|[_ -])/i.exec(String(asset?.name || asset?.relativePath || asset?.absolutePath || ''))
+    if (match) ids.add(match[1])
+  }
+  return ids
+}
+
+export function selectPexelsImportItems({
+  items = [],
+  resultIds = [],
+  count = 10,
+  existingIds = new Set(),
+  skipExisting = true,
+} = {}) {
+  const cappedCount = clampInteger(count, 10, 1, PEXELS_MAX_MCP_IMPORT_ITEMS)
+  const byId = new Map((items || []).map((item) => [String(item?.id ?? ''), item]))
+  const requestedIds = Array.isArray(resultIds)
+    ? [...new Set(resultIds.map((id) => String(id ?? '').trim()).filter(Boolean))]
+    : []
+  const missingIds = requestedIds.filter((id) => !byId.has(id))
+  const ordered = requestedIds.length > 0
+    ? requestedIds.map((id) => byId.get(id)).filter(Boolean)
+    : [...(items || [])]
+  const duplicateItems = ordered.filter((item) => existingIds.has(String(item?.id ?? '')))
+  const candidates = ordered
+    .filter((item) => !skipExisting || !existingIds.has(String(item?.id ?? '')))
+    .slice(0, cappedCount)
+
+  return {
+    candidates,
+    duplicateItems,
+    missingIds,
+    requestedIds,
+    count: cappedCount,
+  }
+}
+
+export function buildDefaultPexelsFolderPath(query) {
+  const normalizedQuery = normalizePexelsQuery(query)
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80)
+  const leaf = normalizedQuery
+    ? normalizedQuery.replace(/\b[a-z]/g, (letter) => letter.toUpperCase())
+    : 'Imported Stock'
+  return ['Stock', 'Pexels', leaf]
+}
+
+export function readPexelsStockPanelState(storage = globalThis.localStorage) {
+  try {
+    const raw = storage?.getItem?.(PEXELS_STOCK_PANEL_STORAGE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+export function writePexelsStockPanelState(state, storage = globalThis.localStorage) {
+  try {
+    storage?.setItem?.(PEXELS_STOCK_PANEL_STORAGE_KEY, JSON.stringify(state || {}))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/services/pexelsStock.test.mjs
+++ b/src/services/pexelsStock.test.mjs
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildDefaultPexelsFolderPath,
+  buildPexelsAssetRecord,
+  downloadPexelsMediaItem,
+  getPexelsMediaDownloadSpec,
+  getExistingPexelsIds,
+  normalizePexelsMediaType,
+  searchPexelsMedia,
+  selectPexelsImportItems,
+} from './pexelsStock.js'
+
+const PHOTO = {
+  id: 101,
+  width: 6000,
+  height: 4000,
+  url: 'https://www.pexels.com/photo/ocean-101/',
+  photographer: 'Ocean Artist',
+  photographer_url: 'https://www.pexels.com/@ocean-artist',
+  alt: 'Aerial ocean shoreline',
+  src: {
+    original: 'https://images.pexels.com/photos/101/original.jpg',
+    medium: 'https://images.pexels.com/photos/101/medium.jpg',
+  },
+}
+
+const VIDEO = {
+  id: 202,
+  width: 1920,
+  height: 1080,
+  duration: 12,
+  url: 'https://www.pexels.com/video/ocean-202/',
+  user: { name: 'Drone Artist', url: 'https://www.pexels.com/@drone-artist' },
+  image: 'https://images.pexels.com/videos/202/poster.jpg',
+  video_files: [
+    { quality: 'sd', file_type: 'video/mp4', link: 'https://videos.pexels.com/202-sd.mp4', fps: 24 },
+    { quality: 'hd', file_type: 'video/mp4', link: 'https://videos.pexels.com/202-hd.mp4', fps: 30 },
+  ],
+}
+
+test('normalizes common stock-media type aliases', () => {
+  assert.equal(normalizePexelsMediaType('images'), 'photos')
+  assert.equal(normalizePexelsMediaType('footage'), 'videos')
+  assert.equal(normalizePexelsMediaType('', 'photos'), 'photos')
+})
+
+test('searches Pexels photos with bounded request fields and normalized results', async () => {
+  let requestedUrl = ''
+  let requestedOptions = null
+  const result = await searchPexelsMedia({
+    apiKey: 'secret-key',
+    query: '  ocean   drone shots ',
+    mediaType: 'images',
+    page: 2,
+    perPage: 500,
+    orientation: 'landscape',
+    fetchImpl: async (url, options) => {
+      requestedUrl = url
+      requestedOptions = options
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ page: 2, total_results: 900, photos: [PHOTO] }),
+      }
+    },
+  })
+
+  const url = new URL(requestedUrl)
+  assert.equal(url.pathname, '/v1/search')
+  assert.equal(url.searchParams.get('query'), 'ocean drone shots')
+  assert.equal(url.searchParams.get('per_page'), '80')
+  assert.equal(url.searchParams.get('page'), '2')
+  assert.equal(url.searchParams.get('orientation'), 'landscape')
+  assert.equal(requestedOptions.headers.Authorization, 'secret-key')
+  assert.equal(result.mediaType, 'photos')
+  assert.equal(result.results[0].id, '101')
+  assert.equal(result.results[0].photographer, 'Ocean Artist')
+  assert.equal(result.results[0].thumbnailUrl, PHOTO.src.medium)
+})
+
+test('prefers an HD MP4 for Pexels video downloads without exposing it in search results', async () => {
+  const result = await searchPexelsMedia({
+    apiKey: 'secret-key',
+    query: 'waves',
+    mediaType: 'videos',
+    fetchImpl: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ page: 1, total_results: 1, videos: [VIDEO] }),
+    }),
+  })
+
+  assert.equal(getPexelsMediaDownloadSpec(VIDEO, 'videos').url, 'https://videos.pexels.com/202-hd.mp4')
+  assert.equal('downloadUrl' in result.results[0], false)
+  assert.equal(result.results[0].fps, 30)
+  assert.equal(result.results[0].duration, 12)
+})
+
+test('downloads the selected Pexels video as an importable project file', async () => {
+  const downloaded = await downloadPexelsMediaItem({
+    item: VIDEO,
+    mediaType: 'videos',
+    fetchImpl: async (url) => {
+      assert.equal(url, 'https://videos.pexels.com/202-hd.mp4')
+      return {
+        ok: true,
+        status: 200,
+        blob: async () => new Blob(['video-bytes'], { type: 'video/mp4' }),
+      }
+    },
+  })
+
+  assert.equal(downloaded.file.name, 'pexels_202.mp4')
+  assert.equal(downloaded.file.type, 'video/mp4')
+  assert.equal(downloaded.spec.category, 'video')
+  assert.equal(downloaded.spec.duration, 12)
+  assert.equal(downloaded.spec.fps, 30)
+})
+
+test('reports invalid Pexels credentials without exposing the key', async () => {
+  await assert.rejects(
+    searchPexelsMedia({
+      apiKey: 'do-not-echo',
+      query: 'ocean',
+      fetchImpl: async () => ({ ok: false, status: 401, text: async () => 'unauthorized' }),
+    }),
+    /Invalid Pexels API key/,
+  )
+})
+
+test('selects requested IDs in order and skips existing Pexels assets', () => {
+  const items = [{ id: 1 }, { id: 2 }, { id: 3 }]
+  const selection = selectPexelsImportItems({
+    items,
+    resultIds: ['3', '2', '1'],
+    count: 3,
+    existingIds: new Set(['2']),
+    skipExisting: true,
+  })
+  assert.deepEqual(selection.candidates.map((item) => item.id), [3, 1])
+  assert.deepEqual(selection.duplicateItems.map((item) => item.id), [2])
+  assert.deepEqual(selection.missingIds, [])
+})
+
+test('recognizes both explicit provenance and legacy Pexels filenames', () => {
+  const ids = getExistingPexelsIds([
+    { stockSource: { provider: 'pexels', id: '101' } },
+    { name: 'pexels_202.mp4' },
+    { name: 'unrelated.jpg' },
+  ])
+  assert.deepEqual([...ids].sort(), ['101', '202'])
+})
+
+test('builds a portable query folder and persists Pexels provenance on assets', () => {
+  assert.deepEqual(buildDefaultPexelsFolderPath('ocean drone shots'), ['Stock', 'Pexels', 'Ocean Drone Shots'])
+  const asset = buildPexelsAssetRecord({
+    item: PHOTO,
+    mediaType: 'photos',
+    query: 'ocean drone shots',
+    imported: { name: 'pexels_101.jpg', absolutePath: '/project/images/pexels_101.jpg' },
+    blobUrl: 'blob:photo',
+    folderId: 'folder-1',
+    sourceTool: 'import_stock_media',
+  })
+  assert.equal(asset.type, 'image')
+  assert.equal(asset.folderId, 'folder-1')
+  assert.equal(asset.sourceTool, 'import_stock_media')
+  assert.equal(asset.stockSource.id, '101')
+  assert.equal(asset.stockSource.pageUrl, PHOTO.url)
+  assert.deepEqual(asset.settings.stockSource, asset.stockSource)
+})

--- a/src/stores/timelineStore.js
+++ b/src/stores/timelineStore.js
@@ -13,6 +13,7 @@ import { CLIP_COMPOSITE_MODE, normalizeClipCompositeMode } from '../utils/layerC
 import { getKeyframeTimeTolerance } from '../utils/keyframes'
 import { DEFAULT_SHAPE_MASK, normalizeShapeMask } from '../utils/shapeMask'
 import { normalizeTrackMatte } from '../utils/trackMatte'
+import { translateTransitionsForClipMoves } from '../utils/transitionClipMoves.mjs'
 import { DEFAULT_LINE_THICKNESS, DEFAULT_SHAPE_PROPERTIES, getShapeDisplayName, normalizeShapeProperties } from '../utils/shapes'
 import {
   quantizeTimeToFrame as roundToFrame,
@@ -2444,8 +2445,8 @@ export const useTimelineStore = create(
       startTime: roundToFrame(Math.max(0, u.startTime), fps),
       trackId: typeof u.trackId === 'string' ? u.trackId : undefined,
     }]))
-    set((state) => ({
-      clips: state.clips.map((clip) => {
+    set((state) => {
+      const updatedClips = state.clips.map((clip) => {
         if (!targetIds.has(clip.id)) return clip
         const nextPosition = map.get(clip.id)
         if (!nextPosition) return clip
@@ -2455,7 +2456,15 @@ export const useTimelineStore = create(
           trackId: nextPosition.trackId ?? clip.trackId,
         }, fps)
       })
-    }))
+      return {
+        clips: updatedClips,
+        transitions: translateTransitionsForClipMoves({
+          transitions: state.transitions,
+          beforeClips: state.clips,
+          afterClips: updatedClips,
+        }),
+      }
+    })
   },
 
   /**
@@ -2490,10 +2499,15 @@ export const useTimelineStore = create(
         }
         return clip
       })
+      const movedTransitions = translateTransitionsForClipMoves({
+        transitions: state.transitions,
+        beforeClips: state.clips,
+        afterClips: updatedClips,
+      })
       
       // Only resolve overlaps if explicitly requested (on drag end)
       if (!resolveOverlaps) {
-        return { clips: updatedClips }
+        return { clips: updatedClips, transitions: movedTransitions }
       }
       
       // Now resolve overlaps for each moved clip (NLE overwrite behavior)
@@ -2598,8 +2612,8 @@ export const useTimelineStore = create(
       
       // Remove transitions that are now broken (clips no longer adjacent on same track)
       let finalClips = updatedClips
-      let finalTransitions = state.transitions
-      if (state.transitions.length > 0) {
+      let finalTransitions = movedTransitions
+      if (movedTransitions.length > 0) {
         const isBroken = (t, clips) => {
           if (t.kind !== 'between') return false
           const a = clips.find(c => c.id === t.clipAId)
@@ -2611,7 +2625,7 @@ export const useTimelineStore = create(
           const j = trackClips.findIndex(c => c.id === b.id)
           return Math.abs(i - j) !== 1
         }
-        const broken = state.transitions.filter(t => isBroken(t, finalClips))
+        const broken = movedTransitions.filter(t => isBroken(t, finalClips))
         if (broken.length > 0) {
           const brokenIds = new Set(broken.map(t => t.id))
           for (const t of broken) {
@@ -2626,7 +2640,7 @@ export const useTimelineStore = create(
               return c
             })
           }
-          finalTransitions = state.transitions.filter(t => !brokenIds.has(t.id))
+          finalTransitions = movedTransitions.filter(t => !brokenIds.has(t.id))
         }
       }
       

--- a/src/utils/transitionClipMoves.mjs
+++ b/src/utils/transitionClipMoves.mjs
@@ -1,0 +1,72 @@
+const DEFAULT_MOVE_EPSILON = 1e-6
+
+const getClipStartTime = (clip) => {
+  const value = Number(clip?.startTime)
+  return Number.isFinite(value) ? value : null
+}
+
+const translateFiniteTime = (value, delta) => {
+  if (value == null) return value
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric + delta : value
+}
+
+/**
+ * Keep absolute between-transition metadata attached to a group move.
+ *
+ * A between transition moves only when both of its clips moved by the same
+ * timeline delta and still share a track. If one side moves independently,
+ * the transition stays put until the normal drop-time validity cleanup
+ * decides whether the edit relationship still exists.
+ */
+export const translateTransitionsForClipMoves = ({
+  transitions = [],
+  beforeClips = [],
+  afterClips = [],
+  epsilon = DEFAULT_MOVE_EPSILON,
+} = {}) => {
+  if (!Array.isArray(transitions) || transitions.length === 0) return transitions || []
+
+  const beforeById = new Map((beforeClips || []).map((clip) => [clip?.id, clip]))
+  const afterById = new Map((afterClips || []).map((clip) => [clip?.id, clip]))
+
+  let changed = false
+  const translated = transitions.map((transition) => {
+    if (transition?.kind !== 'between') return transition
+
+    const beforeA = beforeById.get(transition.clipAId)
+    const beforeB = beforeById.get(transition.clipBId)
+    const afterA = afterById.get(transition.clipAId)
+    const afterB = afterById.get(transition.clipBId)
+    if (!beforeA || !beforeB || !afterA || !afterB) return transition
+    if (afterA.trackId !== afterB.trackId) return transition
+
+    const beforeAStart = getClipStartTime(beforeA)
+    const beforeBStart = getClipStartTime(beforeB)
+    const afterAStart = getClipStartTime(afterA)
+    const afterBStart = getClipStartTime(afterB)
+    if ([beforeAStart, beforeBStart, afterAStart, afterBStart].some((value) => value == null)) {
+      return transition
+    }
+
+    const deltaA = afterAStart - beforeAStart
+    const deltaB = afterBStart - beforeBStart
+    if (Math.abs(deltaA) <= epsilon || Math.abs(deltaA - deltaB) > epsilon) return transition
+
+    const shiftedTransition = { ...transition }
+    let transitionChanged = false
+    for (const field of ['editPoint', 'originalClipAEnd', 'originalClipBStart']) {
+      if (transition[field] != null) {
+        const shiftedValue = translateFiniteTime(transition[field], deltaA)
+        if (!Object.is(shiftedValue, transition[field])) {
+          shiftedTransition[field] = shiftedValue
+          transitionChanged = true
+        }
+      }
+    }
+    if (!transitionChanged) return transition
+    changed = true
+    return shiftedTransition
+  })
+  return changed ? translated : transitions
+}

--- a/src/utils/transitionClipMoves.test.mjs
+++ b/src/utils/transitionClipMoves.test.mjs
@@ -1,0 +1,103 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { translateTransitionsForClipMoves } from './transitionClipMoves.mjs'
+
+const clips = [
+  { id: 'clip-a', trackId: 'video-1', startTime: 10, duration: 5 },
+  { id: 'clip-b', trackId: 'video-1', startTime: 15, duration: 5 },
+]
+
+const betweenTransition = {
+  id: 'transition-1',
+  kind: 'between',
+  clipAId: 'clip-a',
+  clipBId: 'clip-b',
+  editPoint: 15,
+  originalClipAEnd: 15,
+  originalClipBStart: 15,
+  duration: 1,
+}
+
+test('moves a between transition when both attached clips translate together', () => {
+  const result = translateTransitionsForClipMoves({
+    transitions: [betweenTransition],
+    beforeClips: clips,
+    afterClips: clips.map((clip) => ({ ...clip, startTime: clip.startTime - 7 })),
+  })
+
+  assert.deepEqual(result[0], {
+    ...betweenTransition,
+    editPoint: 8,
+    originalClipAEnd: 8,
+    originalClipBStart: 8,
+  })
+})
+
+test('uses actual clamped clip movement rather than the requested delta', () => {
+  const result = translateTransitionsForClipMoves({
+    transitions: [betweenTransition],
+    beforeClips: clips,
+    afterClips: clips.map((clip) => ({ ...clip, startTime: clip.startTime - 10 })),
+  })
+
+  assert.equal(result[0].editPoint, 5)
+  assert.equal(result[0].originalClipAEnd, 5)
+  assert.equal(result[0].originalClipBStart, 5)
+})
+
+test('does not move a transition when only one attached clip moves', () => {
+  const transitions = [betweenTransition]
+  const result = translateTransitionsForClipMoves({
+    transitions,
+    beforeClips: clips,
+    afterClips: [
+      { ...clips[0], startTime: 4 },
+      clips[1],
+    ],
+  })
+
+  assert.equal(result, transitions)
+  assert.equal(result[0], betweenTransition)
+})
+
+test('does not move a transition when its clips land on different tracks', () => {
+  const result = translateTransitionsForClipMoves({
+    transitions: [betweenTransition],
+    beforeClips: clips,
+    afterClips: [
+      { ...clips[0], startTime: 4, trackId: 'video-1' },
+      { ...clips[1], startTime: 9, trackId: 'video-2' },
+    ],
+  })
+
+  assert.equal(result[0], betweenTransition)
+})
+
+test('leaves edge transitions and missing compatibility fields unchanged', () => {
+  const edgeTransition = {
+    id: 'edge-1',
+    kind: 'edge',
+    clipId: 'clip-a',
+    edge: 'in',
+    duration: 1,
+  }
+  const modernBetween = {
+    id: 'transition-modern',
+    kind: 'between',
+    clipAId: 'clip-a',
+    clipBId: 'clip-b',
+    editPoint: 15,
+    duration: 1,
+  }
+  const result = translateTransitionsForClipMoves({
+    transitions: [edgeTransition, modernBetween],
+    beforeClips: clips,
+    afterClips: clips.map((clip) => ({ ...clip, startTime: clip.startTime + 2 })),
+  })
+
+  assert.equal(result[0], edgeTransition)
+  assert.deepEqual(result[1], { ...modernBetween, editPoint: 17 })
+  assert.equal(Object.hasOwn(result[1], 'originalClipAEnd'), false)
+  assert.equal(Object.hasOwn(result[1], 'originalClipBStart'), false)
+})


### PR DESCRIPTION
## Summary\n\n- add preview-first Pexels MCP search and bulk import tools\n- open agent search results in Velorn's Stock tab and preserve project-owned provenance\n- skip duplicate Pexels assets and keep timeline placement as a separate approval\n- move between-clip transitions when both attached clips move together\n- prepare version 0.3.29 and release notes\n\n## Verification\n\n- Pexels suite: 8/8\n- complete local test-file matrix: 18/18\n- npm run build\n- node --check src/services/mcpActions.js\n- node --check electron/mcpServer.js\n- node --check src/services/pexelsStock.js\n- git diff --check\n\nThe existing npm scripts that use --experimental-default-type=module target the release workflow's Node 20 runtime; this Ubuntu host runs Node 24, so the same files were invoked directly with node --test for the complete local matrix.\n\n## Contributor License Agreement\n\n- [x] I have read and agree to the Contributor License Agreement in `CONTRIBUTOR_LICENSE_AGREEMENT.md`, and I have the right to submit this contribution.
